### PR TITLE
moe_runner适配lighop-w8a8-int8和aiter-w8a8-int8

### DIFF
--- a/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
@@ -21,7 +21,8 @@ from sglang.srt.layers.attention.fla.utils import (
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
 CHUNK_SIZE = 64
 
-from sglang.srt.utils import get_bool_env_var
+from sglang.srt.utils import get_bool_env_var, is_dcu
+_is_dcu = is_dcu()
 _use_prefill_aiter_linear_attn = get_bool_env_var("SGLANG_USE_AITER_LINEAR_ATTN")
 
 @triton.autotune(
@@ -346,26 +347,53 @@ def chunk_gated_delta_rule_fwd_h(
             NT_BUCKET=(0 if NT <= 32 else (1 if NT <= 128 else 2)),
         )
     else:
-        from aiter.ops.triton.fla.sglang.chunk_delta_h import launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64
-        launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
-            k=k,
-            u=u,
-            w=w,
-            v_new=v_new,
-            g=g,
-            gk=gk,
-            h=h,
-            initial_state=initial_state,
-            initial_state_indices=initial_state_indices,
-            cu_seqlens=cu_seqlens,
-            chunk_offsets=chunk_offsets,
-            N=N,
-            T=T,
-            H=H,
-            Hg=Hg,
-            K=K,
-            V=V,
-            BT=BT,
-            kernel_cfg=None,
-        )
+        if _is_dcu:
+            from aiter.ops.triton.fla.sglang.chunk_delta_h import launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64
+            launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
+                k=k,
+                u=u,
+                w=w,
+                v_new=v_new,
+                g=g,
+                gk=gk,
+                h=h,
+                initial_state=initial_state,
+                initial_state_indices=initial_state_indices,
+                cu_seqlens=cu_seqlens,
+                chunk_offsets=chunk_offsets,
+                N=N,
+                T=T,
+                H=H,
+                Hg=Hg,
+                K=K,
+                V=V,
+                BT=BT,
+                kernel_cfg=None,
+            )
+        else:
+            from aiter.ops.triton.fla.chunk_delta_h import launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64
+            launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
+                k=k,
+                u=u,
+                w=w,
+                v_new=v_new,
+                g=g,
+                gk=gk,
+                h=h,
+                initial_state=initial_state,
+                initial_state_indices=initial_state_indices,
+                final_state=None,
+                cu_seqlens=cu_seqlens,
+                chunk_offsets=chunk_offsets,
+                N=N,
+                T=T,
+                H=H,
+                Hg=Hg,
+                K=K,
+                V=V,
+                BT=BT,
+                use_exp2=False,
+                transpose_state_layout=True,
+                kernel_cfg=None,
+            )
     return h, v_new

--- a/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
@@ -346,7 +346,7 @@ def chunk_gated_delta_rule_fwd_h(
             NT_BUCKET=(0 if NT <= 32 else (1 if NT <= 128 else 2)),
         )
     else:
-        from aiter.ops.triton.fla.chunk_delta_h import launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64
+        from aiter.ops.triton.fla.sglang.chunk_delta_h import launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64
         launch_chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             k=k,
             u=u,
@@ -357,7 +357,6 @@ def chunk_gated_delta_rule_fwd_h(
             h=h,
             initial_state=initial_state,
             initial_state_indices=initial_state_indices,
-            final_state=None,
             cu_seqlens=cu_seqlens,
             chunk_offsets=chunk_offsets,
             N=N,
@@ -367,8 +366,6 @@ def chunk_gated_delta_rule_fwd_h(
             K=K,
             V=V,
             BT=BT,
-            use_exp2=False,
-            transpose_state_layout=True,
             kernel_cfg=None,
         )
     return h, v_new

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -5,12 +5,14 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 import torch
+from torch.nn.parameter import Parameter
 
 from sglang.srt.layers.moe.moe_runner.base import (
     MoeQuantInfo,
     MoeRunnerConfig,
     register_fused_func,
 )
+from sglang.srt.utils import is_dcu
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher.standard import (
@@ -24,6 +26,9 @@ class AiterQuantType(str, Enum):
     PER_TOKEN = "per_Token"
     PER_128X128 = "per_128x128"
     PER_1X32 = "per_1x32"
+
+
+_is_dcu = is_dcu()
 
 
 @dataclass
@@ -41,9 +46,278 @@ class AiterMoeQuantInfo(MoeQuantInfo):
     doweight_stage1: bool = False
     hidden_pad: int = 0
     intermediate_pad: int = 0
+    use_int8_w8a8: bool = False
+    global_num_experts: Optional[int] = None
+    expert_map: Optional[torch.Tensor] = None
+    moe_config_cache: Optional[dict] = None
+    weight_cache: Optional[dict] = None
+    layer: Optional[torch.nn.Module] = None
 
 
 _AITER_ACTIVATIONS = {"silu": "Silu", "swiglu": "Swiglu"}
+
+
+def process_weights_after_loading_aiter_w8a8_int8(layer: torch.nn.Module) -> None:
+    try:
+        from aiter.moe import (  # noqa: F401
+            MoeQuantType,
+            aiter_moe,
+            get_aiter_moe_config,
+        )
+        from aiter.ops.shuffle import (  # noqa: F401
+            moe_layout_shuffle_gemm1,
+            moe_layout_shuffle_gemm2,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "AITER W8A8 INT8 MoE is enabled but required aiter modules are "
+            "unavailable."
+        ) from exc
+
+    if not hasattr(MoeQuantType, "W8A8"):
+        raise RuntimeError(
+            "The installed aiter package does not expose MoeQuantType.W8A8."
+        )
+    moe_runner_config = getattr(layer, "moe_runner_config", None)
+    if getattr(layer, "apply_router_weight_on_input", False) or (
+        moe_runner_config is not None
+        and moe_runner_config.apply_router_weight_on_input
+    ):
+        raise RuntimeError(
+            "AITER W8A8 INT8 MoE does not support "
+            "apply_router_weight_on_input=True."
+        )
+
+    layer.w13_weight = Parameter(layer.w13_weight.data, requires_grad=False)
+    layer.w2_weight = Parameter(layer.w2_weight.data, requires_grad=False)
+    setattr(layer, "_aiter_w8a8_int8_moe_c_w13_weight", None)
+    setattr(layer, "_aiter_w8a8_int8_moe_c_w2_weight", None)
+    setattr(layer, "_aiter_w8a8_int8_moe_config_cache", {})
+    setattr(layer, "_aiter_w8a8_int8_weight_cache", {})
+
+
+def get_aiter_w8a8_int8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
+    dispatcher = getattr(layer, "dispatcher", None)
+    expert_map = (
+        getattr(dispatcher, "local_expert_mapping", None)
+        if getattr(dispatcher, "expert_mask_gpu", None) is not None
+        else None
+    )
+
+    return AiterMoeQuantInfo(
+        w13_weight=layer.w13_weight,
+        w2_weight=layer.w2_weight,
+        w13_scale=layer.w13_weight_scale,
+        w2_scale=layer.w2_weight_scale,
+        a13_scale=layer.w13_input_scale,
+        a2_scale=layer.w2_input_scale,
+        use_int8_w8a8=True,
+        global_num_experts=getattr(layer, "num_experts", None),
+        expert_map=expert_map,
+        moe_config_cache=getattr(layer, "_aiter_w8a8_int8_moe_config_cache", None),
+        weight_cache=getattr(layer, "_aiter_w8a8_int8_weight_cache", None),
+        layer=layer,
+    )
+
+
+def _get_aiter_w8a8_quant_type():
+    from aiter.moe import MoeQuantType
+
+    quant_type = getattr(MoeQuantType, "W8A8", None)
+    if quant_type is None:
+        raise RuntimeError(
+            "The installed aiter package does not expose MoeQuantType.W8A8."
+        )
+    return quant_type
+
+
+def _get_aiter_w8a8_moe_config(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str,
+    quant_info: AiterMoeQuantInfo,
+):
+    from aiter.moe import MoeSolutionType, get_aiter_moe_config
+
+    if hidden_states.dim() != 2:
+        raise RuntimeError(
+            "AITER W8A8 INT8 MoE expects 2D hidden_states, got "
+            f"shape={tuple(hidden_states.shape)}."
+        )
+    if w1.dim() != 3 or w2.dim() != 3:
+        raise RuntimeError(
+            "AITER W8A8 INT8 MoE expects 3D expert weights, got "
+            f"w1.shape={tuple(w1.shape)}, w2.shape={tuple(w2.shape)}."
+        )
+
+    M, K = hidden_states.shape
+    E, N1, K1 = w1.shape
+    E2, N2, _ = w2.shape
+    if E != E2 or K != K1 or K != N2:
+        raise RuntimeError(
+            "AITER W8A8 INT8 MoE shape mismatch: "
+            f"hidden_states={tuple(hidden_states.shape)}, "
+            f"w1={tuple(w1.shape)}, w2={tuple(w2.shape)}."
+        )
+
+    top_k = topk_ids.shape[1]
+    cache_key = (M, top_k, hidden_states.dtype, activation)
+    if quant_info.moe_config_cache is not None:
+        moe_config = quant_info.moe_config_cache.get(cache_key)
+        if moe_config is not None:
+            return moe_config
+
+    quant_type = _get_aiter_w8a8_quant_type()
+    config_kwargs = dict(
+        M=M,
+        E=E,
+        N1=N1,
+        N2=N2,
+        K=K,
+        top_k=top_k,
+        block_size=0,
+        dtype=hidden_states.dtype,
+        quant_type=quant_type,
+        activation=activation
+    )
+    try:
+        status, moe_config = get_aiter_moe_config(**config_kwargs)
+    except TypeError:
+        config_kwargs.pop("activation", None)
+        status, moe_config = get_aiter_moe_config(**config_kwargs)
+
+
+    if not status:
+        raise RuntimeError(
+            "AITER W8A8 INT8 MoE did not find a valid backend config: "
+            f"M={M}, N1={N1}, N2={N2}, K={K}, E={E}, topk={top_k}, "
+            f"dtype={hidden_states.dtype}."
+        )
+
+    allowed_solution_types = {
+        MoeSolutionType.MOE_C,
+        MoeSolutionType.ASM,
+        MoeSolutionType.TRITON,
+        MoeSolutionType.CK,
+    }
+    if moe_config.solution_type not in allowed_solution_types:
+        raise RuntimeError(
+            f"Unsupported AITER MoE solution_type: {moe_config.solution_type}"
+        )
+    if moe_config.quant_type != quant_type:
+        raise RuntimeError(f"Unexpected AITER MoE quant_type: {moe_config.quant_type}")
+
+    if quant_info.moe_config_cache is not None:
+        quant_info.moe_config_cache[cache_key] = moe_config
+    return moe_config
+
+
+def _get_aiter_w8a8_weights_for_solution(
+    quant_info: AiterMoeQuantInfo,
+    solution_type,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from aiter.moe import MoeSolutionType
+    from aiter.ops.shuffle import moe_layout_shuffle_gemm1, moe_layout_shuffle_gemm2
+
+    if solution_type != MoeSolutionType.MOE_C:
+        return quant_info.w13_weight, quant_info.w2_weight
+
+    layer = quant_info.layer
+    if layer is not None:
+        w1_moe_c = getattr(layer, "_aiter_w8a8_int8_moe_c_w13_weight", None)
+        w2_moe_c = getattr(layer, "_aiter_w8a8_int8_moe_c_w2_weight", None)
+        if w1_moe_c is not None and w2_moe_c is not None:
+            return w1_moe_c, w2_moe_c
+
+    if quant_info.weight_cache is not None:
+        w1_moe_c = quant_info.weight_cache.get("moe_c_w13_weight")
+        w2_moe_c = quant_info.weight_cache.get("moe_c_w2_weight")
+        if w1_moe_c is not None and w2_moe_c is not None:
+            return w1_moe_c, w2_moe_c
+
+    with torch.no_grad():
+        w1_moe_c = moe_layout_shuffle_gemm1(quant_info.w13_weight).view(
+            *quant_info.w13_weight.shape
+        )
+        w2_moe_c = moe_layout_shuffle_gemm2(quant_info.w2_weight).view(
+            *quant_info.w2_weight.shape
+        )
+
+    if layer is not None:
+        setattr(layer, "_aiter_w8a8_int8_moe_c_w13_weight", w1_moe_c)
+        setattr(layer, "_aiter_w8a8_int8_moe_c_w2_weight", w2_moe_c)
+    if quant_info.weight_cache is not None:
+        quant_info.weight_cache["moe_c_w13_weight"] = w1_moe_c
+        quant_info.weight_cache["moe_c_w2_weight"] = w2_moe_c
+    return w1_moe_c, w2_moe_c
+
+
+def _fused_experts_none_to_aiter_w8a8_int8(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    from aiter.moe import aiter_moe
+
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+    assert not runner_config.no_combine, "no_combine=True is not supported by AITER"
+    if runner_config.apply_router_weight_on_input:
+        raise RuntimeError(
+            "AITER W8A8 INT8 MoE does not support "
+            "apply_router_weight_on_input=True."
+        )
+
+    hidden_states = dispatch_output.hidden_states
+    topk_weights, topk_ids, _ = dispatch_output.topk_output
+    activation = str(runner_config.activation)
+    moe_config = _get_aiter_w8a8_moe_config(
+        hidden_states,
+        quant_info.w13_weight,
+        quant_info.w2_weight,
+        topk_ids,
+        activation,
+        quant_info,
+    )
+    w1, w2 = _get_aiter_w8a8_weights_for_solution(
+        quant_info, moe_config.solution_type
+    )
+    routed_scaling_factor = (
+        runner_config.routed_scaling_factor
+        if runner_config.routed_scaling_factor is not None
+        else 1.0
+    )
+    if quant_info.expert_map is not None:
+        global_num_experts = quant_info.global_num_experts or w1.shape[0]
+    else:
+        global_num_experts = w1.shape[0]
+
+    output = aiter_moe(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights.to(torch.float32),
+        topk_ids=topk_ids.to(torch.int32),
+        moe_config=moe_config,
+        inplace=runner_config.inplace,
+        activation=activation,
+        w1_scale=quant_info.w13_scale,
+        w2_scale=quant_info.w2_scale,
+        w1_zp=None,
+        w2_zp=None,
+        a1_scale=quant_info.a13_scale,
+        a2_scale=quant_info.a2_scale,
+        block_shape=None,
+        global_num_experts=global_num_experts,
+        expert_map=quant_info.expert_map,
+        routed_scaling_factor=float(routed_scaling_factor),
+        output_dtype=hidden_states.dtype,
+        gemm1_alpha=runner_config.gemm1_alpha,
+        gemm1_limit=runner_config.gemm1_clamp_limit,
+    )
+    return StandardCombineInput(hidden_states=output)
 
 
 @register_fused_func("none", "aiter")
@@ -52,6 +326,18 @@ def fused_experts_none_to_aiter(
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
+    if quant_info.use_int8_w8a8:
+        if _is_dcu:
+            return _fused_experts_none_to_aiter_w8a8_int8(
+                dispatch_output,
+                quant_info,
+                runner_config,
+            )
+        raise RuntimeError(
+            "AITER W8A8 INT8 MoE is only supported on DCU. "
+            "Use the native AITER path for other quantization modes."
+        )
+
     from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
 

--- a/python/sglang/srt/layers/moe/moe_runner/lightop.py
+++ b/python/sglang/srt/layers/moe/moe_runner/lightop.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+from torch.nn.parameter import Parameter
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+    MoeRunnerCore,
+    RunnerInput,
+    RunnerOutput,
+    register_post_permute,
+    register_pre_permute,
+)
+from sglang.srt.layers.moe.utils import MoeRunnerBackend, get_moe_a2a_backend
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors_moe_marlin import (
+    get_w8a8_int8_marlin_weights,
+    weight8bit_nt_kpack2_marlin1,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher.standard import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+
+
+@dataclass
+class LightOpRunnerInput(RunnerInput):
+    hidden_states: torch.Tensor
+    topk_weights: torch.Tensor
+    topk_ids: torch.Tensor
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.LIGHTOP
+
+
+@dataclass
+class LightOpRunnerOutput(RunnerOutput):
+    hidden_states: torch.Tensor
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.LIGHTOP
+
+
+@dataclass
+class LightOpMoeQuantInfo(MoeQuantInfo):
+    w13_weight: torch.Tensor
+    w2_weight: torch.Tensor
+    w13_scale: torch.Tensor
+    w2_scale: torch.Tensor
+    a13_scale: Optional[torch.Tensor] = None
+    a2_scale: Optional[torch.Tensor] = None
+
+
+def get_lightop_marlin_weight(weight: torch.Tensor) -> torch.Tensor:
+    if get_moe_a2a_backend().is_deepep():
+        return weight8bit_nt_kpack2_marlin1(weight)
+    return get_w8a8_int8_marlin_weights(weight)
+
+
+def process_weights_after_loading_lightop(layer: torch.nn.Module) -> None:
+    w13_weight = torch.stack(
+        [
+            get_lightop_marlin_weight(layer.w13_weight[i])
+            for i in range(layer.w13_weight.shape[0])
+        ],
+        dim=0,
+    )
+    w2_weight = torch.stack(
+        [
+            get_lightop_marlin_weight(layer.w2_weight[i])
+            for i in range(layer.w2_weight.shape[0])
+        ],
+        dim=0,
+    )
+    layer.w13_weight = Parameter(w13_weight, requires_grad=False)
+    layer.w2_weight = Parameter(w2_weight, requires_grad=False)
+
+
+def get_lightop_quant_info(layer: torch.nn.Module) -> LightOpMoeQuantInfo:
+    return LightOpMoeQuantInfo(
+        w13_weight=layer.w13_weight,
+        w2_weight=layer.w2_weight,
+        w13_scale=layer.w13_weight_scale,
+        w2_scale=layer.w2_weight_scale,
+        a13_scale=layer.w13_input_scale,
+        a2_scale=layer.w2_input_scale,
+    )
+
+
+class LightOpRunnerCore(MoeRunnerCore):
+    def run(
+        self,
+        runner_input: LightOpRunnerInput,
+        quant_info: LightOpMoeQuantInfo,
+        running_state: dict,
+        hooks: Optional[Any] = None,
+    ) -> LightOpRunnerOutput:
+        assert hooks is None, "LightOp MoE does not support LoRA hooks."
+
+        routed_scaling_factor = (
+            self.config.routed_scaling_factor
+            if self.config.routed_scaling_factor is not None
+            else 1.0
+        )
+
+        output = torch.ops.sglang.fused_experts_impl_int8_marlin(
+            runner_input.hidden_states,
+            quant_info.w13_weight,
+            quant_info.w2_weight,
+            topk_weights=runner_input.topk_weights,
+            topk_ids=runner_input.topk_ids,
+            inplace=self.config.inplace,
+            activation=self.config.activation,
+            apply_router_weight_on_input=self.config.apply_router_weight_on_input,
+            use_int8_w8a8=True,
+            per_channel_quant=True,
+            global_num_experts=self.config.num_experts,
+            w1_scale=quant_info.w13_scale,
+            w2_scale=quant_info.w2_scale,
+            a1_scale=quant_info.a13_scale,
+            a2_scale=quant_info.a2_scale,
+            use_nn_moe=False,
+            routed_scaling_factor=float(routed_scaling_factor),
+        )
+        return LightOpRunnerOutput(hidden_states=output)
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.LIGHTOP
+
+
+@register_pre_permute("standard", "lightop")
+def pre_permute_standard_to_lightop(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: LightOpMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> LightOpRunnerInput:
+    from sglang.srt.layers.moe.topk import apply_topk_weights_cpu
+
+    hidden_states = dispatch_output.hidden_states
+    topk_weights, topk_ids, _ = dispatch_output.topk_output
+    hidden_states, topk_weights = apply_topk_weights_cpu(
+        runner_config.apply_router_weight_on_input,
+        topk_weights,
+        hidden_states,
+    )
+
+    return LightOpRunnerInput(
+        hidden_states=hidden_states,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+
+
+@register_post_permute("lightop", "standard")
+def post_permute_lightop_to_standard(
+    runner_output: LightOpRunnerOutput,
+    quant_info: LightOpMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> StandardCombineInput:
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+    return StandardCombineInput(hidden_states=runner_output.hidden_states)

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -55,6 +55,10 @@ class MoeRunner:
                 self.runner_core = MarlinLoraRunnerCore(config)
             else:
                 self.runner_core = None  # Marlin only supports fused path
+        elif runner_backend.is_lightop():
+            from sglang.srt.layers.moe.moe_runner.lightop import LightOpRunnerCore
+
+            self.runner_core = LightOpRunnerCore(config)
         elif (
             runner_backend.is_flashinfer_trtllm()
             or runner_backend.is_flashinfer_trtllm_routed()

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -85,6 +85,7 @@ class MoeRunnerBackend(Enum):
     CUTLASS = "cutlass"
     MARLIN = "marlin"
     AITER = "aiter"
+    LIGHTOP = "lightop"
 
     def is_auto(self):
         return self == MoeRunnerBackend.AUTO
@@ -121,6 +122,9 @@ class MoeRunnerBackend(Enum):
 
     def is_aiter(self):
         return self == MoeRunnerBackend.AITER
+
+    def is_lightop(self):
+        return self == MoeRunnerBackend.LIGHTOP
 
 
 class DeepEPMode(Enum):

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from sglang.srt.layers.moe.utils import get_moe_runner_backend
 from sglang.srt.layers.quantization.compressed_tensors.utils import should_ignore_layer
 # from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8
 from lmslim.layers.gemm.int8_utils import per_token_quant_int8
@@ -29,6 +30,7 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
+    is_dcu,
     is_host_cpu_arm64,
     set_weight_attrs,
     use_intel_amx_backend,
@@ -40,6 +42,7 @@ if TYPE_CHECKING:
 from lmslim import quant_ops
 
 _is_cuda = is_cuda()
+_is_dcu = is_dcu()
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_cpu_arm64 = is_host_cpu_arm64()
@@ -316,7 +319,13 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if _is_cpu_amx_available:
+        if _is_dcu and self.runner.runner_backend.is_lightop():
+            from sglang.srt.layers.moe.moe_runner.lightop import (
+                process_weights_after_loading_lightop,
+            )
+
+            process_weights_after_loading_lightop(layer)
+        elif _is_cpu_amx_available:
             _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
         else:
             layer.w13_weight = Parameter(layer.w13_weight, requires_grad=False)
@@ -331,8 +340,18 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
+
         self.moe_runner_config = moe_runner_config
-        self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
+        moe_runner_backend = get_moe_runner_backend()
+        if moe_runner_backend.is_auto():
+            moe_runner_backend = MoeRunnerBackend.TRITON
+
+        if moe_runner_backend.is_lightop() and _is_dcu:
+            self.runner = MoeRunner(MoeRunnerBackend.LIGHTOP, moe_runner_config)
+        elif moe_runner_backend.is_triton():
+            self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
+        else:
+            raise ValueError(f"Unsupported MoE runner backend: {moe_runner_backend}")
 
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
         return TritonMoeQuantInfo(
@@ -382,4 +401,9 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
             return StandardCombineInput(hidden_states=output)
 
         quant_info = self.get_triton_quant_info(layer)
+
+        if _is_dcu and self.runner.runner_backend.is_lightop():
+            from sglang.srt.layers.moe.moe_runner.lightop import get_lightop_quant_info
+            quant_info = get_lightop_quant_info(layer)
+            
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -319,7 +319,13 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if _is_dcu and self.runner.runner_backend.is_lightop():
+        if _is_dcu and self.runner.runner_backend.is_aiter():
+            from sglang.srt.layers.moe.moe_runner.aiter import (
+                process_weights_after_loading_aiter_w8a8_int8,
+            )
+
+            process_weights_after_loading_aiter_w8a8_int8(layer)
+        elif _is_dcu and self.runner.runner_backend.is_lightop():
             from sglang.srt.layers.moe.moe_runner.lightop import (
                 process_weights_after_loading_lightop,
             )
@@ -346,7 +352,9 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
         if moe_runner_backend.is_auto():
             moe_runner_backend = MoeRunnerBackend.TRITON
 
-        if moe_runner_backend.is_lightop() and _is_dcu:
+        if moe_runner_backend.is_aiter() and _is_dcu:
+            self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
+        elif moe_runner_backend.is_lightop() and _is_dcu:
             self.runner = MoeRunner(MoeRunnerBackend.LIGHTOP, moe_runner_config)
         elif moe_runner_backend.is_triton():
             self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
@@ -369,6 +377,7 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
         self,
         layer: torch.nn.Module,
         dispatch_output: StandardDispatchOutput,
+        bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
@@ -398,12 +407,26 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
                 None,  # block_size
                 True,  # is_vnni
             )
+            if bias is not None:
+                output = output + bias
             return StandardCombineInput(hidden_states=output)
 
         quant_info = self.get_triton_quant_info(layer)
 
-        if _is_dcu and self.runner.runner_backend.is_lightop():
+        if _is_dcu and self.runner.runner_backend.is_aiter():
+            from sglang.srt.layers.moe.moe_runner.aiter import (
+                get_aiter_w8a8_int8_quant_info,
+            )
+
+            quant_info = get_aiter_w8a8_int8_quant_info(layer)
+        elif _is_dcu and self.runner.runner_backend.is_lightop():
             from sglang.srt.layers.moe.moe_runner.lightop import get_lightop_quant_info
+
             quant_info = get_lightop_quant_info(layer)
-            
-        return self.runner.run(dispatch_output, quant_info)
+
+        combine_input = self.runner.run(dispatch_output, quant_info)
+        if bias is not None:
+            return StandardCombineInput(
+                hidden_states=combine_input.hidden_states + bias
+            )
+        return combine_input

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -205,6 +205,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "cutlass",
     "aiter",
     "marlin",
+    "lightop",
 ]
 
 MOE_A2A_BACKEND_CHOICES = [
@@ -3158,6 +3159,16 @@ class ServerArgs:
             self.disable_shared_experts_fusion = True
             logger.warning(
                 "FlashInfer TRTLLM routed MoE is enabled. --disable-shared-experts-fusion is automatically set."
+            )
+
+        if self.moe_runner_backend == "lightop":
+            assert is_dcu(), "lightop MoE runner backend is only supported on DCU."
+            assert (
+                self.quantization == "w8a8_int8"
+            ), "lightop MoE runner backend currently supports only w8a8_int8 quantization."
+            assert self.moe_a2a_backend == "none", (
+                "lightop MoE runner backend currently supports only "
+                "moe_a2a_backend='none'."
             )
 
         if envs.SGLANG_CUTLASS_MOE.get():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3162,6 +3162,9 @@ class ServerArgs:
             )
 
         if self.moe_runner_backend == "lightop":
+            logger.warning(
+                "LightOp MoE runner is a transitional backend and may be deprecated in future releases. Please use AITER MoE runner."
+            )
             assert is_dcu(), "lightop MoE runner backend is only supported on DCU."
             assert (
                 self.quantization == "w8a8_int8"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3174,6 +3174,16 @@ class ServerArgs:
                 "moe_a2a_backend='none'."
             )
 
+        if self.moe_runner_backend == "aiter" and self.quantization == "w8a8_int8":
+            assert is_dcu(), (
+                "aiter MoE runner backend with w8a8_int8 quantization is only "
+                "supported on DCU."
+            )
+            assert self.moe_a2a_backend == "none", (
+                "aiter MoE runner backend with w8a8_int8 quantization currently "
+                "supports only moe_a2a_backend='none'."
+            )
+
         if envs.SGLANG_CUTLASS_MOE.get():
             logger.warning(
                 "SGLANG_CUTLASS_MOE is deprecated, use --moe-runner-backend=cutlass and/or --speculative-moe-runner-backend=cutlass instead"


### PR DESCRIPTION
1. 参考官网moe接入流程
  forward
    -> DeepseekV2MoE.forward
       -> router_logits = self.gate(hidden_states)
       -> topk_output = self.topk(hidden_states, router_logits)
       -> self.experts(hidden_states, topk_output)
          -> FusedMoE.forward_impl
             -> dispatcher.dispatch(...)
             -> quant_method.apply(...)  #模型调用接口 创建quant_info
                -> self.runner.run(...) 或 direct cutlass/flashinfer kernel #实际调用地方
                   -> fused_func(...)
                   或 pre_permute -> runner_core.run -> post_permute #前后处理
             -> dispatcher.combine(...)
   2. moe-runner-backend支持lightop和aiter，目前支持量化类型w8a8_int8_perchennale
   3. moe-runner-backend走lightop，会提升该接口会被弃用
   4. 修复chunk_delta_h报错问题
   5. 启动服务脚本参考
`
# int8 aiter
python3 -m sglang.launch_server --model-path /mnt1/qwen3_5/Qwen3.5-397B-A17B-W8A8 \
    --tp-size 2 \
    --pp-size 4 \
    --trust-remote-code \
    --dtype bfloat16 \
    --attention-backend fa3 \
    --kv-cache-dtype fp8_e5m2 \
    --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 32}' \
    --mem-fraction-static 0.90 \
    --quantization w8a8_int8 \
    --moe-runner-backend aiter \
    --chunked-prefill-size 8192 \
    --page-size 64 \
    --enable-piecewise-cuda-graph \
    --mamba-scheduler-strategy extra_buffer


# int8 lightop
python3 -m sglang.launch_server --model-path /mnt1/qwen3_5/Qwen3.5-397B-A17B-W8A8 \
    --tp-size 2 \
    --pp-size 4 \
    --trust-remote-code \
    --dtype bfloat16 \
    --attention-backend fa3 \
    --kv-cache-dtype fp8_e5m2 \
    --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 32}' \
    --mem-fraction-static 0.90 \
    --quantization w8a8_int8 \
    --moe-runner-backend lightop \
    --chunked-prefill-size 8192 \
    --page-size 64 \
    --enable-piecewise-cuda-graph \
    --mamba-scheduler-strategy extra_buffer
`