### PR TITLE
docs: add Apache license notices for DCU SGLang

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ Long-term active SGLang contributors are eligible for coding agent sponsorship, 
 
 ## Acknowledgment
 We learned the design and reused code from the following projects: [Guidance](https://github.com/guidance-ai/guidance), [vLLM](https://github.com/vllm-project/vllm), [LightLLM](https://github.com/ModelTC/lightllm), [FlashInfer](https://github.com/flashinfer-ai/flashinfer), [Outlines](https://github.com/outlines-dev/outlines), and [LMQL](https://github.com/eth-sri/lmql).
+
+## License
+
+This repository is based on [SGLang](https://github.com/sgl-project/sglang), version `v0.5.12`, licensed under the Apache License, Version 2.0.
+
+DCU adaptations, modifications, and original contributions by Hygon Information Technology Co., Ltd. are licensed under the Apache License, Version 2.0.
+
+Original copyright notices and license terms from the upstream SGLang project are retained. See `LICENSE` and `THIRD_PARTY_NOTICES.md` for details.

--- a/README_DCU.md
+++ b/README_DCU.md
@@ -235,4 +235,10 @@ curl -X POST http://localhost:30002/v1/completions \
 - [README_ORIGIN](README_ORIGIN.md)
 - [https://github.com/sgl-project/sglang](https://github.com/sgl-project/sglang)
 
+## License
 
+本仓库基于 [SGLang](https://github.com/sgl-project/sglang) `v0.5.12` 版本进行 DCU 平台适配和优化，上游项目采用 Apache License, Version 2.0。
+
+Hygon Information Technology Co., Ltd. 对 DCU 适配、修改和新增贡献部分同样采用 Apache License, Version 2.0。
+
+本仓库保留上游 SGLang 项目的版权声明和许可证条款，详见 `LICENSE` 和 `THIRD_PARTY_NOTICES.md`。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,9 @@
+# Third Party Notices
+
+## SGLang
+
+- Source: https://github.com/sgl-project/sglang
+- Upstream version: v0.5.12
+- License: Apache License, Version 2.0
+- Original copyright: Copyright 2023-2024 SGLang Team
+- Hygon modifications: DCU platform adaptations, build scripts, dependency adjustments, performance optimizations, and documentation updates.


### PR DESCRIPTION
## Summary

Add license-related documentation for dcu-sglang based on upstream SGLang v0.5.12.

## Changes

- Add License section to README.md.
- Add License section to README_DCU.md.
- Add THIRD_PARTY_NOTICES.md for upstream SGLang attribution.

## Notes

- The repository keeps Apache License 2.0, consistent with upstream SGLang.
- Upstream SGLang v0.5.12 does not appear to include a root NOTICE file, so no root NOTICE is added in this change.