### PR TITLE
更新aiter的moe处理逻辑，添加环境变量PRINT_MOE_ARGS打印moe层信息

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,8 @@ sgl-kernel/csrc/**/*_musa/
 *.npz
 artifacts/
 .claude/scheduled_tasks.lock
+
+
+# hip_kernel
+*.hip
+*_hip.*

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -47,10 +47,12 @@ class AiterMoeQuantInfo(MoeQuantInfo):
     hidden_pad: int = 0
     intermediate_pad: int = 0
     use_int8_w8a8: bool = False
+    use_fp8_w8a8: bool = False
     global_num_experts: Optional[int] = None
     expert_map: Optional[torch.Tensor] = None
     moe_config_cache: Optional[dict] = None
     weight_cache: Optional[dict] = None
+    moe_c_weight_layout: bool = False
     layer: Optional[torch.nn.Module] = None
 
 
@@ -88,12 +90,73 @@ def process_weights_after_loading_aiter_w8a8_int8(layer: torch.nn.Module) -> Non
             "apply_router_weight_on_input=True."
         )
 
-    layer.w13_weight = Parameter(layer.w13_weight.data, requires_grad=False)
-    layer.w2_weight = Parameter(layer.w2_weight.data, requires_grad=False)
-    setattr(layer, "_aiter_w8a8_int8_moe_c_w13_weight", None)
-    setattr(layer, "_aiter_w8a8_int8_moe_c_w2_weight", None)
+    with torch.no_grad():
+        w13_weight = moe_layout_shuffle_gemm1(layer.w13_weight).view(
+            *layer.w13_weight.shape
+        )
+    layer.w13_weight = Parameter(w13_weight, requires_grad=False)
+
+    with torch.no_grad():
+        w2_weight = moe_layout_shuffle_gemm2(layer.w2_weight).view(
+            *layer.w2_weight.shape
+        )
+    layer.w2_weight = Parameter(w2_weight, requires_grad=False)
+
+    setattr(layer, "_aiter_w8a8_int8_moe_c_w13_weight", layer.w13_weight)
+    setattr(layer, "_aiter_w8a8_int8_moe_c_w2_weight", layer.w2_weight)
     setattr(layer, "_aiter_w8a8_int8_moe_config_cache", {})
     setattr(layer, "_aiter_w8a8_int8_weight_cache", {})
+    setattr(layer, "_aiter_w8a8_int8_moe_c_weight_layout", True)
+
+
+def process_weights_after_loading_aiter_w8a8_fp8(layer: torch.nn.Module) -> None:
+    try:
+        from aiter.moe import (  # noqa: F401
+            MoeQuantType,
+            aiter_moe,
+            get_aiter_moe_config,
+        )
+        from aiter.ops.shuffle import (  # noqa: F401
+            moe_layout_shuffle_gemm1,
+            moe_layout_shuffle_gemm2,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "AITER FP8 W8A8 MoE is enabled but required aiter modules are "
+            "unavailable."
+        ) from exc
+
+    if not hasattr(MoeQuantType, "FP8_W8A8"):
+        raise RuntimeError(
+            "The installed aiter package does not expose MoeQuantType.FP8_W8A8."
+        )
+    moe_runner_config = getattr(layer, "moe_runner_config", None)
+    if getattr(layer, "apply_router_weight_on_input", False) or (
+        moe_runner_config is not None
+        and moe_runner_config.apply_router_weight_on_input
+    ):
+        raise RuntimeError(
+            "AITER FP8 W8A8 MoE does not support "
+            "apply_router_weight_on_input=True."
+        )
+
+    with torch.no_grad():
+        w13_weight = moe_layout_shuffle_gemm1(layer.w13_weight).view(
+            *layer.w13_weight.shape
+        )
+    layer.w13_weight = Parameter(w13_weight, requires_grad=False)
+
+    with torch.no_grad():
+        w2_weight = moe_layout_shuffle_gemm2(layer.w2_weight).view(
+            *layer.w2_weight.shape
+        )
+    layer.w2_weight = Parameter(w2_weight, requires_grad=False)
+
+    setattr(layer, "_aiter_w8a8_fp8_moe_c_w13_weight", layer.w13_weight)
+    setattr(layer, "_aiter_w8a8_fp8_moe_c_w2_weight", layer.w2_weight)
+    setattr(layer, "_aiter_w8a8_fp8_moe_config_cache", {})
+    setattr(layer, "_aiter_w8a8_fp8_weight_cache", {})
+    setattr(layer, "_aiter_w8a8_fp8_moe_c_weight_layout", True)
 
 
 def get_aiter_w8a8_int8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
@@ -116,17 +179,48 @@ def get_aiter_w8a8_int8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
         expert_map=expert_map,
         moe_config_cache=getattr(layer, "_aiter_w8a8_int8_moe_config_cache", None),
         weight_cache=getattr(layer, "_aiter_w8a8_int8_weight_cache", None),
+        moe_c_weight_layout=getattr(
+            layer, "_aiter_w8a8_int8_moe_c_weight_layout", False
+        ),
         layer=layer,
     )
 
 
-def _get_aiter_w8a8_quant_type():
+def get_aiter_w8a8_fp8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
+    dispatcher = getattr(layer, "dispatcher", None)
+    expert_map = (
+        getattr(dispatcher, "local_expert_mapping", None)
+        if getattr(dispatcher, "expert_mask_gpu", None) is not None
+        else None
+    )
+
+    return AiterMoeQuantInfo(
+        w13_weight=layer.w13_weight,
+        w2_weight=layer.w2_weight,
+        w13_scale=layer.w13_weight_scale,
+        w2_scale=layer.w2_weight_scale,
+        a13_scale=layer.w13_input_scale,
+        a2_scale=layer.w2_input_scale,
+        use_fp8_w8a8=True,
+        global_num_experts=getattr(layer, "num_experts", None),
+        expert_map=expert_map,
+        moe_config_cache=getattr(layer, "_aiter_w8a8_fp8_moe_config_cache", None),
+        weight_cache=getattr(layer, "_aiter_w8a8_fp8_weight_cache", None),
+        moe_c_weight_layout=getattr(
+            layer, "_aiter_w8a8_fp8_moe_c_weight_layout", False
+        ),
+        layer=layer,
+    )
+
+
+def _get_aiter_w8a8_quant_type(use_fp8_w8a8: bool = False):
     from aiter.moe import MoeQuantType
 
-    quant_type = getattr(MoeQuantType, "W8A8", None)
+    quant_type_name = "FP8_W8A8" if use_fp8_w8a8 else "W8A8"
+    quant_type = getattr(MoeQuantType, quant_type_name, None)
     if quant_type is None:
         raise RuntimeError(
-            "The installed aiter package does not expose MoeQuantType.W8A8."
+            f"The installed aiter package does not expose MoeQuantType.{quant_type_name}."
         )
     return quant_type
 
@@ -143,12 +237,12 @@ def _get_aiter_w8a8_moe_config(
 
     if hidden_states.dim() != 2:
         raise RuntimeError(
-            "AITER W8A8 INT8 MoE expects 2D hidden_states, got "
+            "AITER W8A8 MoE expects 2D hidden_states, got "
             f"shape={tuple(hidden_states.shape)}."
         )
     if w1.dim() != 3 or w2.dim() != 3:
         raise RuntimeError(
-            "AITER W8A8 INT8 MoE expects 3D expert weights, got "
+            "AITER W8A8 MoE expects 3D expert weights, got "
             f"w1.shape={tuple(w1.shape)}, w2.shape={tuple(w2.shape)}."
         )
 
@@ -157,7 +251,7 @@ def _get_aiter_w8a8_moe_config(
     E2, N2, _ = w2.shape
     if E != E2 or K != K1 or K != N2:
         raise RuntimeError(
-            "AITER W8A8 INT8 MoE shape mismatch: "
+            "AITER W8A8 MoE shape mismatch: "
             f"hidden_states={tuple(hidden_states.shape)}, "
             f"w1={tuple(w1.shape)}, w2={tuple(w2.shape)}."
         )
@@ -169,7 +263,7 @@ def _get_aiter_w8a8_moe_config(
         if moe_config is not None:
             return moe_config
 
-    quant_type = _get_aiter_w8a8_quant_type()
+    quant_type = _get_aiter_w8a8_quant_type(quant_info.use_fp8_w8a8)
     config_kwargs = dict(
         M=M,
         E=E,
@@ -188,10 +282,9 @@ def _get_aiter_w8a8_moe_config(
         config_kwargs.pop("activation", None)
         status, moe_config = get_aiter_moe_config(**config_kwargs)
 
-
     if not status:
         raise RuntimeError(
-            "AITER W8A8 INT8 MoE did not find a valid backend config: "
+            "AITER W8A8 MoE did not find a valid backend config: "
             f"M={M}, N1={N1}, N2={N2}, K={K}, E={E}, topk={top_k}, "
             f"dtype={hidden_states.dtype}."
         )
@@ -222,12 +315,24 @@ def _get_aiter_w8a8_weights_for_solution(
     from aiter.ops.shuffle import moe_layout_shuffle_gemm1, moe_layout_shuffle_gemm2
 
     if solution_type != MoeSolutionType.MOE_C:
+        if quant_info.moe_c_weight_layout:
+            raise RuntimeError(
+                "AITER W8A8 weights were converted to MOE_C layout during "
+                "weight loading, but AITER selected a non-MOE_C solution: "
+                f"{solution_type}."
+            )
         return quant_info.w13_weight, quant_info.w2_weight
 
+    if quant_info.moe_c_weight_layout:
+        return quant_info.w13_weight, quant_info.w2_weight
+
+    cache_prefix = (
+        "_aiter_w8a8_fp8" if quant_info.use_fp8_w8a8 else "_aiter_w8a8_int8"
+    )
     layer = quant_info.layer
     if layer is not None:
-        w1_moe_c = getattr(layer, "_aiter_w8a8_int8_moe_c_w13_weight", None)
-        w2_moe_c = getattr(layer, "_aiter_w8a8_int8_moe_c_w2_weight", None)
+        w1_moe_c = getattr(layer, f"{cache_prefix}_moe_c_w13_weight", None)
+        w2_moe_c = getattr(layer, f"{cache_prefix}_moe_c_w2_weight", None)
         if w1_moe_c is not None and w2_moe_c is not None:
             return w1_moe_c, w2_moe_c
 
@@ -246,15 +351,15 @@ def _get_aiter_w8a8_weights_for_solution(
         )
 
     if layer is not None:
-        setattr(layer, "_aiter_w8a8_int8_moe_c_w13_weight", w1_moe_c)
-        setattr(layer, "_aiter_w8a8_int8_moe_c_w2_weight", w2_moe_c)
+        setattr(layer, f"{cache_prefix}_moe_c_w13_weight", w1_moe_c)
+        setattr(layer, f"{cache_prefix}_moe_c_w2_weight", w2_moe_c)
     if quant_info.weight_cache is not None:
         quant_info.weight_cache["moe_c_w13_weight"] = w1_moe_c
         quant_info.weight_cache["moe_c_w2_weight"] = w2_moe_c
     return w1_moe_c, w2_moe_c
 
 
-def _fused_experts_none_to_aiter_w8a8_int8(
+def _fused_experts_none_to_aiter_w8a8(
     dispatch_output: StandardDispatchOutput,
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
@@ -266,7 +371,7 @@ def _fused_experts_none_to_aiter_w8a8_int8(
     assert not runner_config.no_combine, "no_combine=True is not supported by AITER"
     if runner_config.apply_router_weight_on_input:
         raise RuntimeError(
-            "AITER W8A8 INT8 MoE does not support "
+            "AITER W8A8 MoE does not support "
             "apply_router_weight_on_input=True."
         )
 
@@ -326,15 +431,15 @@ def fused_experts_none_to_aiter(
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
-    if quant_info.use_int8_w8a8:
+    if quant_info.use_int8_w8a8 or quant_info.use_fp8_w8a8:
         if _is_dcu:
-            return _fused_experts_none_to_aiter_w8a8_int8(
+            return _fused_experts_none_to_aiter_w8a8(
                 dispatch_output,
                 quant_info,
                 runner_config,
             )
         raise RuntimeError(
-            "AITER W8A8 INT8 MoE is only supported on DCU. "
+            "AITER W8A8 MoE is only supported on DCU. "
             "Use the native AITER path for other quantization modes."
         )
 

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 from torch.nn.parameter import Parameter
@@ -10,8 +11,13 @@ from torch.nn.parameter import Parameter
 from sglang.srt.layers.moe.moe_runner.base import (
     MoeQuantInfo,
     MoeRunnerConfig,
-    register_fused_func,
+    MoeRunnerCore,
+    RunnerInput,
+    RunnerOutput,
+    register_post_permute,
+    register_pre_permute,
 )
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.utils import is_dcu
 
 if TYPE_CHECKING:
@@ -51,35 +57,37 @@ class AiterMoeQuantInfo(MoeQuantInfo):
     global_num_experts: Optional[int] = None
     expert_map: Optional[torch.Tensor] = None
     moe_config_cache: Optional[dict] = None
-    weight_cache: Optional[dict] = None
     moe_c_weight_layout: bool = False
+    original_w13_shape: Optional[tuple[int, ...]] = None
+    original_w2_shape: Optional[tuple[int, ...]] = None
     layer: Optional[torch.nn.Module] = None
 
 
 _AITER_ACTIVATIONS = {"silu": "Silu", "swiglu": "Swiglu"}
 
 
-def process_weights_after_loading_aiter_w8a8_int8(layer: torch.nn.Module) -> None:
-    try:
-        from aiter.moe import (  # noqa: F401
-            MoeQuantType,
-            aiter_moe,
-            get_aiter_moe_config,
-        )
-        from aiter.ops.shuffle import (  # noqa: F401
-            moe_layout_shuffle_gemm1,
-            moe_layout_shuffle_gemm2,
-        )
-    except Exception as exc:
-        raise RuntimeError(
-            "AITER W8A8 INT8 MoE is enabled but required aiter modules are "
-            "unavailable."
-        ) from exc
+@dataclass
+class AiterRunnerInput(RunnerInput):
+    hidden_states: torch.Tensor
+    topk_weights: torch.Tensor
+    topk_ids: torch.Tensor
 
-    if not hasattr(MoeQuantType, "W8A8"):
-        raise RuntimeError(
-            "The installed aiter package does not expose MoeQuantType.W8A8."
-        )
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.AITER
+
+
+@dataclass
+class AiterRunnerOutput(RunnerOutput):
+    hidden_states: torch.Tensor
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.AITER
+
+
+def process_weights_after_loading_aiter_w8a8_int8(layer: torch.nn.Module) -> None:
+
     moe_runner_config = getattr(layer, "moe_runner_config", None)
     if getattr(layer, "apply_router_weight_on_input", False) or (
         moe_runner_config is not None
@@ -90,46 +98,14 @@ def process_weights_after_loading_aiter_w8a8_int8(layer: torch.nn.Module) -> Non
             "apply_router_weight_on_input=True."
         )
 
-    with torch.no_grad():
-        w13_weight = moe_layout_shuffle_gemm1(layer.w13_weight).view(
-            *layer.w13_weight.shape
-        )
-    layer.w13_weight = Parameter(w13_weight, requires_grad=False)
-
-    with torch.no_grad():
-        w2_weight = moe_layout_shuffle_gemm2(layer.w2_weight).view(
-            *layer.w2_weight.shape
-        )
-    layer.w2_weight = Parameter(w2_weight, requires_grad=False)
-
-    setattr(layer, "_aiter_w8a8_int8_moe_c_w13_weight", layer.w13_weight)
-    setattr(layer, "_aiter_w8a8_int8_moe_c_w2_weight", layer.w2_weight)
+    setattr(layer, "_aiter_w8a8_int8_original_w13_shape", tuple(layer.w13_weight.shape))
+    setattr(layer, "_aiter_w8a8_int8_original_w2_shape", tuple(layer.w2_weight.shape))
     setattr(layer, "_aiter_w8a8_int8_moe_config_cache", {})
-    setattr(layer, "_aiter_w8a8_int8_weight_cache", {})
-    setattr(layer, "_aiter_w8a8_int8_moe_c_weight_layout", True)
+    setattr(layer, "_aiter_w8a8_int8_moe_c_weight_layout", False)
 
 
 def process_weights_after_loading_aiter_w8a8_fp8(layer: torch.nn.Module) -> None:
-    try:
-        from aiter.moe import (  # noqa: F401
-            MoeQuantType,
-            aiter_moe,
-            get_aiter_moe_config,
-        )
-        from aiter.ops.shuffle import (  # noqa: F401
-            moe_layout_shuffle_gemm1,
-            moe_layout_shuffle_gemm2,
-        )
-    except Exception as exc:
-        raise RuntimeError(
-            "AITER FP8 W8A8 MoE is enabled but required aiter modules are "
-            "unavailable."
-        ) from exc
 
-    if not hasattr(MoeQuantType, "FP8_W8A8"):
-        raise RuntimeError(
-            "The installed aiter package does not expose MoeQuantType.FP8_W8A8."
-        )
     moe_runner_config = getattr(layer, "moe_runner_config", None)
     if getattr(layer, "apply_router_weight_on_input", False) or (
         moe_runner_config is not None
@@ -140,23 +116,10 @@ def process_weights_after_loading_aiter_w8a8_fp8(layer: torch.nn.Module) -> None
             "apply_router_weight_on_input=True."
         )
 
-    with torch.no_grad():
-        w13_weight = moe_layout_shuffle_gemm1(layer.w13_weight).view(
-            *layer.w13_weight.shape
-        )
-    layer.w13_weight = Parameter(w13_weight, requires_grad=False)
-
-    with torch.no_grad():
-        w2_weight = moe_layout_shuffle_gemm2(layer.w2_weight).view(
-            *layer.w2_weight.shape
-        )
-    layer.w2_weight = Parameter(w2_weight, requires_grad=False)
-
-    setattr(layer, "_aiter_w8a8_fp8_moe_c_w13_weight", layer.w13_weight)
-    setattr(layer, "_aiter_w8a8_fp8_moe_c_w2_weight", layer.w2_weight)
+    setattr(layer, "_aiter_w8a8_fp8_original_w13_shape", tuple(layer.w13_weight.shape))
+    setattr(layer, "_aiter_w8a8_fp8_original_w2_shape", tuple(layer.w2_weight.shape))
     setattr(layer, "_aiter_w8a8_fp8_moe_config_cache", {})
-    setattr(layer, "_aiter_w8a8_fp8_weight_cache", {})
-    setattr(layer, "_aiter_w8a8_fp8_moe_c_weight_layout", True)
+    setattr(layer, "_aiter_w8a8_fp8_moe_c_weight_layout", False)
 
 
 def get_aiter_w8a8_int8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
@@ -166,6 +129,22 @@ def get_aiter_w8a8_int8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
         if getattr(dispatcher, "expert_mask_gpu", None) is not None
         else None
     )
+    if not hasattr(layer, "_aiter_w8a8_int8_original_w13_shape"):
+        setattr(
+            layer,
+            "_aiter_w8a8_int8_original_w13_shape",
+            tuple(layer.w13_weight.shape),
+        )
+    if not hasattr(layer, "_aiter_w8a8_int8_original_w2_shape"):
+        setattr(
+            layer,
+            "_aiter_w8a8_int8_original_w2_shape",
+            tuple(layer.w2_weight.shape),
+        )
+    if not hasattr(layer, "_aiter_w8a8_int8_moe_config_cache"):
+        setattr(layer, "_aiter_w8a8_int8_moe_config_cache", {})
+    if not hasattr(layer, "_aiter_w8a8_int8_moe_c_weight_layout"):
+        setattr(layer, "_aiter_w8a8_int8_moe_c_weight_layout", False)
 
     return AiterMoeQuantInfo(
         w13_weight=layer.w13_weight,
@@ -178,9 +157,14 @@ def get_aiter_w8a8_int8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
         global_num_experts=getattr(layer, "num_experts", None),
         expert_map=expert_map,
         moe_config_cache=getattr(layer, "_aiter_w8a8_int8_moe_config_cache", None),
-        weight_cache=getattr(layer, "_aiter_w8a8_int8_weight_cache", None),
         moe_c_weight_layout=getattr(
             layer, "_aiter_w8a8_int8_moe_c_weight_layout", False
+        ),
+        original_w13_shape=getattr(
+            layer, "_aiter_w8a8_int8_original_w13_shape", tuple(layer.w13_weight.shape)
+        ),
+        original_w2_shape=getattr(
+            layer, "_aiter_w8a8_int8_original_w2_shape", tuple(layer.w2_weight.shape)
         ),
         layer=layer,
     )
@@ -193,6 +177,22 @@ def get_aiter_w8a8_fp8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
         if getattr(dispatcher, "expert_mask_gpu", None) is not None
         else None
     )
+    if not hasattr(layer, "_aiter_w8a8_fp8_original_w13_shape"):
+        setattr(
+            layer,
+            "_aiter_w8a8_fp8_original_w13_shape",
+            tuple(layer.w13_weight.shape),
+        )
+    if not hasattr(layer, "_aiter_w8a8_fp8_original_w2_shape"):
+        setattr(
+            layer,
+            "_aiter_w8a8_fp8_original_w2_shape",
+            tuple(layer.w2_weight.shape),
+        )
+    if not hasattr(layer, "_aiter_w8a8_fp8_moe_config_cache"):
+        setattr(layer, "_aiter_w8a8_fp8_moe_config_cache", {})
+    if not hasattr(layer, "_aiter_w8a8_fp8_moe_c_weight_layout"):
+        setattr(layer, "_aiter_w8a8_fp8_moe_c_weight_layout", False)
 
     return AiterMoeQuantInfo(
         w13_weight=layer.w13_weight,
@@ -205,9 +205,14 @@ def get_aiter_w8a8_fp8_quant_info(layer: torch.nn.Module) -> AiterMoeQuantInfo:
         global_num_experts=getattr(layer, "num_experts", None),
         expert_map=expert_map,
         moe_config_cache=getattr(layer, "_aiter_w8a8_fp8_moe_config_cache", None),
-        weight_cache=getattr(layer, "_aiter_w8a8_fp8_weight_cache", None),
         moe_c_weight_layout=getattr(
             layer, "_aiter_w8a8_fp8_moe_c_weight_layout", False
+        ),
+        original_w13_shape=getattr(
+            layer, "_aiter_w8a8_fp8_original_w13_shape", tuple(layer.w13_weight.shape)
+        ),
+        original_w2_shape=getattr(
+            layer, "_aiter_w8a8_fp8_original_w2_shape", tuple(layer.w2_weight.shape)
         ),
         layer=layer,
     )
@@ -225,35 +230,48 @@ def _get_aiter_w8a8_quant_type(use_fp8_w8a8: bool = False):
     return quant_type
 
 
+def _get_aiter_w8a8_original_dims(
+    hidden_states: torch.Tensor,
+    quant_info: AiterMoeQuantInfo,
+) -> tuple[int, int, int, int]:
+    _, K = hidden_states.shape
+    w1_shape = quant_info.original_w13_shape
+    w2_shape = quant_info.original_w2_shape
+    E, N1, K1 = w1_shape
+    E2, N2, _ = w2_shape
+    if E != E2 or K != K1 or K != N2:
+        raise RuntimeError(
+            "AITER W8A8 MoE shape mismatch: "
+            f"hidden_states={tuple(hidden_states.shape)}, "
+            f"w1_original={tuple(w1_shape)}, w2_original={tuple(w2_shape)}, "
+            f"w1_current={tuple(quant_info.w13_weight.shape)}, "
+            f"w2_current={tuple(quant_info.w2_weight.shape)}."
+        )
+    return E, N1, N2, K
+
+
 def _get_aiter_w8a8_moe_config(
     hidden_states: torch.Tensor,
-    w1: torch.Tensor,
-    w2: torch.Tensor,
+    E: int,
+    N1: int,
+    N2: int,
+    K: int,
     topk_ids: torch.Tensor,
     activation: str,
     quant_info: AiterMoeQuantInfo,
 ):
-    from aiter.moe import AiterMoeConfig, MoeSolutionType, get_aiter_moe_config
+    from aiter.moe import MoeSolutionType, get_aiter_moe_config
 
     if hidden_states.dim() != 2:
         raise RuntimeError(
             "AITER W8A8 MoE expects 2D hidden_states, got "
             f"shape={tuple(hidden_states.shape)}."
         )
-    if w1.dim() != 3 or w2.dim() != 3:
-        raise RuntimeError(
-            "AITER W8A8 MoE expects 3D expert weights, got "
-            f"w1.shape={tuple(w1.shape)}, w2.shape={tuple(w2.shape)}."
-        )
-
-    M, K = hidden_states.shape
-    E, N1, K1 = w1.shape
-    E2, N2, _ = w2.shape
-    if E != E2 or K != K1 or K != N2:
+    M, hidden_size = hidden_states.shape
+    if hidden_size != K:
         raise RuntimeError(
             "AITER W8A8 MoE shape mismatch: "
-            f"hidden_states={tuple(hidden_states.shape)}, "
-            f"w1={tuple(w1.shape)}, w2={tuple(w2.shape)}."
+            f"hidden_states={tuple(hidden_states.shape)}, K={K}."
         )
 
     top_k = topk_ids.shape[1]
@@ -274,13 +292,22 @@ def _get_aiter_w8a8_moe_config(
         block_size=0,
         dtype=hidden_states.dtype,
         quant_type=quant_type,
-        activation=activation
+        activation=activation,
     )
+
     try:
         status, moe_config = get_aiter_moe_config(**config_kwargs)
     except TypeError:
         config_kwargs.pop("activation", None)
         status, moe_config = get_aiter_moe_config(**config_kwargs)
+
+    if os.environ.get("PRINT_MOE_ARGS", "0") == "1":
+        print(
+            "AITER W8A8 MoE args: "
+            f"moe_config={moe_config}, "
+            f"M={M}, N1={N1}, N2={N2}, K={K}, E={E}, topk={top_k}",
+            flush=True,
+        )
 
     if not status:
         raise RuntimeError(
@@ -309,16 +336,21 @@ def _get_aiter_w8a8_moe_config(
 
 def _get_aiter_w8a8_weights_for_solution(
     quant_info: AiterMoeQuantInfo,
-    solution_type,
+    moe_config,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     from aiter.moe import MoeSolutionType
     from aiter.ops.shuffle import moe_layout_shuffle_gemm1, moe_layout_shuffle_gemm2
 
-    if solution_type != MoeSolutionType.MOE_C:
+    solution_type = moe_config.solution_type
+    need_shuffle = getattr(
+        moe_config, "need_shuffle", solution_type == MoeSolutionType.MOE_C
+    )
+
+    if not need_shuffle:
         if quant_info.moe_c_weight_layout:
             raise RuntimeError(
-                "AITER W8A8 weights were converted to MOE_C layout during "
-                "weight loading, but AITER selected a non-MOE_C solution: "
+                "AITER W8A8 weights were converted to shuffled layout, but "
+                "AITER selected a config that does not need shuffled weights: "
                 f"{solution_type}."
             )
         return quant_info.w13_weight, quant_info.w2_weight
@@ -330,17 +362,6 @@ def _get_aiter_w8a8_weights_for_solution(
         "_aiter_w8a8_fp8" if quant_info.use_fp8_w8a8 else "_aiter_w8a8_int8"
     )
     layer = quant_info.layer
-    if layer is not None:
-        w1_moe_c = getattr(layer, f"{cache_prefix}_moe_c_w13_weight", None)
-        w2_moe_c = getattr(layer, f"{cache_prefix}_moe_c_w2_weight", None)
-        if w1_moe_c is not None and w2_moe_c is not None:
-            return w1_moe_c, w2_moe_c
-
-    if quant_info.weight_cache is not None:
-        w1_moe_c = quant_info.weight_cache.get("moe_c_w13_weight")
-        w2_moe_c = quant_info.weight_cache.get("moe_c_w2_weight")
-        if w1_moe_c is not None and w2_moe_c is not None:
-            return w1_moe_c, w2_moe_c
 
     with torch.no_grad():
         w1_moe_c = moe_layout_shuffle_gemm1(quant_info.w13_weight).view(
@@ -351,22 +372,21 @@ def _get_aiter_w8a8_weights_for_solution(
         )
 
     if layer is not None:
-        setattr(layer, f"{cache_prefix}_moe_c_w13_weight", w1_moe_c)
-        setattr(layer, f"{cache_prefix}_moe_c_w2_weight", w2_moe_c)
-    if quant_info.weight_cache is not None:
-        quant_info.weight_cache["moe_c_w13_weight"] = w1_moe_c
-        quant_info.weight_cache["moe_c_w2_weight"] = w2_moe_c
-    return w1_moe_c, w2_moe_c
+        layer.w13_weight = Parameter(w1_moe_c, requires_grad=False)
+        layer.w2_weight = Parameter(w2_moe_c, requires_grad=False)
+        setattr(layer, f"{cache_prefix}_moe_c_weight_layout", True)
+    quant_info.w13_weight = layer.w13_weight if layer is not None else w1_moe_c
+    quant_info.w2_weight = layer.w2_weight if layer is not None else w2_moe_c
+    quant_info.moe_c_weight_layout = True
+    return quant_info.w13_weight, quant_info.w2_weight
 
 
-def _fused_experts_none_to_aiter_w8a8(
-    dispatch_output: StandardDispatchOutput,
+def _run_aiter_w8a8(
+    runner_input: AiterRunnerInput,
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
-) -> StandardCombineInput:
+) -> AiterRunnerOutput:
     from aiter.moe import aiter_moe
-
-    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
 
     assert not runner_config.no_combine, "no_combine=True is not supported by AITER"
     if runner_config.apply_router_weight_on_input:
@@ -375,19 +395,23 @@ def _fused_experts_none_to_aiter_w8a8(
             "apply_router_weight_on_input=True."
         )
 
-    hidden_states = dispatch_output.hidden_states
-    topk_weights, topk_ids, _ = dispatch_output.topk_output
+    hidden_states = runner_input.hidden_states
+    topk_weights = runner_input.topk_weights
+    topk_ids = runner_input.topk_ids
     activation = str(runner_config.activation)
+    E, N1, N2, K = _get_aiter_w8a8_original_dims(hidden_states, quant_info)
     moe_config = _get_aiter_w8a8_moe_config(
         hidden_states,
-        quant_info.w13_weight,
-        quant_info.w2_weight,
+        E,
+        N1,
+        N2,
+        K,
         topk_ids,
         activation,
         quant_info,
     )
     w1, w2 = _get_aiter_w8a8_weights_for_solution(
-        quant_info, moe_config.solution_type
+        quant_info, moe_config
     )
     routed_scaling_factor = (
         runner_config.routed_scaling_factor
@@ -422,36 +446,22 @@ def _fused_experts_none_to_aiter_w8a8(
         gemm1_alpha=runner_config.gemm1_alpha,
         gemm1_limit=runner_config.gemm1_clamp_limit,
     )
-    return StandardCombineInput(hidden_states=output)
+    return AiterRunnerOutput(hidden_states=output)
 
 
-@register_fused_func("none", "aiter")
-def fused_experts_none_to_aiter(
-    dispatch_output: StandardDispatchOutput,
+def _run_aiter_native(
+    runner_input: AiterRunnerInput,
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
-) -> StandardCombineInput:
-    if quant_info.use_int8_w8a8 or quant_info.use_fp8_w8a8:
-        if _is_dcu:
-            return _fused_experts_none_to_aiter_w8a8(
-                dispatch_output,
-                quant_info,
-                runner_config,
-            )
-        raise RuntimeError(
-            "AITER W8A8 MoE is only supported on DCU. "
-            "Use the native AITER path for other quantization modes."
-        )
-
+) -> AiterRunnerOutput:
     from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
 
-    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
-
     assert not runner_config.no_combine, "no_combine=True is not supported by AITER"
 
-    hidden_states = dispatch_output.hidden_states
-    topk_weights, topk_ids, _ = dispatch_output.topk_output
+    hidden_states = runner_input.hidden_states
+    topk_weights = runner_input.topk_weights
+    topk_ids = runner_input.topk_ids
     topk_weights = topk_weights.to(torch.float32)
 
     if runner_config.apply_router_weight_on_input and not quant_info.doweight_stage1:
@@ -482,4 +492,57 @@ def fused_experts_none_to_aiter(
         hidden_pad=quant_info.hidden_pad,
         intermediate_pad=quant_info.intermediate_pad,
     )
-    return StandardCombineInput(hidden_states=output)
+    return AiterRunnerOutput(hidden_states=output)
+
+
+class AiterRunnerCore(MoeRunnerCore):
+    def run(
+        self,
+        runner_input: AiterRunnerInput,
+        quant_info: AiterMoeQuantInfo,
+        running_state: dict,
+        hooks: Optional[Any] = None,
+    ) -> AiterRunnerOutput:
+        assert hooks is None, "AITER MoE does not support LoRA hooks."
+
+        if quant_info.use_int8_w8a8 or quant_info.use_fp8_w8a8:
+            if _is_dcu:
+                return _run_aiter_w8a8(runner_input, quant_info, self.config)
+            raise RuntimeError(
+                "AITER W8A8 MoE is only supported on DCU. "
+                "Use the native AITER path for other quantization modes."
+            )
+
+        return _run_aiter_native(runner_input, quant_info, self.config)
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.AITER
+
+
+@register_pre_permute("standard", "aiter")
+def pre_permute_standard_to_aiter(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> AiterRunnerInput:
+    hidden_states = dispatch_output.hidden_states
+    topk_weights, topk_ids, _ = dispatch_output.topk_output
+    return AiterRunnerInput(
+        hidden_states=hidden_states,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+
+
+@register_post_permute("aiter", "standard")
+def post_permute_aiter_to_standard(
+    runner_output: AiterRunnerOutput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> StandardCombineInput:
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+    return StandardCombineInput(hidden_states=runner_output.hidden_states)

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -233,7 +233,7 @@ def _get_aiter_w8a8_moe_config(
     activation: str,
     quant_info: AiterMoeQuantInfo,
 ):
-    from aiter.moe import MoeSolutionType, get_aiter_moe_config
+    from aiter.moe import AiterMoeConfig, MoeSolutionType, get_aiter_moe_config
 
     if hidden_states.dim() != 2:
         raise RuntimeError(

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -44,10 +44,9 @@ class MoeRunner:
         elif runner_backend.is_deep_gemm():
             self.runner_core = DeepGemmRunnerCore(config)
         elif runner_backend.is_aiter():
-            # Side-effect import: registers the ("none", "aiter") fused func.
-            from sglang.srt.layers.moe.moe_runner import aiter  # noqa: F401
+            from sglang.srt.layers.moe.moe_runner.aiter import AiterRunnerCore
 
-            self.runner_core = None  # AITER only supports fused path
+            self.runner_core = AiterRunnerCore(config)
         elif runner_backend.is_marlin():
             if lora_enabled:
                 from sglang.srt.lora.lora_moe_runner_marlin import MarlinLoraRunnerCore

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
@@ -360,7 +360,17 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
                 max_w13_scales, requires_grad=False
             )
 
-        if self.weight_quant.strategy == QuantizationStrategy.CHANNEL and _use_aiter:
+        if (
+            _is_dcu
+            and self.runner.runner_backend.is_aiter()
+            and self.weight_quant.strategy == QuantizationStrategy.CHANNEL
+        ):
+            from sglang.srt.layers.moe.moe_runner.aiter import (
+                process_weights_after_loading_aiter_w8a8_fp8,
+            )
+
+            process_weights_after_loading_aiter_w8a8_fp8(layer)
+        elif self.weight_quant.strategy == QuantizationStrategy.CHANNEL and _use_aiter:
             with torch.no_grad():
                 # Pre-shuffle weights
                 layer.w13_weight = torch.nn.Parameter(
@@ -502,7 +512,28 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
 
         moe_runner_config = self.moe_runner_config
 
-        if self.runner.runner_backend.is_aiter():
+        if (
+            _is_dcu
+            and self.runner.runner_backend.is_aiter()
+            and self.weight_quant.strategy == QuantizationStrategy.CHANNEL
+        ):
+            from sglang.srt.layers.moe.moe_runner.aiter import (
+                get_aiter_w8a8_fp8_quant_info,
+            )
+
+            assert not moe_runner_config.no_combine, "unsupported"
+            quant_info = get_aiter_w8a8_fp8_quant_info(layer)
+            combine_input = self.runner.run(dispatch_output, quant_info)
+            if bias is not None:
+                from sglang.srt.layers.moe.token_dispatcher import (
+                    StandardCombineInput,
+                )
+
+                return StandardCombineInput(
+                    hidden_states=combine_input.hidden_states + bias
+                )
+            return combine_input
+        elif self.runner.runner_backend.is_aiter():
             from sglang.srt.layers.moe.moe_runner.aiter import (
                 AiterMoeQuantInfo,
                 AiterQuantType,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
@@ -360,17 +360,7 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
                 max_w13_scales, requires_grad=False
             )
 
-        if (
-            _is_dcu
-            and self.runner.runner_backend.is_aiter()
-            and self.weight_quant.strategy == QuantizationStrategy.CHANNEL
-        ):
-            from sglang.srt.layers.moe.moe_runner.aiter import (
-                process_weights_after_loading_aiter_w8a8_fp8,
-            )
-
-            process_weights_after_loading_aiter_w8a8_fp8(layer)
-        elif self.weight_quant.strategy == QuantizationStrategy.CHANNEL and _use_aiter:
+        if self.weight_quant.strategy == QuantizationStrategy.CHANNEL and _use_aiter:
             with torch.no_grad():
                 # Pre-shuffle weights
                 layer.w13_weight = torch.nn.Parameter(

--- a/python/sglang/srt/layers/quantization/w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_fp8.py
@@ -283,13 +283,7 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if _is_dcu and self.runner.runner_backend.is_aiter():
-            from sglang.srt.layers.moe.moe_runner.aiter import (
-                process_weights_after_loading_aiter_w8a8_fp8,
-            )
-
-            process_weights_after_loading_aiter_w8a8_fp8(layer)
-        elif _is_dcu and _use_fp8_w8a8_moe:
+        if _is_dcu and _use_fp8_w8a8_moe:
             w1 = layer.w13_weight
             w2 = layer.w2_weight
             w1_shape = w1.shape

--- a/python/sglang/srt/layers/quantization/w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_fp8.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import torch
 from torch.nn.parameter import Parameter
 
-from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.moe import (
+    MoeRunner,
+    MoeRunnerBackend,
+    MoeRunnerConfig,
+    get_moe_runner_backend,
+)
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.layers.parameter import ChannelQuantScaleParameter, ModelWeightParameter
@@ -26,7 +31,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     input_to_float8,
     normalize_e4m3fn_to_e4m3fnuz,
 )
-from sglang.srt.utils import set_weight_attrs, is_hip, is_dcu, set_weight_attrs, get_bool_env_var
+from sglang.srt.utils import get_bool_env_var, is_dcu, set_weight_attrs
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
         CombineInput,
@@ -278,7 +283,13 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if _is_dcu and _use_fp8_w8a8_moe:
+        if _is_dcu and self.runner.runner_backend.is_aiter():
+            from sglang.srt.layers.moe.moe_runner.aiter import (
+                process_weights_after_loading_aiter_w8a8_fp8,
+            )
+
+            process_weights_after_loading_aiter_w8a8_fp8(layer)
+        elif _is_dcu and _use_fp8_w8a8_moe:
             w1 = layer.w13_weight
             w2 = layer.w2_weight
             w1_shape = w1.shape
@@ -363,7 +374,16 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
-        self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
+        moe_runner_backend = get_moe_runner_backend()
+        if moe_runner_backend.is_auto():
+            moe_runner_backend = MoeRunnerBackend.TRITON
+
+        if moe_runner_backend.is_aiter() and _is_dcu:
+            self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
+        elif moe_runner_backend.is_triton():
+            self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
+        else:
+            raise ValueError(f"Unsupported MoE runner backend: {moe_runner_backend}")
 
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
         return TritonMoeQuantInfo(
@@ -390,6 +410,20 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
         moe_runner_config = self.moe_runner_config
 
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+        if _is_dcu and self.runner.runner_backend.is_aiter():
+            from sglang.srt.layers.moe.moe_runner.aiter import (
+                get_aiter_w8a8_fp8_quant_info,
+            )
+
+            quant_info = get_aiter_w8a8_fp8_quant_info(layer)
+            combine_input = self.runner.run(dispatch_output, quant_info)
+            if bias is not None:
+                return StandardCombineInput(
+                    hidden_states=combine_input.hidden_states + bias
+                )
+            return combine_input
+
         if _is_dcu and _use_fp8_w8a8_moe:
             if (getattr(layer.w13_weight, "_w8a8_fp8_packed", False)
                 or getattr(layer.w2_weight, "_w8a8_fp8_packed", False)):
@@ -424,15 +458,14 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
                     hidden_states_scale_fp8_input=i_s if use_prequant_input else None,
                 )
                 return StandardCombineInput(hidden_states=output)
-        else:
-            quant_info = TritonMoeQuantInfo(
-                w13_weight=layer.w13_weight,
-                w2_weight=layer.w2_weight,
-                use_fp8_w8a8=True,
-                per_channel_quant=True,
-                w13_scale=layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale,
-                a13_scale=layer.w13_input_scale,
-                a2_scale=layer.w2_input_scale,
-            )
-            return self.runner.run(dispatch_output, quant_info)
+        quant_info = TritonMoeQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            use_fp8_w8a8=True,
+            per_channel_quant=True,
+            w13_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            a13_scale=layer.w13_input_scale,
+            a2_scale=layer.w2_input_scale,
+        )
+        return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -319,13 +319,7 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if _is_dcu and self.runner.runner_backend.is_aiter():
-            from sglang.srt.layers.moe.moe_runner.aiter import (
-                process_weights_after_loading_aiter_w8a8_int8,
-            )
-
-            process_weights_after_loading_aiter_w8a8_int8(layer)
-        elif _is_dcu and self.runner.runner_backend.is_lightop():
+        if _is_dcu and self.runner.runner_backend.is_lightop():
             from sglang.srt.layers.moe.moe_runner.lightop import (
                 process_weights_after_loading_lightop,
             )


### PR DESCRIPTION
1. 更新aiter的moe处理逻辑，将重排函数通过aiter.useshuffle来判断，并在第一次加载时重排，避免后续反复malloc
2. 添加环境变量 PRINT_MOE_ARGS  打印moe层的shape信息和aiter config使用的后端