### PR TITLE
test: trigger DCU PR workflow from main

### DIFF
--- a/.github/workflows/pr-test-dcu.yml
+++ b/.github/workflows/pr-test-dcu.yml
@@ -220,7 +220,6 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          cd "${DCU_CI_CHECKOUT_DIR}"
 
           if [[ "${FORCE_WHEEL_MODE}" == "true" ]]; then
             echo "wheel_required=true" >> "${GITHUB_OUTPUT}"
@@ -235,6 +234,8 @@ jobs:
             echo "Wheel mode disabled for non-PR run without force_wheel_mode."
             exit 0
           fi
+
+          cd "${DCU_CI_CHECKOUT_DIR:-${GITHUB_WORKSPACE}}"
 
           git fetch --no-tags --depth=1 origin "${BASE_SHA}" "${HEAD_SHA}"
           changed_files="$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"

--- a/python/sglang/test/dcu_utils.py
+++ b/python/sglang/test/dcu_utils.py
@@ -7,6 +7,7 @@ import openai
 import requests
 
 
+# DCU PR validation helper defaults live here to avoid runtime-code changes.
 DCU_TEXT_SERVER_ARGS = [
     "--attention-backend",
     "fa3",


### PR DESCRIPTION
Temporary PR to validate real DCU PR trigger path after merge. Includes workflow_dispatch fix plus a harmless python test helper comment so release-pr-dcu and pr-test-dcu are triggered by PR events.