### PR TITLE
ci: wait for DCU wheels on release workflow changes

### DIFF
--- a/.github/workflows/pr-test-dcu.yml
+++ b/.github/workflows/pr-test-dcu.yml
@@ -255,7 +255,7 @@ jobs:
           wheel_required=false
           gateway_wheel_required=false
 
-          if echo "${changed_files}" | grep -Eq '^(sgl-kernel/|requirements_dcu\.txt$|python/pyproject.*\.toml|python/sglang/)'; then
+          if echo "${changed_files}" | grep -Eq '^(\.github/workflows/release-pr-dcu\.yml$|sgl-kernel/|requirements_dcu\.txt$|python/pyproject.*\.toml|python/sglang/)'; then
             wheel_required=true
           fi
 


### PR DESCRIPTION
When release-pr-dcu.yml changes, Release PR DCU Wheels is triggered and produces commit-specific wheels. PR Test (DCU) should also enter wheel mode so Wait DCU wheels validates and consumes those wheels.

This adds .github/workflows/release-pr-dcu.yml to the wheel_required classifier.