### PR TITLE
【DCU】修复 GLM-5 在 v0.5.12 上运行失败并修复 custom allreduce 精度问题

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -704,6 +704,7 @@ class TboForwardBatchPreparer:
             "split_index",  # for split prefill
             "orig_seq_lens",  # only used by qwen-1m, thus not care
             "return_pooled_hidden_states",
+            "reuse_mtp_topk_indices",  # forward-level flag, inherited by both child batches
         ]:
             output_dict[key] = getattr(batch, key)
 

--- a/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
@@ -432,14 +432,14 @@ def _set_k_and_s_triton(
             f"index_k_scale must be 1D or 2D, got shape {index_k_scale.shape}"
         )
 
-    if _is_hip and not _is_dcu: #nhb
+    if _is_hip and not _is_dcu:
         assert buf_numel_per_page == 1 * (128 + 4)
     else:
         assert buf_numel_per_page == 64 * (128 + 4)
     assert num_tokens_to_write == num_tokens_to_write_ == num_tokens_to_write__
     assert index_head_dim == 128
     assert scale_dim == 1
-    if _is_hip and not _is_dcu: #nhb
+    if _is_hip and not _is_dcu:
         assert page_size == 1
     else:
         assert page_size == 64

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -6,8 +6,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
-import triton
-import triton.language as tl
 from einops import rearrange
 
 from sglang.srt.environ import envs
@@ -28,20 +26,14 @@ from sglang.srt.utils import (
     ceil_align,
     get_bool_env_var,
     is_cuda,
+    is_dcu,
     is_gfx95_supported,
     is_hip,
     is_npu,
-    is_dcu,
-    get_bool_env_var
 )
 
 logger = logging.getLogger(__name__)
 
-import lightop
-from lightop import gemmopt
-from lightop import op
-import logging
-logger = logging.getLogger(__name__)
 global _use_multi_stream
 _is_cuda = is_cuda()
 _is_hip = is_hip()
@@ -60,7 +52,15 @@ if _use_aiter and not _use_aiter_preshuffle:
         "falling back to legacy page_size=1 / KVBlockSize=1 path."
     )
 _is_dcu = is_dcu()
-if not _is_dcu:
+if _is_dcu:
+    import lightop
+    from lightop import gemmopt
+    from lightop import op
+    from sglang.srt.layers.attention.nsa.triton_kernel import (
+        fused_get_logits_head_gate_triton,
+        hadamard_transform_optimized,
+    )
+else:
     from sglang.jit_kernel.fused_store_index_cache import (
         can_use_nsa_fused_store,
         fused_store_index_k_cache,
@@ -69,7 +69,7 @@ if not _is_dcu:
 _use_fast_hadamard_transform = get_bool_env_var("SGLANG_USE_FAST_HADAMARD_TRANSFORM")
 if _is_dcu and _use_fast_hadamard_transform:
     from fast_hadamard_transform import hadamard_transform
-    
+
 if _is_cuda:
     try:
         import deep_gemm
@@ -104,147 +104,6 @@ if TYPE_CHECKING:
 
 
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
-
-def ceil_div(x: int, y: int) -> int:
-    return (x + y - 1) // y
-
-def ref_fp8_paged_mqa_logits(q: torch.Tensor, kv_cache: torch.Tensor,
-                             weights: torch.Tensor, context_lens: torch.Tensor, block_tables: torch.Tensor,
-                             max_model_len: int, is_context_lens_2d: bool):
-    batch_size, next_n, heads, dim = q.size()
-    num_block, block_size, _, dim = kv_cache.size()
-    logits = torch.full([batch_size * next_n, max_model_len], float('-inf'), device=q.device, dtype=torch.float32)
-    context_lens = context_lens.tolist()
-    for i in range(batch_size):
-        context_len = context_lens[i]
-        q_offsets = torch.full((next_n, ), context_len, device='cuda', dtype=torch.int32) if is_context_lens_2d \
-                    else torch.arange(context_len - next_n, context_len, device='cuda')
-        weight_slice = weights[i * next_n:(i + 1) * next_n, :].transpose(0, 1).contiguous()
-
-        num_blocks = (context_len + block_size - 1) // block_size
-        block_idxs = block_tables[i][:num_blocks]
-        kv_slice = kv_cache[block_idxs]                 # [num_blocks, block_size, kv_heads, dim]
-        kx = kv_slice.permute(2, 3, 0, 1).reshape(kv_slice.size(2), dim, -1)    # [kv_heads, dim, total_tokens]
-        qx = q[i].transpose(0, 1)                       # q[i]: [next_n, heads, dim] -> [heads, next_n, dim]
-        s = torch.matmul(qx, kx).to(logits.dtype)       # [heads, next_n, dim] @ [1, dim, total_tokens] -> [heads, next_n, total_tokens]
-
-        total_len = num_blocks * block_size
-        k_offsets = torch.arange(0, total_len, device=q.device)
-        mask = (k_offsets[None, :] < context_len) & (k_offsets[None, :] <= q_offsets[:, None])
-        s = torch.where(mask[None, :, :], s, float('-inf'))     # mask shape: [1, next_n, total_tokens]
-        s = torch.relu(s) * weight_slice[..., None]             # weight_slice: [heads, next_n] -> [heads, next_n, 1]
-        s = s.sum(dim=0)                                        # [next_n, total_tokens]
-        logits[i * next_n:(i + 1) * next_n, :total_len] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float('-inf'))
-
-    return logits
-
-
-def ref_bf16_paged_mqa_logits(
-    q: torch.Tensor,
-    kv_cache: torch.Tensor,
-    weights: torch.Tensor,
-    context_lens: torch.Tensor,
-    block_tables: torch.Tensor,
-    max_model_len: int,
-    is_context_lens_2d: bool,
-):
-    batch_size, next_n, _, dim = q.size()
-    block_size = kv_cache.shape[1]
-    logits = torch.full(
-        [batch_size * next_n, max_model_len],
-        float("-inf"),
-        device=q.device,
-        dtype=torch.float32,
-    )
-    context_lens = context_lens.tolist()
-    q = q.float()
-    kv_cache = kv_cache.float()
-    weights = weights.float()
-    for i in range(batch_size):
-        context_len = context_lens[i]
-        q_offsets = (
-            torch.full((next_n,), context_len, device=q.device, dtype=torch.int32)
-            if is_context_lens_2d
-            else torch.arange(context_len - next_n, context_len, device=q.device)
-        )
-        weight_slice = weights[i * next_n:(i + 1) * next_n, :].transpose(0, 1).contiguous()
-
-        num_blocks = (context_len + block_size - 1) // block_size
-        block_idxs = block_tables[i][:num_blocks]
-        kv_slice = kv_cache[block_idxs]
-        kx = kv_slice.permute(2, 3, 0, 1).reshape(kv_slice.size(2), dim, -1)
-        qx = q[i].transpose(0, 1)
-        s = torch.matmul(qx, kx).to(logits.dtype)
-
-        total_len = num_blocks * block_size
-        k_offsets = torch.arange(0, total_len, device=q.device)
-        mask = (k_offsets[None, :] < context_len) & (k_offsets[None, :] <= q_offsets[:, None])
-        s = torch.where(mask[None, :, :], s, float("-inf"))
-        s = torch.relu(s) * weight_slice[..., None]
-        s = s.sum(dim=0)
-        logits[i * next_n:(i + 1) * next_n, :total_len] = torch.where(
-            k_offsets[None, :] <= q_offsets[:, None], s, float("-inf")
-        )
-
-    return logits
-
-
-def ref_fp8_mqa_logits(q: torch.Tensor, kv: torch.Tensor, weights: torch.Tensor,
-                       cu_seqlen_ks: torch.Tensor, cu_seqlen_ke: torch.Tensor, cost_only: bool = False):
-    seq_len_kv = kv.shape[0]
-
-    if cost_only:
-        start = cu_seqlen_ks.clamp(min=0, max=seq_len_kv)
-        end   = cu_seqlen_ke.clamp(min=0, max=seq_len_kv)
-        count_ones_per_row = (end - start).clamp(min=0)
-        return count_ones_per_row.sum()
-
-    k = kv
-    q = q.float()
-    k = k.float()
-
-    mask_lo = torch.arange(0, seq_len_kv, device='cuda')[None, :] >= cu_seqlen_ks[:, None]
-    mask_hi = torch.arange(0, seq_len_kv, device='cuda')[None, :] < cu_seqlen_ke[:, None]
-    mask = mask_lo & mask_hi
-
-    score = torch.einsum('mhd,nd->hmn', q, k)
-    logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
-    logits = logits.masked_fill(~mask, float('-inf'))
-
-    cost = mask.sum()
-    return logits, cost
-
-
-def ref_bf16_mqa_logits(
-    q: torch.Tensor,
-    kv: torch.Tensor,
-    weights: torch.Tensor,
-    cu_seqlen_ks: torch.Tensor,
-    cu_seqlen_ke: torch.Tensor,
-    cost_only: bool = False,
-):
-    if kv.dim() == 3:
-        kv = kv.squeeze(1)
-
-    seq_len_kv = kv.shape[0]
-    if cost_only:
-        start = cu_seqlen_ks.clamp(min=0, max=seq_len_kv)
-        end = cu_seqlen_ke.clamp(min=0, max=seq_len_kv)
-        count_ones_per_row = (end - start).clamp(min=0)
-        return count_ones_per_row.sum()
-
-    q = q.float()
-    kv = kv.float()
-    weights = weights.float()
-
-    mask_lo = torch.arange(0, seq_len_kv, device=q.device)[None, :] >= cu_seqlen_ks[:, None]
-    mask_hi = torch.arange(0, seq_len_kv, device=q.device)[None, :] < cu_seqlen_ke[:, None]
-    mask = mask_lo & mask_hi
-
-    score = torch.einsum("mhd,nd->hmn", q, kv)
-    logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
-    logits = logits.masked_fill(~mask, float("-inf"))
-    return logits
 
 class BaseIndexerMetadata(ABC):
     @abstractmethod
@@ -315,115 +174,30 @@ class BaseIndexerMetadata(ABC):
                 for further processing on sparse attention computation.
                 Don't assume it is the topk indices of the input logits.
         """
-import math
-from scipy.linalg import hadamard
-import torch.nn.functional as F
-# 全局缓存
-_HADAMARD_CACHE = {}
 
-def get_hadamard_matrix(dim, device=None, dtype=torch.float32):
-    """获取缓存的 Hadamard 矩阵"""
-    global _HADAMARD_CACHE
-    key = (dim, str(device), str(dtype))
-    if key not in _HADAMARD_CACHE:
-        log_dim = math.ceil(math.log2(dim))
-        dim_padded = 2 ** log_dim
-        h = hadamard(dim_padded, dtype=float)
-        _HADAMARD_CACHE[key] = torch.tensor(h, dtype=dtype, device=device)
-    return _HADAMARD_CACHE[key]
-
-def rotate_activation(x: torch.Tensor) -> torch.Tensor:
-    # from sgl_kernel import hadamard_transform
-    # if _is_hip or _is_sm103:
-    #     from fast_hadamard_transform import hadamard_transform
-    # else:
-    #     from sgl_kernel import hadamard_transform
-
-    return x
-
-def hadamard_transform_optimized(x, scale=1.0):
-    """
-    x: (..., dim) - dim 固定为 128
-    """
-    x_shape = x.shape
-    dim = x.shape[-1]
-
-    h_matrix = get_hadamard_matrix(dim, x.device, x.dtype)
-
-    x = x.reshape(-1, dim)
-    log_dim = math.ceil(math.log2(dim))
-    dim_padded = 2 ** log_dim
-
-    if dim != dim_padded:
-        x = F.pad(x, (0, dim_padded - dim))
-
-    out = F.linear(x, h_matrix)
-    if scale != 1.0:
-        out = out * scale
-    return out[..., :dim].reshape(*x_shape)
 
 def rotate_activation(x: torch.Tensor, apply_scale: bool = True) -> torch.Tensor:
     # DSV4 compressor kernels may return a non-bf16 staging dtype on DCU.
     # The older working dpskv4 branch intentionally allowed this path.
     # from sgl_kernel import hadamard_transform
-    # if _is_hip:
-    #     from fast_hadamard_transform import hadamard_transform
-    # else:
-    #     from sglang.jit_kernel.hadamard import hadamard_transform
+    if not _is_dcu and _is_hip:
+        from fast_hadamard_transform import hadamard_transform
+    elif not _is_dcu:
+        from sglang.jit_kernel.hadamard import hadamard_transform
+
     hidden_size = x.size(-1)
     assert (
         hidden_size & (hidden_size - 1)
     ) == 0, "Hidden size must be a power of 2 for Hadamard transform."
-    
+
     scale = hidden_size**-0.5 if apply_scale else 1.0
-    
+
     if _is_dcu and _use_fast_hadamard_transform:
-        return  hadamard_transform(x, scale=scale) 
+        return hadamard_transform(x, scale=scale)
+    elif _is_dcu:
+        return hadamard_transform_optimized(x, scale=scale)
     else:
-        return  hadamard_transform_optimized(x, scale=scale) 
-
-
-@triton.jit
-def _fused_gate_scale_kernel(
-    weights_ptr, q_scale_ptr, out_ptr,
-    scale, M, K,
-    BLOCK_K: tl.constexpr
-):
-    pid_m = tl.program_id(0)
-    w = tl.load(weights_ptr + pid_m)
-    w_scaled = w * scale
-    row_start_idx = pid_m * K
-    for k_offset in range(0, K, BLOCK_K):
-        cols = k_offset + tl.arange(0, BLOCK_K)
-        mask = cols < K
-        
-        q_ptrs = q_scale_ptr + row_start_idx + cols
-        out_ptrs = out_ptr + row_start_idx + cols
-        q = tl.load(q_ptrs, mask=mask)
-        out = w_scaled * q
-        tl.store(out_ptrs, out, mask=mask)
-
-def fused_get_logits_head_gate_triton(weights, q_scale, n_heads, softmax_scale):
-    weights = weights.contiguous()
-    q_scale = q_scale.contiguous()
-    
-    K = q_scale.size(-1)
-    M = weights.numel() 
-    
-    out_dtype = torch.promote_types(weights.dtype, q_scale.dtype)
-    out = torch.empty_like(q_scale, dtype=out_dtype)
-    
-    scale = softmax_scale * (n_heads ** -0.5)
-    BLOCK_K = triton.next_power_of_2(K)
-    if BLOCK_K > 1024: BLOCK_K = 1024
-    
-    grid = (M, )
-    _fused_gate_scale_kernel[grid](
-        weights, q_scale, out,
-        scale, M, K,
-        BLOCK_K=BLOCK_K
-    )
-    return out
+        return hadamard_transform(x, scale=scale)
 
 class Indexer(MultiPlatformOp):
     def __init__(
@@ -466,7 +240,7 @@ class Indexer(MultiPlatformOp):
             self.half_device_sm_count = ceil_align(self.sm_count // 2, 8)
             pp_size = get_global_server_args().pp_size
             self.logits_with_pp_recv = pp_size > 1 and not get_pp_group().is_last_rank
-        elif _is_dcu: #nhb
+        elif _is_dcu:
             device_props = torch.cuda.get_device_properties(0)
             device_name = device_props.gcnArchName.split(':')[0] if hasattr(device_props, 'gcnArchName') else device_props.name
             self.sm_count = device_props.multi_processor_count
@@ -603,9 +377,9 @@ class Indexer(MultiPlatformOp):
         weights = self._weights_proj_bf16_in_fp32_out(x)
         if _is_dcu:
             return fused_get_logits_head_gate_triton(
-                weights=weights, 
-                q_scale=q_scale, 
-                n_heads=self.n_heads, 
+                weights=weights,
+                q_scale=q_scale,
+                n_heads=self.n_heads,
                 softmax_scale=self.softmax_scale
             )
         else:
@@ -626,14 +400,14 @@ class Indexer(MultiPlatformOp):
         positions: torch.Tensor,
         enable_dual_stream: bool,
         forward_batch: ForwardBatch,
-        apply_hadamard_scale: bool = True, 
+        apply_hadamard_scale: bool = True,
     ):
         if _is_dcu:
             query, _ = self.wq_b(q_lora)
             query = rearrange(query, "l (h d) -> l h d", d=self.head_dim)
-         
+
             key, _ = self.wk(x)
-            
+
             if key.ndim == 2:
                 key = key.view(key.shape[0], -1, self.head_dim)
 
@@ -642,14 +416,14 @@ class Indexer(MultiPlatformOp):
                 query,
                 key,
                 self.head_dim,
-                self.rotary_emb.cos_sin_cache,     
-                False,                              
-                None,                               
-                None,                              
-                self.k_norm.weight,                
-                getattr(self.k_norm, 'bias', None),  
-                None,                                
-                None,                               
+                self.rotary_emb.cos_sin_cache,
+                False,
+                None,
+                None,
+                self.k_norm.weight,
+                getattr(self.k_norm, 'bias', None),
+                None,
+                None,
                 1e-6,
             )
         else:
@@ -682,12 +456,16 @@ class Indexer(MultiPlatformOp):
                 query, _ = self.wq_b(q_lora)
                 query = rearrange(query, "l (h d) -> l h d", d=self.head_dim)
                 q_rope, _ = torch.split(
-                    query, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
+                    query,
+                    [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                    dim=-1,
                 )
                 key, _ = self.wk(x)
                 key = self.k_norm(key)
                 k_rope, _ = torch.split(
-                    key, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
+                    key,
+                    [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                    dim=-1,
                 )
 
             q_rope, k_rope = self.rotary_emb(positions, q_rope, k_rope)
@@ -818,18 +596,9 @@ class Indexer(MultiPlatformOp):
                 schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
                     seqlens_32_2d, blocksize, self.sm_count
                 )
-        elif _is_dcu: #nhb
+        elif _is_dcu:
             schedule_metadata = None
 
-        assert len(q_fp8.shape) == 3
-        q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
-        assert len(kv_cache_fp8.shape) == 2
-        block_kv = page_size
-        num_heads_kv = 1
-        head_dim_with_sf = 132
-        kv_cache_fp8 = kv_cache_fp8.view(
-            kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
-        )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
 
@@ -859,7 +628,7 @@ class Indexer(MultiPlatformOp):
             assert len(q.shape) == 3
             q_fp8 = q.unsqueeze(1)  # the next_n dim is 1 now
             assert len(kv_cache_fp8.shape) == 2
-            block_kv = 1 if _is_hip and not _is_dcu else 64 #nhb
+            block_kv = 1 if _is_hip and not _is_dcu else 64
             num_heads_kv = 1
             head_dim_with_sf = 132
             if _is_hip and not _is_dcu:
@@ -894,16 +663,16 @@ class Indexer(MultiPlatformOp):
                     TotalCuCount=256,
                     WavePerEU=5,
                 )
-            elif _is_dcu: #nhb
+            elif _is_dcu:
 
                 logits = gemmopt.paged_mqa_logits(
-                            q_fp8[:q_offset], 
-                            kv_cache_fp8, 
+                            q_fp8[:q_offset],
+                            kv_cache_fp8,
                             weights[:q_offset],
-                            seqlens_32, 
+                            seqlens_32,
                             block_tables,
-                            schedule_metadata, 
-                            max_seq_len, 
+                            schedule_metadata,
+                            max_seq_len,
                             clean_logits=True
                         )
             else:
@@ -920,7 +689,6 @@ class Indexer(MultiPlatformOp):
 
         # NOTE(dark): logits should be cleaned in topk_transform
         topk_result = metadata.topk_transform(logits, self.index_topk)
-        #logger.info(f"topk_result:{topk_result},logits:{logits.shape}，{logits}")
         # Restore possible padding exist in the hidden states.
         if not _is_hip and q_offset < q.shape[0]:
             pad_len = q.shape[0] - q_offset
@@ -931,7 +699,6 @@ class Indexer(MultiPlatformOp):
                 device=topk_result.device,
             )
             topk_result = torch.cat([topk_result, padding], dim=0)
-        #logger.info(f"topk_result22222:{topk_result},logits:{logits.shape}")
         return topk_result
 
     def _should_chunk_mqa_logits(
@@ -968,7 +735,7 @@ class Indexer(MultiPlatformOp):
         assert forward_batch.forward_mode.is_extend_without_speculative()
 
         page_size = forward_batch.token_to_kv_pool.page_size
-        if _is_hip and not _is_dcu:#nhb
+        if _is_hip and not _is_dcu:
             assert page_size == 1, "only support page size 1"
         else:
             assert page_size == 64, "only support page size 64"
@@ -980,7 +747,7 @@ class Indexer(MultiPlatformOp):
         )
         weights = weights.squeeze(-1)
 
-        if _is_hip and not _use_aiter_preshuffle and not _is_dcu: #nhb
+        if _is_hip and not _use_aiter_preshuffle and not _is_dcu:
             block_tables = metadata.get_page_table_1()
         else:
             block_tables = metadata.get_page_table_64()
@@ -1070,7 +837,7 @@ class Indexer(MultiPlatformOp):
                     logits = fp8_mqa_logits(
                         q[:q_offset], kv, scale, weights[:q_offset], ks, ke
                     )
-                else:
+                elif _is_dcu:
                     kv, scale = kv_fp8
                     logits = op.mqa_logits(
                         q[:q_offset],
@@ -1085,22 +852,21 @@ class Indexer(MultiPlatformOp):
                         scale.view(torch.float32).flatten(),
                         True
                     )
-                    
-                    # logits, _ = ref_fp8_mqa_logits(
-                    #     q_fp8[:q_offset],
-                    #     kv,
-                    #     weights[:q_offset],
-                    #     ks,
-                    #     ke,
-                    #     #scale
-                    # )
+                else:
+                    logits = deep_gemm.fp8_mqa_logits(
+                        q[:q_offset],
+                        kv_fp8,
+                        weights[:q_offset],
+                        ks,
+                        ke,
+                        clean_logits=False,
+                    )
 
             assert logits.shape[0] == len(seq_lens_expanded)
             assert logits.shape[1] == k_offset
 
             raw_topk_result = metadata.topk_transform(logits, self.index_topk, ks=ks)
             topk_result[:q_offset] = raw_topk_result
-            #logger.info(f"topk_result:{topk_result},logits:{logits.shape},ke:{ke}")
             return topk_result
 
         # Chunk path
@@ -1153,7 +919,7 @@ class Indexer(MultiPlatformOp):
                         ks[start:end],
                         ke[start:end],
                     )
-                else:
+                elif _is_dcu:
                     kv, scale = kv_fp8
                     logits_chunk = lightop.mqa_logits(
                         q[start:end],
@@ -1162,6 +928,15 @@ class Indexer(MultiPlatformOp):
                         ks[start:end],
                         ke[start:end],
                         scale
+                    )
+                else:
+                    logits_chunk = deep_gemm.fp8_mqa_logits(
+                        q[start:end],
+                        kv_fp8,
+                        weights[start:end],
+                        ks[start:end],
+                        ke[start:end],
+                        clean_logits=False,
                     )
 
 
@@ -1196,7 +971,7 @@ class Indexer(MultiPlatformOp):
                 topk_indices_offset_override=topk_offset_chunk,
             )
             topk_result[start:end] = raw_topk_chunk
-           
+
             start = end
 
         return topk_result
@@ -1416,7 +1191,7 @@ class Indexer(MultiPlatformOp):
                         ks,
                         ke,
                         k_scale,
-                    )               
+                    )
                 else:
                     k_scale = forward_batch.token_to_kv_pool.get_index_k_scale_continuous(
                         layer_id,
@@ -1602,7 +1377,7 @@ class Indexer(MultiPlatformOp):
             buf = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(
                 layer_id=layer_id
             )
-            is_e4m3 = not _is_fp8_fnuz 
+            is_e4m3 = not _is_fp8_fnuz
             op.fuse_act_quant_and_store_index_k_cache(
                 key,                                      # input
                 buf,                                      # buf
@@ -1678,10 +1453,10 @@ class Indexer(MultiPlatformOp):
         # Determine if should skip topk based on sequence length
         # We can only skip the logits computation if cuda graph is not involved
         skip_logits_computation = False
-        # if forward_batch.forward_mode.is_extend_without_speculative():
-        #     if forward_batch.seq_lens_cpu is not None:
-        #         max_kv_len = forward_batch.seq_lens_cpu.max().item()
-        #         skip_logits_computation = max_kv_len <= self.index_topk
+        if (not _is_dcu) and forward_batch.forward_mode.is_extend_without_speculative():
+            if forward_batch.seq_lens_cpu is not None:
+                max_kv_len = forward_batch.seq_lens_cpu.max().item()
+                skip_logits_computation = max_kv_len <= self.index_topk
 
         # Optimization: fast path when skipping topk computation
         if skip_logits_computation and (not self.nsa_enable_prefill_cp):
@@ -1717,22 +1492,22 @@ class Indexer(MultiPlatformOp):
                     weights = self._project_and_scale_head_gates(x)
                     query, key = self._get_q_k_bf16(
                         q_lora, x, positions, False, forward_batch=forward_batch,
-                        apply_hadamard_scale=False 
+                        apply_hadamard_scale=False
                     )
                     k_buf = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(layer_id=layer_id)
                     k_loc = forward_batch.out_cache_loc
                     page_size = forward_batch.token_to_kv_pool.page_size
                     is_e4m3 = not _is_fp8_fnuz
-                    
+
                     hadamard_scale = self.hidden_size ** -0.5
                     fused_q_scale = hadamard_scale * self.softmax_scale
                     fused_k_scale = hadamard_scale
-                    
+
                     q_fp8, q_scale, weights = op.fuse_qk_quant_and_store_index_k_cache(
-                            query, 
-                            key, 
-                            k_buf, 
-                            k_loc, 
+                            query,
+                            key,
+                            k_buf,
+                            k_loc,
                             page_size,
                             weights,           # weights_in_opt
                             fused_q_scale,     # q_scale_factor
@@ -1775,23 +1550,31 @@ class Indexer(MultiPlatformOp):
                     )
                 else:
                     query, key = self._get_q_k_bf16(
-                        q_lora, x, positions, enable_dual_stream if not _is_dcu else False, forward_batch=forward_batch,
-                        apply_hadamard_scale=False  
+                        q_lora,
+                        x,
+                        positions,
+                        enable_dual_stream if not _is_dcu else False,
+                        forward_batch=forward_batch,
+                        apply_hadamard_scale=False,
                     )
-                    k_buf = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(layer_id=layer_id)
+                    k_buf = (
+                        forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(
+                            layer_id=layer_id
+                        )
+                    )
                     k_loc = forward_batch.out_cache_loc
                     page_size = forward_batch.token_to_kv_pool.page_size
                     is_e4m3 = not _is_fp8_fnuz
-            
+
                     hadamard_scale = self.hidden_size ** -0.5
                     fused_q_scale = hadamard_scale * self.softmax_scale
                     fused_k_scale = hadamard_scale
-                    
+
                     q_fp8, q_scale, _ = op.fuse_qk_quant_and_store_index_k_cache(
-                        query, 
-                        key, 
-                        k_buf, 
-                        k_loc, 
+                        query,
+                        key,
+                        k_buf,
+                        k_loc,
                         page_size,
                         None,              # weights_in_opt=None
                         fused_q_scale,     # q_scale_factor
@@ -1800,10 +1583,18 @@ class Indexer(MultiPlatformOp):
                         False,             # use_ue8m0
                         is_e4m3            # is_e4m3
                     )
-                    q_index = q_fp8.view(torch.float8_e4m3fnuz) if _is_fp8_fnuz else q_fp8.view(torch.float8_e4m3fn)
+                    q_index = (
+                        q_fp8.view(torch.float8_e4m3fnuz)
+                        if _is_fp8_fnuz
+                        else q_fp8.view(torch.float8_e4m3fn)
+                    )
             else:
                 query, key = self._get_q_k_bf16(
-                    q_lora, x, positions, enable_dual_stream if not _is_dcu else False, forward_batch=forward_batch
+                    q_lora,
+                    x,
+                    positions,
+                    enable_dual_stream if not _is_dcu else False,
+                    forward_batch=forward_batch,
                 )
                 if enable_dual_stream:
                     current_stream = torch.cuda.current_stream()

--- a/python/sglang/srt/layers/attention/nsa/triton_kernel.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_kernel.py
@@ -194,3 +194,109 @@ def get_valid_kv_indices(
         bs,
         topk,
     )
+
+
+@triton.jit
+def _hadamard_transform_kernel(
+    x_ptr,
+    out_ptr,
+    scale: tl.constexpr,
+    dim: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_D)
+    mask = cols < dim
+    row_offset = row * dim
+    acc = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    for k in tl.static_range(0, BLOCK_D):
+        x_k = tl.load(x_ptr + row_offset + k, mask=k < dim, other=0.0).to(tl.float32)
+        parity = tl.popcount(cols & k) & 1
+        sign = tl.where(parity == 0, 1.0, -1.0)
+        acc += x_k * sign
+
+    tl.store(out_ptr + row_offset + cols, acc * scale, mask=mask)
+
+
+def hadamard_transform_optimized(x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
+    """
+    x: (..., dim) - dim must be a power of 2
+    """
+    x_shape = x.shape
+    dim = x.shape[-1]
+    assert (
+        dim & (dim - 1)
+    ) == 0, "Hidden size must be a power of 2 for Hadamard transform."
+
+    x_2d = x.contiguous().view(-1, dim)
+    out = torch.empty_like(x_2d)
+    block_d = triton.next_power_of_2(dim)
+    num_warps = min(max(block_d // 32, 1), 8)
+    _hadamard_transform_kernel[(x_2d.shape[0],)](
+        x_2d,
+        out,
+        float(scale),
+        dim,
+        BLOCK_D=block_d,
+        num_warps=num_warps,
+    )
+    return out.view(*x_shape)
+
+
+@triton.jit
+def _fused_gate_scale_kernel(
+    weights_ptr,
+    q_scale_ptr,
+    out_ptr,
+    scale,
+    M,
+    K,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    w = tl.load(weights_ptr + pid_m)
+    w_scaled = w * scale
+    row_start_idx = pid_m * K
+    for k_offset in range(0, K, BLOCK_K):
+        cols = k_offset + tl.arange(0, BLOCK_K)
+        mask = cols < K
+
+        q_ptrs = q_scale_ptr + row_start_idx + cols
+        out_ptrs = out_ptr + row_start_idx + cols
+        q = tl.load(q_ptrs, mask=mask)
+        out = w_scaled * q
+        tl.store(out_ptrs, out, mask=mask)
+
+
+def fused_get_logits_head_gate_triton(
+    weights: torch.Tensor,
+    q_scale: torch.Tensor,
+    n_heads: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    weights = weights.contiguous()
+    q_scale = q_scale.contiguous()
+
+    K = q_scale.size(-1)
+    M = weights.numel()
+
+    out_dtype = torch.promote_types(weights.dtype, q_scale.dtype)
+    out = torch.empty_like(q_scale, dtype=out_dtype)
+
+    scale = softmax_scale * (n_heads**-0.5)
+    block_k = triton.next_power_of_2(K)
+    if block_k > 1024:
+        block_k = 1024
+
+    grid = (M,)
+    _fused_gate_scale_kernel[grid](
+        weights,
+        q_scale,
+        out,
+        scale,
+        M,
+        K,
+        BLOCK_K=block_k,
+    )
+    return out

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -43,8 +43,6 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.speculative.spec_info import SpecInput
 
-import logging
-logger = logging.getLogger(__name__)
 _is_hip = is_hip()
 _is_dcu = is_dcu()
 
@@ -64,12 +62,6 @@ if _is_hip and not _is_dcu:
         print(
             "aiter is AMD specific kernel library. Please make sure aiter is installed on your AMD device."
         )
-else:
-    # from sglang.jit_kernel.flash_attention import (
-    #     flash_attn_varlen_func,
-    #     flash_attn_with_kvcache,
-    # )
-    pass
 from sglang.srt.layers.attention.flashattention_interface import flash_attn_with_kvcache
 
 
@@ -90,11 +82,6 @@ global_workspace_buffer = None
 # Control whether to use fused metadata copy kernel for cuda graph replay (default: enabled)
 # Set SGLANG_USE_FUSED_METADATA_COPY=0 or false to disable
 _USE_FUSED_METADATA_COPY = envs.SGLANG_USE_FUSED_METADATA_COPY.get() and not _is_hip
-DECODE_PRINT=False
-# Control whether to verify fused metadata copy against individual copies (default: disabled)
-# Set SGLANG_VERIFY_FUSED_METADATA_COPY=1 or true to enable verification
-# This will crash with detailed error message if any inconsistency is detected
-# _VERIFY_FUSED_METADATA_COPY = envs.SGLANG_VERIFY_FUSED_METADATA_COPY.get()
 
 
 @dataclass(frozen=True)
@@ -104,7 +91,7 @@ class NSAFlashMLAMetadata:
     flashmla_metadata: torch.Tensor
     num_splits: torch.Tensor
 
-    def slice(self, sli): #nhb
+    def slice(self, sli):
         if self.num_splits:
             return NSAFlashMLAMetadata(
                 flashmla_metadata=self.flashmla_metadata,
@@ -116,17 +103,26 @@ class NSAFlashMLAMetadata:
                 num_splits=self.num_splits,
             )
 
-    def copy_(self, other: "NSAFlashMLAMetadata"): #nhb
-        if other.flashmla_metadata is None:
-            self.flashmla_metadata = None
-        else:
-            self.flashmla_metadata.copy_(
-                other.flashmla_metadata.flashmla_metadata
-            )
+    def copy_(self, other: "NSAFlashMLAMetadata"):
+        if _is_dcu:
+            flashmla_metadata = other.flashmla_metadata
+            if hasattr(flashmla_metadata, "flashmla_metadata"):
+                flashmla_metadata = flashmla_metadata.flashmla_metadata
+            if flashmla_metadata is None:
+                object.__setattr__(self, "flashmla_metadata", None)
+            elif hasattr(self.flashmla_metadata, "copy_"):
+                self.flashmla_metadata.copy_(flashmla_metadata)
+            else:
+                object.__setattr__(self, "flashmla_metadata", flashmla_metadata)
 
-        if other.num_splits is None:
-            self.num_splits=None
+            if other.num_splits is None:
+                object.__setattr__(self, "num_splits", None)
+            elif hasattr(self.num_splits, "copy_"):
+                self.num_splits.copy_(other.num_splits)
+            else:
+                object.__setattr__(self, "num_splits", other.num_splits)
         else:
+            self.flashmla_metadata.copy_(other.flashmla_metadata)
             self.num_splits.copy_(other.num_splits)
 
 
@@ -886,15 +882,11 @@ class NativeSparseAttnBackend(
                 flashmla_metadata = self.decode_cuda_graph_metadata[
                     "flashmla_metadata"
                 ].slice(slice(0, num_tokens + 1))
-                # flashmla_metadata.copy_(
-                #     self._compute_flashmla_metadata(
-                #         cache_seqlens=nsa_cache_seqlens_int32,
-                #         seq_len_q=1,
-                #     )
-                # )
-                flashmla_metadata = self._compute_flashmla_metadata( #nhb
-                    cache_seqlens=nsa_cache_seqlens_int32,
-                    seq_len_q=1,
+                flashmla_metadata.copy_(
+                    self._compute_flashmla_metadata(
+                        cache_seqlens=nsa_cache_seqlens_int32,
+                        seq_len_q=1,
+                    )
                 )
             else:
                 flashmla_metadata = None
@@ -950,15 +942,11 @@ class NativeSparseAttnBackend(
                     "flashmla_metadata"
                 ].slice(slice(0, bs * self.speculative_num_draft_tokens + 1))
 
-                # flashmla_metadata.copy_( #nhb
-                #     self._compute_flashmla_metadata(
-                #         cache_seqlens=nsa_cache_seqlens_int32,
-                #         seq_len_q=1,
-                #     )
-                # )
-                flashmla_metadata = self._compute_flashmla_metadata(
-                    cache_seqlens=nsa_cache_seqlens_int32,
-                    seq_len_q=1,
+                flashmla_metadata.copy_(
+                    self._compute_flashmla_metadata(
+                        cache_seqlens=nsa_cache_seqlens_int32,
+                        seq_len_q=1,
+                    )
                 )
             else:
                 flashmla_metadata = None
@@ -1172,16 +1160,12 @@ class NativeSparseAttnBackend(
             flashmla_metadata = metadata.flashmla_metadata.slice(
                 slice(0, seqlens_expanded_size + 1)
             )
-            # flashmla_metadata.copy_(
-            #     self._compute_flashmla_metadata(
-            #         cache_seqlens=nsa_cache_seqlens,
-            #         seq_len_q=1,
-            #     )
-            # )
-            flashmla_metadata = self._compute_flashmla_metadata( #nhb
+            flashmla_metadata.copy_(
+                self._compute_flashmla_metadata(
                     cache_seqlens=nsa_cache_seqlens,
                     seq_len_q=1,
                 )
+            )
 
         self.forward_metadata = metadata
 
@@ -1335,8 +1319,7 @@ class NativeSparseAttnBackend(
             if precomputed.flashmla_metadata is not None:
                 size = precomputed.seqlens_expanded_size
                 flashmla_metadata = metadata.flashmla_metadata.slice(slice(0, size + 1))
-                #flashmla_metadata.copy_(precomputed.flashmla_metadata)
-                flashmla_metadata = precomputed.flashmla_metadata #nhb
+                flashmla_metadata.copy_(precomputed.flashmla_metadata)
 
         # Refresh DeepGEMM paged MQA schedule metadata for the actual seqlens of
         # this replay (the captured graph holds stale data otherwise, which can
@@ -1782,8 +1765,7 @@ class NativeSparseAttnBackend(
         page_table_1: torch.Tensor,
         sm_scale: float,
     ) -> torch.Tensor:
-        #from sgl_kernel.flash_mla import flash_mla_sparse_fwd 
-        from flash_mla.flash_mla_interface import  flash_mla_sparse_fwd
+        from flash_mla.flash_mla_interface import flash_mla_sparse_fwd
 
         # FlashMLA sparse kernel requires num_heads to be a multiple of 64 (Hopper) or 128 (Blackwell)
         # When using TP, num_heads might be smaller (e.g., 256//8=32)
@@ -1793,19 +1775,20 @@ class NativeSparseAttnBackend(
         required_padding = 128 if self.device_sm_major >= 10 else 64
         need_padding = num_heads % required_padding != 0
 
-        # if need_padding:
-        #     assert required_padding % num_heads == 0, (
-        #         f"num_heads {num_heads} cannot be padded to {required_padding}. "
-        #         f"TP size may be too large for this model."
-        #     )
+        if _is_dcu:
+            q_input = q_all
+        elif need_padding:
+            assert required_padding % num_heads == 0, (
+                f"num_heads {num_heads} cannot be padded to {required_padding}. "
+                f"TP size may be too large for this model."
+            )
 
-        #     # Pad q to required size
-        #     q_padded = q_all.new_zeros((num_tokens, required_padding, head_dim))
-        #     q_padded[:, :num_heads, :] = q_all
-        #     q_input = q_padded
-        # else:
-        #     q_input = q_all
-        q_input = q_all
+            # Pad q to required size
+            q_padded = q_all.new_zeros((num_tokens, required_padding, head_dim))
+            q_padded[:, :num_heads, :] = q_all
+            q_input = q_padded
+        else:
+            q_input = q_all
         # indices shape must be (s_q, h_kv=1, topk), keep h_kv=1 unchanged
         indices_input = page_table_1.unsqueeze(1)
 
@@ -1818,8 +1801,8 @@ class NativeSparseAttnBackend(
         )
 
         # Trim output back to original num_heads if we padded
-        # if need_padding:
-        #     o = o[:, :num_heads, :]
+        if (not _is_dcu) and need_padding:
+            o = o[:, :num_heads, :]
 
         return o
 
@@ -1833,8 +1816,7 @@ class NativeSparseAttnBackend(
         metadata: NSAMetadata,
         page_table_1,
     ) -> torch.Tensor:
-        #from sgl_kernel.flash_mla import flash_mla_with_kvcache
-        from flash_mla.flash_mla_interface import  flash_mla_with_kvcache
+        from flash_mla.flash_mla_interface import flash_mla_with_kvcache
 
         cache_seqlens = metadata.nsa_cache_seqlens_int32
         assert metadata.flashmla_metadata is not None
@@ -2332,11 +2314,10 @@ class NativeSparseAttnBackend(
         )
 
     def _compute_flashmla_metadata(self, cache_seqlens: torch.Tensor, seq_len_q: int):
-        #from sgl_kernel.flash_mla import get_mla_metadata
-        from flash_mla.flash_mla_interface import  get_mla_metadata
+        from flash_mla.flash_mla_interface import get_mla_metadata
 
         num_heads_q = self.flashmla_kv_num_q_heads
-        
+
         flashmla_metadata, num_splits = get_mla_metadata(
             cache_seqlens=cache_seqlens,
             # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -146,9 +146,9 @@ class TritonAttnBackend(AttentionBackend):
             self.swa_v_head_dim = None
         else:
             self.swa_v_head_dim = None
-            if hasattr(model_runner.token_to_kv_pool, 'v_head_dim'):
-                self.v_head_dim = model_runner.token_to_kv_pool.v_head_dim #nhb
-            elif hasattr(model_runner.token_to_kv_pool, 'get_value_buffer'):
+            if hasattr(model_runner.token_to_kv_pool, "v_head_dim"):
+                self.v_head_dim = model_runner.token_to_kv_pool.v_head_dim
+            elif hasattr(model_runner.token_to_kv_pool, "get_value_buffer"):
                 try:
                     self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[-1]
                 except KeyError:

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -134,7 +134,7 @@ class FutureMap:
         else:
             # TODO(lsyin): write future indices into spec_info.future_indices
             draft_input: EagleDraftInput = model_worker_batch.spec_info
-            if draft_input is None : #nhb
+            if draft_input is None:
                 # FIXME(lsyin): No future exists, only for prefill batch, not compatible with mixed mode
                 return
             indices = draft_input.future_indices.indices

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -63,6 +63,7 @@ from sglang.srt.utils import (
     is_hip,
     is_npu,
     is_dcu,
+    is_dcu_native_fp8_supported,
     next_power_of_2,
 )
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
@@ -1864,7 +1865,7 @@ class MLATokenToKVPool(KVCache):
     ):
         layer_id = layer.layer_id
 
-        if _is_hip and self.use_nsa and self.dtype == fp8_dtype:
+        if _is_hip and not _is_dcu and self.use_nsa and self.dtype == fp8_dtype:
             # HIP FP8 path uses raw MLA KV layout (nope + rope) without per-block scales.
             # Fuse BF16/FP16 -> FP8 cast with paged KV write.
             set_mla_kv_buffer_triton_fp8_quant(
@@ -2137,11 +2138,18 @@ class NSATokenToKVPool(MLATokenToKVPool):
             index_buf_size = size
         # num head == 1 and head dim == 128 for index_k in NSA
         assert index_head_dim == 128
-        self.use_fp8_index_k_cache = not (
-            _is_dcu and dtype not in (torch.float8_e4m3fn, torch.float8_e5m2)
+        if _is_dcu:
+            self.use_fp8_index_k_cache = dtype in (
+                torch.float8_e4m3fn,
+                torch.float8_e5m2,
+            ) and is_dcu_native_fp8_supported()
+        else:
+            self.use_fp8_index_k_cache = True
+        self.index_k_buffer_dtype = (
+            torch.bfloat16 if _is_dcu and not self.use_fp8_index_k_cache else self.dtype
         )
 
-        if _is_hip and  not _is_dcu: #and  not _is_dcu:nhb
+        if _is_hip and not _is_dcu: #and  not _is_dcu:nhb
             assert self.page_size == 1
         else:
             assert self.page_size == 64
@@ -2183,7 +2191,7 @@ class NSATokenToKVPool(MLATokenToKVPool):
                             1,
                             self.index_head_dim,
                         ),
-                        dtype=self.store_dtype,
+                        dtype=self.index_k_buffer_dtype,
                         device=device,
                     )
                     for _ in range(layer_num)
@@ -2205,8 +2213,6 @@ class NSATokenToKVPool(MLATokenToKVPool):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
 
-        if self.store_dtype != self.dtype:
-            return self.index_k_buffer[layer_id - self.start_layer].view(self.dtype)
         return self.index_k_buffer[layer_id - self.start_layer]
 
     def get_index_k_continuous(
@@ -2215,6 +2221,12 @@ class NSATokenToKVPool(MLATokenToKVPool):
         seq_len: int,
         page_indices: torch.Tensor,
     ):
+        if not self.use_fp8_index_k_cache:
+            num_pages = (seq_len + self.page_size - 1) // self.page_size
+            buf = self.get_index_k_buffer(layer_id)
+            return buf[page_indices[:num_pages]].view(-1, 1, self.index_head_dim)[
+                :seq_len
+            ]
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
@@ -2280,12 +2292,17 @@ class NSATokenToKVPool(MLATokenToKVPool):
         )
 
     def get_cpu_copy(self, indices):
-        # NSA keeps a page-indexed index_k_with_scale_buffer alongside kv_buffer.
+        # NSA keeps a page-indexed indexer cache alongside kv_buffer.
         # Retract frees the slots/pages and they get reused by other reqs'
-        # set_index_k_scale_buffer, so we must offload it here too -- otherwise
+        # indexer cache writes, so we must offload it here too -- otherwise
         # resume restores kv_buffer but leaves foreign index/scale in place and
         # NSA attention reads garbage at those token positions.
         kv_cache_cpu = super().get_cpu_copy(indices)
+        index_k_cache = (
+            self.index_k_with_scale_buffer
+            if self.use_fp8_index_k_cache
+            else self.index_k_buffer
+        )
 
         page_indices = indices[:: self.page_size] // self.page_size
         torch.cuda.synchronize()
@@ -2296,9 +2313,9 @@ class NSATokenToKVPool(MLATokenToKVPool):
             index_k_cpu.append([])
             for i in range(0, len(page_indices), page_chunk_size):
                 chunk_page_indices = page_indices[i : i + page_chunk_size]
-                idx_cpu = self.index_k_with_scale_buffer[layer_id][
-                    chunk_page_indices
-                ].to("cpu", non_blocking=True)
+                idx_cpu = index_k_cache[layer_id][chunk_page_indices].to(
+                    "cpu", non_blocking=True
+                )
                 index_k_cpu[-1].append(idx_cpu)
         torch.cuda.synchronize()
 
@@ -2309,6 +2326,11 @@ class NSATokenToKVPool(MLATokenToKVPool):
 
         page_indices = indices[:: self.page_size] // self.page_size
         index_k_cpu = kv_cache_cpu_dict["index_k"]
+        index_k_cache = (
+            self.index_k_with_scale_buffer
+            if self.use_fp8_index_k_cache
+            else self.index_k_buffer
+        )
         torch.cuda.synchronize()
         chunk_size = self.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.page_size)
@@ -2318,10 +2340,11 @@ class NSATokenToKVPool(MLATokenToKVPool):
                 idx_cpu = index_k_cpu[layer_id][i // page_chunk_size]
                 assert idx_cpu.shape[0] == len(chunk_page_indices)
                 idx_chunk = idx_cpu.to(
-                    self.index_k_with_scale_buffer[0].device, non_blocking=True
+                    index_k_cache[0].device, non_blocking=True
                 )
-                self.index_k_with_scale_buffer[layer_id][chunk_page_indices] = idx_chunk
+                index_k_cache[layer_id][chunk_page_indices] = idx_chunk
         torch.cuda.synchronize()
+
     def set_index_k_buffer(
         self,
         layer_id: int,
@@ -2329,11 +2352,8 @@ class NSATokenToKVPool(MLATokenToKVPool):
         index_k: torch.Tensor,
     ) -> None:
         assert self.index_k_buffer is not None, "BF16 index K cache is not enabled"
-        if index_k.dtype != self.dtype:
-            index_k = index_k.to(self.dtype)
-
-        if self.store_dtype != self.dtype:
-            index_k = index_k.view(self.store_dtype)
+        if index_k.dtype != self.index_k_buffer_dtype:
+            index_k = index_k.to(self.index_k_buffer_dtype)
 
         self.index_k_buffer[layer_id - self.start_layer][
             loc // self.page_size, loc % self.page_size

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -2327,14 +2327,20 @@ class NSAIndexerPoolHost(HostKVCache):
         self.start_layer = device_pool.start_layer
         self.end_layer = device_pool.end_layer
         self.layer_num = device_pool.layer_num
-
+        self.use_fp8 = device_pool.use_fp8_index_k_cache
         self.index_head_dim = device_pool.index_head_dim
         self.indexer_quant_block_size = device_pool.quant_block_size
         self.indexer_dtype = NSATokenToKVPool.index_k_with_scale_buffer_dtype
-        self.indexer_size_per_token = (
-            self.index_head_dim
-            + self.index_head_dim // self.indexer_quant_block_size * 4
-        )
+        if self.use_fp8:
+            self.indexer_size_per_token = (
+                self.index_head_dim
+                + self.index_head_dim // self.indexer_quant_block_size * 4
+            )
+        else:
+            self.indexer_size_per_token = (
+                device_pool.index_k_buffer[0][0].nbytes // self.page_size
+            )
+
         self.size = anchor_host.size
         self.page_num = anchor_host.page_num
 
@@ -2366,6 +2372,14 @@ class NSAIndexerPoolHost(HostKVCache):
         self.lock = threading.RLock()
         self.clear()
 
+    def _get_device_index_k_cache_for_transfer(self, device_pool):
+        if self.use_fp8:
+            return device_pool.index_k_with_scale_buffer
+        return [
+            buf.view(torch.uint8).view(buf.shape[0], -1)
+            for buf in device_pool.index_k_buffer
+        ]
+
     def get_size_per_token(self):
         return (
             self.indexer_size_per_token * self.layer_num * self.indexer_dtype.itemsize
@@ -2376,8 +2390,11 @@ class NSAIndexerPoolHost(HostKVCache):
 
     def init_kv_buffer(self):
         alloc_func = ALLOC_MEMORY_FUNCS[self.device_pool.device]
+        device_index_k_cache = self._get_device_index_k_cache_for_transfer(
+            self.device_pool
+        )
         self.index_k_device_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.device_pool.index_k_with_scale_buffer],
+            [x.data_ptr() for x in device_index_k_cache],
             dtype=torch.uint64,
             device=self.device_pool.device,
         )
@@ -2438,11 +2455,12 @@ class NSAIndexerPoolHost(HostKVCache):
             host_indices, device_indices
         )
         use_kernel = io_backend == "kernel" and self.indexer_page_stride_size % 8 == 0
+        device_index_k_cache = self._get_device_index_k_cache_for_transfer(device_pool)
         if use_kernel:
             if self.layout == "layer_first":
                 transfer_kv_per_layer_mla(
                     src=self.index_k_with_scale_buffer[layer_id],
-                    dst=device_pool.index_k_with_scale_buffer[layer_id],
+                    dst=device_index_k_cache[layer_id],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     item_size=self.indexer_page_stride_size,
@@ -2450,7 +2468,7 @@ class NSAIndexerPoolHost(HostKVCache):
             elif self.layout == "page_first":
                 transfer_kv_per_layer_mla_pf_lf(
                     src=self.index_k_with_scale_buffer,
-                    dst=device_pool.index_k_with_scale_buffer[layer_id],
+                    dst=device_index_k_cache[layer_id],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     layer_id=layer_id,
@@ -2463,7 +2481,7 @@ class NSAIndexerPoolHost(HostKVCache):
             if self.layout == "layer_first":
                 transfer_kv_direct(
                     src_layers=[self.index_k_with_scale_buffer[layer_id]],
-                    dst_layers=[device_pool.index_k_with_scale_buffer[layer_id]],
+                    dst_layers=[device_index_k_cache[layer_id]],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     page_size=1,
@@ -2471,7 +2489,7 @@ class NSAIndexerPoolHost(HostKVCache):
             elif self.layout == "page_first_direct":
                 transfer_kv_per_layer_direct_pf_lf(
                     src_ptrs=[self.index_k_with_scale_buffer],
-                    dst_ptrs=[device_pool.index_k_with_scale_buffer[layer_id]],
+                    dst_ptrs=[device_index_k_cache[layer_id]],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     layer_id=layer_id,
@@ -2489,6 +2507,7 @@ class NSAIndexerPoolHost(HostKVCache):
             host_indices, device_indices
         )
         use_kernel = io_backend == "kernel" and self.indexer_page_stride_size % 8 == 0
+        device_index_k_cache = self._get_device_index_k_cache_for_transfer(device_pool)
         if use_kernel:
             if self.layout == "layer_first":
                 transfer_kv_all_layer_mla(
@@ -2514,7 +2533,7 @@ class NSAIndexerPoolHost(HostKVCache):
         elif io_backend == "direct":
             if self.layout == "layer_first":
                 transfer_kv_direct(
-                    src_layers=device_pool.index_k_with_scale_buffer,
+                    src_layers=device_index_k_cache,
                     dst_layers=self.index_k_data_refs,
                     src_indices=device_page_indices,
                     dst_indices=host_page_indices,
@@ -2522,7 +2541,7 @@ class NSAIndexerPoolHost(HostKVCache):
                 )
             elif self.layout == "page_first_direct":
                 transfer_kv_all_layer_direct_lf_pf(
-                    src_ptrs=device_pool.index_k_with_scale_buffer,
+                    src_ptrs=device_index_k_cache,
                     dst_ptrs=[self.index_k_with_scale_buffer],
                     src_indices=device_page_indices,
                     dst_indices=host_page_indices,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -333,6 +333,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # Position information
     positions: torch.Tensor = None
 
+    # For NSA/DSA topk_indices reuse across forward calls (e.g., EAGLE draft)
+    topk_indices: Optional[torch.Tensor] = None
+    reuse_mtp_topk_indices: Optional[bool] = False
+
     # For extend
     extend_num_tokens: Optional[int] = None
     extend_seq_lens: Optional[torch.Tensor] = None

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -40,6 +40,7 @@ from sglang.srt.utils.common import (
     is_float4_e2m1fn_x2,
     is_hip,
     is_dcu,
+    is_dcu_native_fp8_supported,
     is_npu,
 )
 
@@ -56,6 +57,7 @@ MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP = 1
 logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
+_is_hip = is_hip()
 _is_dcu = is_dcu()
 
 
@@ -86,12 +88,14 @@ class ModelRunnerKVCacheMixin:
             # Add indexer KV cache overhead for NSA models (DeepSeek V3.2)
             if is_deepseek_nsa(self.model_config.hf_config):
                 index_head_dim = get_nsa_index_head_dim(self.model_config.hf_config)
-                if _is_dcu and self.kv_cache_dtype not in (
-                    torch.float8_e4m3fn,
-                    torch.float8_e5m2,
-                ):
+                use_bf16_index_cache = _is_dcu and (
+                    self.kv_cache_dtype
+                    not in (torch.float8_e4m3fn, torch.float8_e5m2)
+                    or not is_dcu_native_fp8_supported()
+                )
+                if use_bf16_index_cache:
                     indexer_size_per_token = index_head_dim
-                    element_size = torch._utils._element_size(self.kv_cache_dtype)
+                    element_size = torch._utils._element_size(torch.bfloat16)
                 else:
                     indexer_size_per_token = (
                         index_head_dim

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -112,6 +112,10 @@ def handle_attention_flashmla(attn, forward_batch):
     return _handle_attention_backend(attn, forward_batch, "flashmla")
 
 
+def handle_attention_dcu_mla(attn, forward_batch):
+    return _handle_attention_backend(attn, forward_batch, "dcu_mla")
+
+
 def handle_attention_cutlass_mla(attn, forward_batch):
     return _handle_attention_backend(attn, forward_batch, "cutlass_mla")
 
@@ -186,6 +190,7 @@ AttentionBackendRegistry.register("ascend", handle_attention_ascend)
 AttentionBackendRegistry.register("flashinfer", handle_attention_flashinfer)
 AttentionBackendRegistry.register("fa3", handle_attention_fa3)
 AttentionBackendRegistry.register("flashmla", handle_attention_flashmla)
+AttentionBackendRegistry.register("dcu_mla", handle_attention_dcu_mla)
 AttentionBackendRegistry.register("cutlass_mla", handle_attention_cutlass_mla)
 AttentionBackendRegistry.register("fa4", handle_attention_fa4)
 AttentionBackendRegistry.register("trtllm_mla", handle_attention_trtllm_mla)

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -238,7 +238,15 @@ class DeepseekMLAForwardMixin:
                     q = self.q_b_proj(q)[0].view(
                         -1, self.num_local_heads, self.qk_head_dim
                     )
-                if not self.skip_topk or prev_topk_indices is None:
+                # skip_topk (shared) layers carry no indexer weights in the
+                # checkpoint, so they must reuse the carried topk and never run
+                # the indexer. Do NOT widen this to `or prev_topk_indices is
+                # None` (the upstream gate): that recomputes with an
+                # uninitialized indexer whenever cross-layer propagation is
+                # unavailable (e.g. the TBO op path drops topk_indices),
+                # reintroducing the >index_topk garbling. The is_nextn clause is
+                # the sole intentional fallback (layer 78 has its own weights).
+                if not self.skip_topk or (self.is_nextn and prev_topk_indices is None):
                     topk_indices = self.indexer(
                         x=hidden_states,
                         q_lora=q_lora,
@@ -257,7 +265,12 @@ class DeepseekMLAForwardMixin:
                 k_nope = k_nope.unsqueeze(1)
                 q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
                 if q_lora is not None:
-                    if not self.skip_topk or prev_topk_indices is None:
+                    # See the skip_topk note above: shared layers have no
+                    # indexer weights, so this gate must not fall back to
+                    # computing when prev_topk_indices is None.
+                    if not self.skip_topk or (
+                        self.is_nextn and prev_topk_indices is None
+                    ):
                         topk_indices = self.indexer(
                             x=hidden_states,
                             q_lora=q_lora,

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -208,7 +208,14 @@ class DeepseekModelNextN(nn.Module):
                 forward_batch,
                 residual,
                 zero_allocator,
+                prev_topk_indices=(
+                    forward_batch.topk_indices
+                    if forward_batch.reuse_mtp_topk_indices
+                    else None
+                ),
             )
+            if forward_batch.reuse_mtp_topk_indices:
+                forward_batch.topk_indices = topk_indices
 
         if not forward_batch.forward_mode.is_idle():
             if residual is not None:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -168,6 +168,7 @@ from sglang.srt.models.deepseek_common.utils import (
 )
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.state_capturer.indexer_topk import maybe_capture_indexer_topk
 from sglang.srt.utils import (
     BumpAllocator,
     LazyValue,
@@ -199,7 +200,6 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 from sglang.srt.distributed import (
     parallel_state,
 )
-from enum import IntEnum, auto
 import tqdm
 from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
@@ -221,7 +221,6 @@ _use_fused_mla_cat = get_bool_env_var("SGLANG_USE_FUSED_MLA_CAT")
 _use_fused_rmsnorm_rope = get_bool_env_var("SGLANG_USE_FUSED_RMSNORM_ROPE")
 _use_fused_rms_quant = get_bool_env_var("SGLANG_USE_FUSED_RMS_QUANT")
 _rms_quant_path = get_int_env_var('SGLANG_USE_RMS_QUANT_PATH')
-_use_fused_dpskv4_silu_mul_fp8_quant = get_bool_env_var("SGLANG_USE_FUSED_DPSKV4_SILU_MUL_FP8_QUANT")
 if _use_fused_rmsnorm_rope:
     from lightop import fused_rms_norm_rope_contiguous
     fused_rms_norm_rope_contiguous = torch._dynamo.disable(fused_rms_norm_rope_contiguous)
@@ -346,205 +345,6 @@ def add_forward_absorb_core_attention_backend(backend_name):
     if backend_name not in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS:
         FORWARD_ABSORB_CORE_ATTENTION_BACKENDS.append(backend_name)
         logger.info(f"Added {backend_name} to FORWARD_ABSORB_CORE_ATTENTION_BACKENDS.")
-
-
-class AttnForwardMethod(IntEnum):
-    # Use multi-head attention
-    MHA = auto()
-
-    # Use absorbed multi-latent attention
-    MLA = auto()
-
-    # Use multi-head attention, but with KV cache chunked.
-    # This method can avoid OOM when prefix lengths are long.
-    MHA_CHUNKED_KV = auto()
-
-    # Use multi-head attention, execute the MHA for prefix and extended kv in one shot
-    # when the sequence lengths are below the threshold.
-    MHA_ONE_SHOT = auto()
-
-    # Use MLA but with fused RoPE
-    MLA_FUSED_ROPE = auto()
-
-    # Use MLA with fused RoPE kernel for CPU
-    MLA_FUSED_ROPE_CPU = auto()
-
-    # Use multi-head attention for NPU
-    MHA_NPU = auto()
-
-    # Use absorbed multi-latent attention for NPU
-    MLA_NPU = auto()
-
-    # Use Deepseek V3.2 sparse multi-latent attention for NPU
-    DSA_NPU = auto()
-
-
-def _dispatch_mla_subtype(attn, forward_batch):
-    if _is_hip:
-        if attn.rocm_fused_decode_mla and forward_batch.forward_mode.is_decode():
-            return AttnForwardMethod.MLA_FUSED_ROPE
-        else:
-            return AttnForwardMethod.MLA
-    else:
-        if hasattr(attn, "fused_qkv_a_proj_with_mqa") and use_intel_amx_backend(attn):
-            return AttnForwardMethod.MLA_FUSED_ROPE_CPU
-        else:
-            return AttnForwardMethod.MLA
-
-
-class AttentionBackendRegistry:
-    _handlers = {}
-
-    @classmethod
-    def register(cls, backend_name, handler_func):
-        cls._handlers[backend_name] = handler_func
-
-    @classmethod
-    def get_handler(cls, backend_name):
-        return cls._handlers.get(backend_name, cls._handlers.get("triton"))
-
-
-def handle_attention_ascend(attn, forward_batch):
-    if (
-        forward_batch.forward_mode.is_extend()
-        and not forward_batch.forward_mode.is_target_verify()
-        and not forward_batch.forward_mode.is_draft_extend()
-        and not forward_batch.forward_mode.is_draft_extend_v2()
-    ):
-        if hasattr(attn, "indexer"):
-            return AttnForwardMethod.DSA_NPU
-        else:
-            return AttnForwardMethod.MHA_NPU
-    else:
-        if hasattr(attn, "indexer"):
-            return AttnForwardMethod.DSA_NPU
-        else:
-            return AttnForwardMethod.MLA_NPU
-
-
-def _get_sum_extend_prefix_lens(forward_batch):
-    return (
-        sum(forward_batch.extend_prefix_lens_cpu)
-        if forward_batch.extend_prefix_lens_cpu is not None
-        else 0
-    )
-
-
-def _support_mha_one_shot(attn: DeepseekV2AttentionMLA, forward_batch, backend_name):
-    attn_supported = backend_name in ["fa3", "flashinfer", "flashmla"]
-    sum_seq_lens = (
-        sum(forward_batch.seq_lens_cpu) if forward_batch.seq_lens_cpu is not None else 0
-    )
-    return attn_supported and sum_seq_lens <= forward_batch.get_max_chunk_capacity()
-
-
-def _handle_attention_backend(
-    attn: DeepseekV2AttentionMLA, forward_batch, backend_name
-):
-    if is_in_piecewise_cuda_graph():
-        return AttnForwardMethod.MLA
-
-    sum_extend_prefix_lens = _get_sum_extend_prefix_lens(forward_batch)
-    disable_ragged = (
-        backend_name in ["flashinfer", "flashmla"]
-    ) and attn.flashinfer_mla_disable_ragged
-
-    if (
-        not disable_ragged
-        and forward_batch.forward_mode.is_extend_without_speculative()
-        and (
-            (
-                sum_extend_prefix_lens >= attn.chunked_prefix_cache_threshold
-                and not attn.disable_chunked_prefix_cache
-            )
-            or sum_extend_prefix_lens == 0
-        )
-    ):
-        if _support_mha_one_shot(attn, forward_batch, backend_name):
-            return AttnForwardMethod.MHA_ONE_SHOT
-        return AttnForwardMethod.MHA_CHUNKED_KV
-    else:
-        return _dispatch_mla_subtype(attn, forward_batch)
-
-
-def handle_attention_flashinfer(attn, forward_batch):
-    return _handle_attention_backend(attn, forward_batch, "flashinfer")
-
-
-def handle_attention_fa3(attn, forward_batch):
-    # when deterministic inference is enabled, use MLA
-    if get_global_server_args().enable_deterministic_inference:
-        return _dispatch_mla_subtype(attn, forward_batch)
-    else:
-        return _handle_attention_backend(attn, forward_batch, "fa3")
-
-
-def handle_attention_flashmla(attn, forward_batch):
-    return _handle_attention_backend(attn, forward_batch, "flashmla")
-
-
-def handle_attention_dcu_mla(attn, forward_batch):
-    return _handle_attention_backend(attn, forward_batch, "dcu_mla")
-
-
-def handle_attention_cutlass_mla(attn, forward_batch):
-    return _handle_attention_backend(attn, forward_batch, "cutlass_mla")
-
-
-def handle_attention_fa4(attn, forward_batch):
-    # TODO(cicirori): use FA4 MHA for DeepSeekV3 for now
-    return AttnForwardMethod.MHA_CHUNKED_KV
-
-
-def handle_attention_trtllm_mla(attn, forward_batch):
-    if is_in_piecewise_cuda_graph():
-        return AttnForwardMethod.MLA
-
-    sum_extend_prefix_lens = _get_sum_extend_prefix_lens(forward_batch)
-    if forward_batch.forward_mode.is_extend_without_speculative() and (
-        not attn.disable_chunked_prefix_cache or sum_extend_prefix_lens == 0
-    ):
-        return AttnForwardMethod.MHA_CHUNKED_KV
-    else:
-        return _dispatch_mla_subtype(attn, forward_batch)
-
-
-def handle_attention_aiter(attn, forward_batch):
-    if forward_batch.forward_mode.is_extend_without_speculative():
-        return AttnForwardMethod.MHA
-    else:
-        return AttnForwardMethod.MLA
-
-
-def handle_attention_nsa(attn, forward_batch):
-    """
-    Dispatch logic is centralized in NativeSparseAttnBackend.set_nsa_prefill_impl and executed
-    in init_forward_metadata. Read the decision from backend.use_mha.
-    """
-
-    backend = forward_batch.attn_backend
-    if isinstance(backend, TboAttnBackend):  # if enable tbo, get primary backend
-        backend = backend.primary
-    if hasattr(backend, "use_mha") and backend.use_mha:
-        return AttnForwardMethod.MHA_ONE_SHOT
-    return AttnForwardMethod.MLA
-
-
-def handle_attention_triton(attn, forward_batch):
-    if is_in_piecewise_cuda_graph():
-        return AttnForwardMethod.MLA
-
-    # when deterministic inference is enabled, use MLA
-    if get_global_server_args().enable_deterministic_inference:
-        return _dispatch_mla_subtype(attn, forward_batch)
-
-    if (
-        forward_batch.forward_mode.is_extend_without_speculative()
-        and sum(forward_batch.extend_prefix_lens_cpu) == 0
-    ):
-        return AttnForwardMethod.MHA
-    else:
-        return _dispatch_mla_subtype(attn, forward_batch)
 
 
 class DeepseekV2MLP(nn.Module):
@@ -675,30 +475,6 @@ class DeepseekV2MLP(nn.Module):
             skip_all_reduce=should_allreduce_fusion or use_reduce_scatter,
         )
         return x
-        # if _use_fused_rms_quant and rms_weight is not None and residual is not None:
-        #     gate_up, new_resi, i_q, _scales, _ = self.gate_up_proj(x, rms_weight, residual, update_hd=update_hd)
-        #     if _use_fused_silu_mul_quant:
-        #         x, _ = self.down_proj(gate_up, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter, use_fused_silu_mul_quant=True)
-        #     elif _use_fused_dpskv4_silu_mul_fp8_quant:
-        #         x, _ = self.down_proj(gate_up, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter, use_fused_silu_mul_fp8_quant=True)
-        #     else:
-        #         x = self.act_fn(gate_up)
-        #         x, _ = self.down_proj(
-        #             x, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter
-        #         )
-        #     return x, new_resi, i_q, _scales
-        # else:
-        #     gate_up, _ = self.gate_up_proj(x)
-        #     if _use_fused_silu_mul_quant:
-        #         x, _ = self.down_proj(gate_up, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter, use_fused_silu_mul_quant=True)
-        #     elif _use_fused_dpskv4_silu_mul_fp8_quant:
-        #         x, _ = self.down_proj(gate_up, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter, use_fused_silu_mul_fp8_quant=True)
-        #     else:
-        #         x = self.act_fn(gate_up)
-        #         x, _ = self.down_proj(
-        #             x, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter
-        #         )
-        #     return x
 
 
 class MoEGate(nn.Module):
@@ -1105,7 +881,6 @@ class DeepseekV2MoE(nn.Module):
                     * (get_global_server_args().speculative_num_draft_tokens or 1)
                 )
             ):
-                # print("进入到了self.forward_normal_dual_stream")
                 return self.forward_normal_dual_stream(
                     hidden_states,
                     should_allreduce_fusion,
@@ -1117,7 +892,6 @@ class DeepseekV2MoE(nn.Module):
                     residual = residual,
                 )
             else:
-                # print("进入到了self.forward_normal")
                 return self.forward_normal(
                     hidden_states,
                     should_allreduce_fusion,
@@ -1129,13 +903,7 @@ class DeepseekV2MoE(nn.Module):
                     residual = residual,
                 )
         else:
-            return self.forward_deepep(
-                hidden_states,
-                forward_batch,
-                input_ids_global=input_ids_global,
-                rms_weight=rms_weight,
-                residual=residual,
-            )
+            return self.forward_deepep(hidden_states, forward_batch, rms_weight=rms_weight, residual=residual,)
 
     def forward_normal_dual_stream(
         self,
@@ -1291,11 +1059,10 @@ class DeepseekV2MoE(nn.Module):
                 post_combine_hook_handle = (
                     self.experts.dispatcher.register_post_combine_hook(_post_combine_hook)
                 )
-            # input_hidden_states = hidden_states.detach().clone() #lj
             final_hidden_states = self.experts(
             hidden_states,
             topk_output,
-            )
+        )
         if (
             not _is_cuda
             and not _is_musa
@@ -1780,6 +1547,7 @@ class DeepseekV2AttentionMLA(
         self.q_lora_rank = q_lora_rank
         self.kv_lora_rank = kv_lora_rank
         self.quant_config = quant_config
+        self.is_nextn = is_nextn
         self.input_layernorm = input_layernorm  # this is from other place
         # self.input_layernorm_weight = input_layernorm_weight
         attn_tp_rank = get_attention_tp_rank()
@@ -1867,12 +1635,33 @@ class DeepseekV2AttentionMLA(
             # skip_topk: when True, this layer will skip computation and reuse previous layer's topk indices.
             # next_skip_topk: when True, the next layer will skip computation and reuse this layer's topk indices.
             if is_nextn:
-                self.skip_topk = False
-                self.next_skip_topk = False
+                self.skip_topk = True
+                self.next_skip_topk = True
             else:
                 self.index_topk_freq = getattr(config, "index_topk_freq", 1)
                 self.index_topk_pattern = getattr(config, "index_topk_pattern", None)
-                if self.index_topk_pattern is None:
+                self.index_skip_topk_offset = getattr(
+                    config, "index_skip_topk_offset", None
+                )
+                if (
+                    self.index_topk_pattern is None
+                    and self.index_skip_topk_offset is not None
+                ):
+                    assert self.index_skip_topk_offset > 0, (
+                        "index_skip_topk_offset must be positive; offset <= 0 "
+                        "marks layer 0 as skip_topk with no prior topk to reuse"
+                    )
+                    self.skip_topk = (
+                        max(layer_id - self.index_skip_topk_offset + 1, 0)
+                        % self.index_topk_freq
+                        != 0
+                    )
+                    self.next_skip_topk = (
+                        max(layer_id - self.index_skip_topk_offset + 2, 0)
+                        % self.index_topk_freq
+                        != 0
+                    )
+                elif self.index_topk_pattern is None:
                     self.skip_topk = max(layer_id - 1, 0) % self.index_topk_freq != 0
                     self.next_skip_topk = layer_id % self.index_topk_freq != 0
                 else:
@@ -2235,6 +2024,7 @@ class DeepseekV2AttentionMLA(
         forward_batch: ForwardBatch,
         zero_allocator: BumpAllocator,
         llama_4_scaling: Optional[torch.Tensor] = None,
+        prev_topk_indices: Optional[torch.Tensor] = None,
     ):
         from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
         global _use_fused_rmsnorm_rope
@@ -2326,13 +2116,18 @@ class DeepseekV2AttentionMLA(
                     q = self.q_b_proj(q)[0].view(
                         -1, self.num_local_heads, self.qk_head_dim
                     )
-                topk_indices = self.indexer(
-                    x=hidden_states,
-                    q_lora=q_lora,
-                    positions=positions,
-                    forward_batch=forward_batch,
-                    layer_id=self.layer_id,
-                )
+                if not self.skip_topk or (self.is_nextn and prev_topk_indices is None):
+                    topk_indices = self.indexer(
+                        x=hidden_states,
+                        q_lora=q_lora,
+                        positions=positions,
+                        forward_batch=forward_batch,
+                        layer_id=self.layer_id,
+                    )
+                else:
+                    topk_indices = maybe_capture_indexer_topk(
+                        self.layer_id, prev_topk_indices
+                    )
                 current_stream.wait_stream(self.alt_stream)
             else:
                 if not _use_fused_rmsnorm_rope:
@@ -2343,13 +2138,20 @@ class DeepseekV2AttentionMLA(
                     q = self.q_b_proj(q, rms_weight=self.q_a_layernorm.weight.data, residual=None,
                                     update_hd=False)[0].view(-1, self.num_local_heads, self.qk_head_dim)
                 if q_lora is not None:
-                    topk_indices = self.indexer(
-                        x=hidden_states,
-                        q_lora=q_lora,
-                        positions=positions,
-                        forward_batch=forward_batch,
-                        layer_id=self.layer_id,
-                    )
+                    if not self.skip_topk or (
+                        self.is_nextn and prev_topk_indices is None
+                    ):
+                        topk_indices = self.indexer(
+                            x=hidden_states,
+                            q_lora=q_lora,
+                            positions=positions,
+                            forward_batch=forward_batch,
+                            layer_id=self.layer_id,
+                        )
+                    else:
+                        topk_indices = maybe_capture_indexer_topk(
+                            self.layer_id, prev_topk_indices
+                        )
         else:
             q = self.q_proj(hidden_states)[0].view(
                 -1, self.num_local_heads, self.qk_head_dim
@@ -2683,7 +2485,11 @@ class DeepseekV2AttentionMLA(
                 # )
         output, _ = self.o_proj(attn_bmm_output)
         # 如果第一维是1才 squeeze
-        return output
+        if self.next_skip_topk is None:
+            return output
+        if not self.next_skip_topk:
+            return output, None
+        return output, topk_indices
 
     def forward_absorb_fused_mla_rope_prepare(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1824,6 +1824,19 @@ class ServerArgs:
                     self.attention_backend = "nsa"
                     logger.info("Use nsa attention backend for DeepSeek with DSA.")
 
+                index_topk_freq = getattr(hf_config, "index_topk_freq", 1)
+                index_topk_pattern = getattr(hf_config, "index_topk_pattern", None)
+                if self.enable_two_batch_overlap and (
+                    index_topk_freq > 1
+                    or (
+                        index_topk_pattern is not None
+                        and "S" in index_topk_pattern
+                    )
+                ):
+                    raise ValueError(
+                        "--enable-two-batch-overlap is not supported with DSA topk indices sharing yet."
+                    )
+
                 if not is_npu() and not is_xpu():  # CUDA or ROCm GPU
                     if self.enable_nsa_prefill_context_parallel:
                         logger.warning(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1828,13 +1828,14 @@ class ServerArgs:
                 index_topk_pattern = getattr(hf_config, "index_topk_pattern", None)
                 if self.enable_two_batch_overlap and (
                     index_topk_freq > 1
-                    or (
-                        index_topk_pattern is not None
-                        and "S" in index_topk_pattern
-                    )
+                    or (index_topk_pattern is not None and "S" in index_topk_pattern)
                 ):
                     raise ValueError(
-                        "--enable-two-batch-overlap is not supported with DSA topk indices sharing yet."
+                        "--enable-two-batch-overlap is not supported with DSA "
+                        "index-topk sharing (index_topk_freq > 1 or an "
+                        "index_topk_pattern containing shared layers): the TBO op "
+                        "path does not propagate topk indices across layers, so "
+                        "shared layers would run sparse attention without indices."
                     )
 
                 if not is_npu() and not is_xpu():  # CUDA or ROCm GPU

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -246,8 +246,7 @@ class EAGLEDraftExtendCudaGraphRunner:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
 
         return is_bs_supported
-    
-    #nhb
+
     def _create_graph(self):
         return torch.cuda.CUDAGraph()
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -561,7 +561,7 @@ def select_top_k_tokens_tmp(
 
     return input_ids, hidden_states, scores, tree_info
 
-#nhb
+
 def assign_extend_cache_locs_func(
     req_pool_indices: torch.Tensor,
     req_to_token: torch.Tensor,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -878,6 +878,16 @@ class EAGLEWorker(TpModelWorker):
 
         # Forward multiple steps
         scores = None
+        index_share_for_mtp_iteration = (
+            getattr(
+                self.model_config.hf_config, "index_share_for_mtp_iteration", False
+            )
+            and self.topk == 1
+        )
+        if index_share_for_mtp_iteration:
+            forward_batch.reuse_mtp_topk_indices = True
+            forward_batch.topk_indices = None
+
         for i in range(self.speculative_num_steps):
             input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
                 i, topk_p, topk_index, hidden_states, scores, self.topk
@@ -921,6 +931,10 @@ class EAGLEWorker(TpModelWorker):
                 topk_index = self.hot_token_id[topk_index]
             hidden_states = logits_output.hidden_states
             forward_batch.positions.add_(1)
+
+        if index_share_for_mtp_iteration:
+            forward_batch.topk_indices = None
+            forward_batch.reuse_mtp_topk_indices = False
 
         parent_list, top_scores_index, draft_tokens = organize_draft_results(
             score_list, token_list, parents_list, self.speculative_num_draft_tokens

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -878,6 +878,10 @@ class EAGLEWorker(TpModelWorker):
 
         # Forward multiple steps
         scores = None
+        # Reuse NSA/DSA topk_indices from the first draft forward step for
+        # subsequent steps, analogous to skip_topk in deepseek_v2.py layers.
+        # Only safe with topk == 1: select_top_k_tokens reorders candidate rows
+        # each step, which would desync the cached indices from their rows.
         index_share_for_mtp_iteration = (
             getattr(
                 self.model_config.hf_config, "index_share_for_mtp_iteration", False

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -60,8 +60,6 @@ from sglang.srt.speculative.spec_utils import (
     maybe_detect_nan,
     maybe_detect_oob,
     select_top_k_tokens,
-    #nhb
-    generate_token_bitmask
 )
 from sglang.srt.utils.common import (
     MultiprocessingSerializer,

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -170,6 +170,18 @@ def is_dcu() -> bool:
         logger.warning("DCU detection failed (not a DCU or HIP misconfigured): %s", e)
         return False
 
+
+@lru_cache(maxsize=1)
+def is_dcu_native_fp8_supported() -> bool:
+    if not is_dcu():
+        return False
+    try:
+        gcn_arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+        return "gfx938" in gcn_arch
+    except Exception as e:
+        logger.warning("DCU native FP8 detection failed: %s", e)
+        return False
+
 @lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -69,6 +69,28 @@ class HfModelConfigParser(ModelConfigParserBase):
 
         if (
             config.architectures is not None
+            and config.architectures[0] == "GlmMoeDsaForCausalLM"
+        ):
+            from transformers import PretrainedConfig
+
+            raw_config, _ = PretrainedConfig.get_config_dict(
+                model, revision=revision
+            )
+            for key in (
+                "qk_rope_head_dim",
+                "index_topk_freq",
+            ):
+                if key in raw_config:
+                    setattr(config, key, raw_config[key])
+            if hasattr(config, "qk_head_dim") and hasattr(
+                config, "qk_nope_head_dim"
+            ):
+                config.qk_head_dim = (
+                    config.qk_nope_head_dim + config.qk_rope_head_dim
+                )
+
+        if (
+            config.architectures is not None
             and config.architectures[0] == "Phi4MMForCausalLM"
         ):
             from transformers import SiglipVisionConfig

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -71,6 +71,10 @@ class HfModelConfigParser(ModelConfigParserBase):
             config.architectures is not None
             and config.architectures[0] == "GlmMoeDsaForCausalLM"
         ):
+            # GlmMoeDsaConfig drops/clobbers raw checkpoint fields the DSA path
+            # needs, so re-read them from config.json and restore. Fixed upstream
+            # by https://github.com/huggingface/transformers/pull/46338; remove
+            # this block once SGLang requires transformers >= 5.10.
             from transformers import PretrainedConfig
 
             raw_config, _ = PretrainedConfig.get_config_dict(

--- a/sgl-kernel/csrc/allreduce/custom_all_reduce.hip
+++ b/sgl-kernel/csrc/allreduce/custom_all_reduce.hip
@@ -56,27 +56,41 @@ bool _is_weak_contiguous(torch::Tensor& t) {
           t.numel() * t.element_size());
 }
 
-void _all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
-                 hipStream_t stream) {
+void _all_reduce(
+    fptr_t _fa,
+    torch::Tensor& inp,
+    torch::Tensor& out,
+    hipStream_t stream,
+    int input_fence_mode = sglang::kInputFenceNone) {
   auto fa = reinterpret_cast<sglang::CustomAllreduce*>(_fa);
   TORCH_CHECK(_is_weak_contiguous(out));
   switch (out.scalar_type()) {
     case at::ScalarType::Float: {
-      fa->allreduce<float>(stream, reinterpret_cast<float*>(inp.data_ptr()),
-                           reinterpret_cast<float*>(out.data_ptr()),
-                           out.numel());
+      fa->allreduce<float>(
+          stream,
+          reinterpret_cast<float*>(inp.data_ptr()),
+          reinterpret_cast<float*>(out.data_ptr()),
+          out.numel(),
+          input_fence_mode);
       break;
     }
     case at::ScalarType::Half: {
-      fa->allreduce<half>(stream, reinterpret_cast<half*>(inp.data_ptr()),
-                          reinterpret_cast<half*>(out.data_ptr()), out.numel());
+      fa->allreduce<half>(
+          stream,
+          reinterpret_cast<half*>(inp.data_ptr()),
+          reinterpret_cast<half*>(out.data_ptr()),
+          out.numel(),
+          input_fence_mode);
       break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
     case at::ScalarType::BFloat16: {
       fa->allreduce<nv_bfloat16>(
-          stream, reinterpret_cast<nv_bfloat16*>(inp.data_ptr()),
-          reinterpret_cast<nv_bfloat16*>(out.data_ptr()), out.numel());
+          stream,
+          reinterpret_cast<nv_bfloat16*>(inp.data_ptr()),
+          reinterpret_cast<nv_bfloat16*>(out.data_ptr()),
+          out.numel(),
+          input_fence_mode);
       break;
     }
 #endif
@@ -106,7 +120,12 @@ void all_reduce_unreg(fptr_t _fa, torch::Tensor& inp, torch::Tensor& reg_buffer,
               "registered buffer is too small to contain the input");
   AT_CUDA_CHECK(hipMemcpyAsync(reg_buffer.data_ptr(), inp.data_ptr(),
                                 input_size, hipMemcpyDeviceToDevice, stream));
-  _all_reduce(_fa, reg_buffer, out, stream);
+  _all_reduce(
+      _fa,
+      reg_buffer,
+      out,
+      stream,
+      sglang::get_input_fence_mode_from_env());
 }
 
 void dispose(fptr_t _fa) {

--- a/sgl-kernel/csrc/allreduce/custom_all_reduce_hip.cuh
+++ b/sgl-kernel/csrc/allreduce/custom_all_reduce_hip.cuh
@@ -11,9 +11,12 @@ typedef __hip_bfloat16 nv_bfloat16;
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <limits>
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -29,6 +32,29 @@ typedef __hip_bfloat16 nv_bfloat16;
 namespace sglang {
 
 constexpr int kMaxBlocks = 64;
+constexpr int kAllReduceGPUSmall = 4;
+constexpr int kAllReduceGPULarge = 8;
+constexpr size_t kAllReduceSmallThreshold = 512 * 1024;
+constexpr size_t kAllReduceLargeThreshold = 256 * 1024;
+constexpr int kInputFenceNone = 0;
+constexpr int kInputFenceAllThreads = 1;
+constexpr int kInputFenceThread0 = 2;
+
+inline int get_input_fence_mode_from_env() {
+  const char* env_mode = std::getenv("SGLANG_CUSTOM_ALLREDUCE_INPUT_FENCE");
+  if (env_mode == nullptr || std::strcmp(env_mode, "all") == 0 || std::strcmp(env_mode, "all_threads") == 0) {
+    return kInputFenceAllThreads;
+  }
+  if (std::strcmp(env_mode, "thread0") == 0 || std::strcmp(env_mode, "single") == 0) {
+    return kInputFenceThread0;
+  }
+  if (std::strcmp(env_mode, "none") == 0 || std::strcmp(env_mode, "off") == 0) {
+    return kInputFenceNone;
+  }
+  throw std::runtime_error(
+      "Invalid SGLANG_CUSTOM_ALLREDUCE_INPUT_FENCE: " + std::string(env_mode) +
+      ". Valid values: all, all_threads, thread0, single, none, off");
+}
 // note: we don't want to use atomics for signals because peer atomics are no
 // supported on PCIe links
 struct Signal {
@@ -159,16 +185,31 @@ DINLINE void start_sync(
     volatile
 #endif
     Signal* self_sg,
-    int rank) {
+    int rank,
+    int input_fence_mode) {
 #ifdef USE_ROCM
   uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+  // In the unregistered path each rank first copies its input into a shared
+  // IPC buffer, then launches this kernel. Peers start reading that buffer
+  // after observing our start flag, so publish prior device writes before the
+  // flag becomes visible to other GPUs.
+  if (input_fence_mode == kInputFenceAllThreads) {
+    __threadfence_system();
+    __syncthreads();
+  } else if (input_fence_mode == kInputFenceThread0) {
+    if (threadIdx.x == 0) __threadfence_system();
+    __syncthreads();
+  }
   if (threadIdx.x < ngpus) {
     // simultaneously write to the corresponding flag of all ranks.
     // Latency = 1 p2p write
-    __hip_atomic_store(
-        &sg.signals[threadIdx.x]->start[blockIdx.x][rank], flag, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    __atomic_store_n(
+        &sg.signals[threadIdx.x]->start[blockIdx.x][rank],
+        flag,
+        __ATOMIC_RELAXED);
     // wait until we got true from all ranks
-    while (__hip_atomic_load(&self_sg->start[blockIdx.x][threadIdx.x], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) <
+    while (__atomic_load_n(
+               &self_sg->start[blockIdx.x][threadIdx.x], __ATOMIC_RELAXED) <
            flag)
       ;
   }
@@ -211,16 +252,14 @@ DINLINE void end_sync(
   if (threadIdx.x < ngpus) {
     // simultaneously write to the corresponding flag of all ranks.
     // Latency = 1 p2p write
-    __hip_atomic_store(
+    __atomic_store_n(
         &sg.signals[threadIdx.x]->end[blockIdx.x][rank],
         flag,
-        final_sync ? __ATOMIC_RELAXED : __ATOMIC_RELEASE,
-        __HIP_MEMORY_SCOPE_SYSTEM);
+        final_sync ? __ATOMIC_RELAXED : __ATOMIC_RELEASE);
     // wait until we got true from all ranks
-    while (__hip_atomic_load(
+    while (__atomic_load_n(
                &self_sg->end[blockIdx.x][threadIdx.x],
-               final_sync ? __ATOMIC_RELAXED : __ATOMIC_ACQUIRE,
-               __HIP_MEMORY_SCOPE_AGENT) < flag)
+               final_sync ? __ATOMIC_RELAXED : __ATOMIC_ACQUIRE) < flag)
       ;
   }
   __syncthreads();
@@ -267,13 +306,14 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_1stage(
     Signal* self_sg,
     T* __restrict__ result,
     int rank,
-    int size) {
+    int size,
+    int input_fence_mode) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
   // note: we don't reorder the address so the accumulation order is the same
   // for all ranks, ensuring bitwise identical results
   auto dp = *_dp;
-  start_sync<ngpus>(sg, self_sg, rank);
+  start_sync<ngpus>(sg, self_sg, rank, input_fence_mode);
   // do the actual reduction
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
     ((P*)result)[idx] = packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0], idx);
@@ -300,7 +340,8 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_2stage(
     Signal* self_sg,
     T* __restrict__ result,
     int rank,
-    int size) {
+    int size,
+    int input_fence_mode) {
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = gridDim.x * blockDim.x;
   using P = typename packed_t<T>::P;
@@ -318,7 +359,7 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_2stage(
     tmps[i] = get_tmp_buf<P>(sg.signals[target]);
   }
   auto tmp_out = tmps[0];
-  start_sync<ngpus>(sg, self_sg, rank);
+  start_sync<ngpus>(sg, self_sg, rank, input_fence_mode);
   // stage 1: reduce scatter
   for (int idx = start + tid; idx < end; idx += stride) {
     tmp_out[idx - start] = packed_reduce<P, ngpus, A>(ptrs, idx);
@@ -362,6 +403,7 @@ class CustomAllreduce {
   std::vector<void*> graph_unreg_buffers_;
   // a map from IPC handles to opened IPC pointers
   std::map<IPC_KEY, char*> ipc_handles_;
+  hipEvent_t stopEvent;
 
   /**
    * meta is a pointer to device metadata and temporary buffer for allreduce.
@@ -397,6 +439,7 @@ class CustomAllreduce {
       }
       sg_.signals[i] = rank_sg;
     }
+    CUDACHECK(hipEventCreate(&stopEvent));
   }
 
   char* open_ipc_handle(const void* ipc_handle) {
@@ -501,6 +544,7 @@ class CustomAllreduce {
       T* input,
       T* output,
       int size,
+      int input_fence_mode = kInputFenceAllThreads,
 #ifndef USE_ROCM
       int threads = 512,
       int block_limit = 36){
@@ -535,21 +579,54 @@ class CustomAllreduce {
   size /= d;
   auto bytes = size * sizeof(typename packed_t<T>::P);
   int blocks = ::min(block_limit, (size + threads - 1) / threads);
-#define KL(ngpus, name) \
-  hipLaunchKernelGGL(   \
-      (name<T, ngpus>), dim3(blocks), dim3(threads), 0, stream, ptrs, sg_, self_sg_, output, rank_, size);
-#define REDUCE_CASE(ngpus)                                                                        \
-  case ngpus: {                                                                                   \
-    if (world_size_ == 2) {                                                                       \
-      KL(ngpus, cross_device_reduce_1stage);                                                      \
-    } else if (full_nvlink_) {                                                                    \
-      if ((world_size_ <= 4 && bytes < 512 * 1024) || (world_size_ <= 8 && bytes < 256 * 1024)) { \
-        KL(ngpus, cross_device_reduce_1stage);                                                    \
-      } else {                                                                                    \
-        KL(ngpus, cross_device_reduce_2stage);                                                    \
-      }                                                                                           \
-    }                                                                                             \
-    break;                                                                                        \
+
+  const char* env_algo = std::getenv("SGLANG_CUSTOM_ALLREDUCE_ALGO");
+  bool force_1stage = false;
+  bool force_2stage = false;
+  if (env_algo != nullptr) {
+    if (std::strcmp(env_algo, "1stage") == 0 || std::strcmp(env_algo, "oneshot") == 0) {
+      force_1stage = true;
+    } else if (std::strcmp(env_algo, "2stage") == 0 || std::strcmp(env_algo, "twoshot") == 0) {
+      force_2stage = true;
+    } else {
+      throw std::runtime_error(
+          "Invalid SGLANG_CUSTOM_ALLREDUCE_ALGO: " + std::string(env_algo) +
+          ". Valid values: 1stage, oneshot, 2stage, twoshot");
+    }
+  }
+
+#define KL(ngpus, name)                                                       \
+  {                                                                           \
+    void* kernelArgs[] = {                                                    \
+        &ptrs, &sg_, &self_sg_, &output, &rank_, &size, &input_fence_mode};   \
+    hipExtLaunchKernel(                                                       \
+        (void*)name<T, ngpus>,                                                \
+        blocks,                                                               \
+        threads,                                                              \
+        kernelArgs,                                                           \
+        0,                                                                    \
+        stream,                                                               \
+        nullptr,                                                              \
+        stopEvent,                                                            \
+        0);                                                                   \
+  }
+#define REDUCE_CASE(ngpus)                                                             \
+  case ngpus: {                                                                        \
+    if (force_1stage) {                                                                \
+      KL(ngpus, cross_device_reduce_1stage);                                           \
+    } else if (force_2stage) {                                                         \
+      KL(ngpus, cross_device_reduce_2stage);                                           \
+    } else if (world_size_ == 2) {                                                     \
+      KL(ngpus, cross_device_reduce_1stage);                                           \
+    } else if (full_nvlink_) {                                                         \
+      if ((world_size_ <= kAllReduceGPUSmall && bytes < kAllReduceSmallThreshold) ||   \
+          (world_size_ <= kAllReduceGPULarge && bytes < kAllReduceLargeThreshold)) {   \
+        KL(ngpus, cross_device_reduce_1stage);                                         \
+      } else {                                                                         \
+        KL(ngpus, cross_device_reduce_2stage);                                         \
+      }                                                                                \
+    }                                                                                  \
+    break;                                                                             \
   }
 
   switch (world_size_) {
@@ -571,6 +648,7 @@ class CustomAllreduce {
   for (auto [_, ptr] : ipc_handles_) {
     CUDACHECK(hipIpcCloseMemHandle(ptr));
   }
+  CUDACHECK(hipEventDestroy(stopEvent));
 }
 };  // namespace sglang
 /**

--- a/sgl-kernel/csrc/allreduce/deterministic_all_reduce.hip
+++ b/sgl-kernel/csrc/allreduce/deterministic_all_reduce.hip
@@ -29,9 +29,37 @@ bool _is_weak_contiguous_det(torch::Tensor& t) {
          (t.storage().nbytes() - t.storage_offset() * t.element_size() == t.numel() * t.element_size());
 }
 
-// Deterministic all-reduce for registered buffers (ROCm)
-// Uses the 1-stage kernel which is deterministic (fixed ordering)
-void deterministic_all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out) {
+template <typename T, int ngpus>
+void launch_deterministic_1stage(
+    sglang::CustomAllreduce* fa,
+    sglang::RankData* ptrs,
+    T* output,
+    int size,
+    int input_fence_mode,
+    int blocks,
+    int threads,
+    hipStream_t stream) {
+  auto sg = fa->sg_;
+  auto self_sg = fa->self_sg_;
+  auto rank = fa->rank_;
+  void* kernelArgs[] = {&ptrs, &sg, &self_sg, &output, &rank, &size, &input_fence_mode};
+  hipExtLaunchKernel(
+      (void*)sglang::cross_device_reduce_1stage<T, ngpus>,
+      blocks,
+      threads,
+      kernelArgs,
+      0,
+      stream,
+      nullptr,
+      fa->stopEvent,
+      0);
+}
+
+void deterministic_all_reduce_impl(
+    fptr_t _fa,
+    torch::Tensor& inp,
+    torch::Tensor& out,
+    int input_fence_mode) {
   const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
   auto stream = c10::hip::getCurrentHIPStreamMasqueradingAsCUDA().stream();
   TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());
@@ -73,20 +101,20 @@ void deterministic_all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor&
       // Always use 1-stage kernel for determinism
       switch (fa->world_size_) {
         case 2:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 2>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 2>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 4:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 4>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 4>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 6:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 6>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 6>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 8:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 8>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 8>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         default:
           throw std::runtime_error("world_size must be in (2,4,6,8)");
@@ -104,20 +132,20 @@ void deterministic_all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor&
       int blocks = std::min(16, (size + threads - 1) / threads);
       switch (fa->world_size_) {
         case 2:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 2>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 2>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 4:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 4>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 4>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 6:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 6>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 6>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 8:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 8>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 8>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         default:
           throw std::runtime_error("world_size must be in (2,4,6,8)");
@@ -136,20 +164,20 @@ void deterministic_all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor&
       int blocks = std::min(16, (size + threads - 1) / threads);
       switch (fa->world_size_) {
         case 2:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 2>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 2>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 4:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 4>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 4>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 6:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 6>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 6>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         case 8:
-          hipLaunchKernelGGL((sglang::cross_device_reduce_1stage<T, 8>), dim3(blocks), dim3(threads), 0, stream,
-                              ptrs, fa->sg_, fa->self_sg_, reinterpret_cast<T*>(out.data_ptr()), fa->rank_, size);
+          launch_deterministic_1stage<T, 8>(
+              fa, ptrs, reinterpret_cast<T*>(out.data_ptr()), size, input_fence_mode, blocks, threads, stream);
           break;
         default:
           throw std::runtime_error("world_size must be in (2,4,6,8)");
@@ -160,6 +188,12 @@ void deterministic_all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor&
     default:
       throw std::runtime_error("deterministic allreduce only supports float32, float16 and bfloat16");
   }
+}
+
+// Deterministic all-reduce for registered buffers (ROCm)
+// Uses the 1-stage kernel which is deterministic (fixed ordering)
+void deterministic_all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out) {
+  deterministic_all_reduce_impl(_fa, inp, out, sglang::kInputFenceNone);
 }
 
 // Deterministic all-reduce for unregistered buffers (ROCm)
@@ -174,5 +208,9 @@ void deterministic_all_reduce_unreg(fptr_t _fa, torch::Tensor& inp, torch::Tenso
               "registered buffer is too small to contain the input");
   AT_CUDA_CHECK(hipMemcpyAsync(reg_buffer.data_ptr(), inp.data_ptr(),
                                 input_size, hipMemcpyDeviceToDevice, stream));
-  deterministic_all_reduce_reg(_fa, reg_buffer, out);
+  deterministic_all_reduce_impl(
+      _fa,
+      reg_buffer,
+      out,
+      sglang::get_input_fence_mode_from_env());
 }

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -16,6 +16,31 @@
 #include "utils.h"  // WARP_SIZE
 #endif
 
+#ifdef USE_ROCM
+namespace {
+
+void* get_rocm_kernel_accessible_ptr(const at::Tensor& tensor) {
+  if (!tensor.defined()) {
+    return nullptr;
+  }
+
+  void* ptr = tensor.data_ptr();
+  if (tensor.is_cuda() || ptr == nullptr) {
+    return ptr;
+  }
+
+  void* device_ptr = nullptr;
+  cudaError_t err = cudaHostGetDevicePointer(&device_ptr, ptr, 0);
+  TORCH_CHECK(
+      err == cudaSuccess,
+      "cudaHostGetDevicePointer failed for ROCm KV cache transfer host tensor: ",
+      cudaGetErrorString(err));
+  return device_ptr;
+}
+
+}  // namespace
+#endif
+
 __device__ __forceinline__ void
 transfer_item_warp(int32_t lane_id, const void* src_addr, void* dst_addr, int64_t item_size_bytes) {
   const uint64_t* __restrict__ src = static_cast<const uint64_t*>(src_addr);
@@ -295,6 +320,14 @@ void transfer_kv_launcher(
   void* dst_k_ptr = dst_k.defined() ? dst_k.data_ptr() : nullptr;
   const void* src_v_ptr = IsMLA || !src_v.defined() ? nullptr : src_v.data_ptr();
   void* dst_v_ptr = IsMLA || !dst_v.defined() ? nullptr : dst_v.data_ptr();
+#ifdef USE_ROCM
+  src_k_ptr = get_rocm_kernel_accessible_ptr(src_k);
+  dst_k_ptr = get_rocm_kernel_accessible_ptr(dst_k);
+  if constexpr (!IsMLA) {
+    src_v_ptr = get_rocm_kernel_accessible_ptr(src_v);
+    dst_v_ptr = get_rocm_kernel_accessible_ptr(dst_v);
+  }
+#endif
   const uintptr_t* src_k_tbl_ptr = src_k_layers.defined() ? src_k_layers.data_ptr<uintptr_t>() : nullptr;
   const uintptr_t* dst_k_tbl_ptr = dst_k_layers.defined() ? dst_k_layers.data_ptr<uintptr_t>() : nullptr;
   const uintptr_t* src_v_tbl_ptr = IsMLA || !src_v_layers.defined() ? nullptr : src_v_layers.data_ptr<uintptr_t>();


### PR DESCRIPTION
## 变更说明

本 PR 主要修复 GLM-5 在 v0.5.12 DCU 分支上跑不通的问题，同时适配 GLM-5.2，并修复 sgl-kernel custom allreduce 精度相关路径。

## 主要改动

- 修复 GLM-5 在 v0.5.12 DCU 分支上的运行问题。
- 适配 GLM-5.2 相关 PR 变更。
- 修复 sgl-kernel custom allreduce 精度相关路径。
- 保留必要的 DCU 特化逻辑，并同步部分上游 DSA/NSA 相关修复。
- 清理调试残留和无效注释，如 `#nhb`、`DECODE_PRINT` 等。