### PR TITLE
fix(fst): use local device in fastsafetensors iterator for multi-node loading

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -957,7 +957,14 @@ def fastsafetensors_weights_iterator(
     except Exception:
         rank = 0
 
-    device = torch.device(f"cuda:{rank}")
+    # Use the local device sglang already assigned to this worker instead of the
+    # global rank: on node>0 (e.g. TP8.PP2 / TP16 across 2 nodes) the global rank
+    # is 8..15 but each node only has 8 cards (0..7), so `cuda:{rank}` yields an
+    # "invalid device ordinal" and multi-node loading crashes. current_device() is
+    # numerically transparent (device only decides which physical card holds the
+    # tensor; file reading / sharding / broadcast are driven by the process group)
+    # and reduces to the same value on single node. Matches vLLM PR #34070.
+    device = torch.device(f"cuda:{torch.cuda.current_device()}")
 
     weight_files_sub_lists = [
         hf_weights_files[i : i + pg.size()]
@@ -984,8 +991,9 @@ def fastsafetensors_weights_iterator(
                 for k in keys:
                     t = fb.get_tensor(k)
                     yield k, t
+                    del t
             finally:
-                pass
+                fb.close()
         finally:
             loader.close()
 


### PR DESCRIPTION
## 问题

`fastsafetensors_weights_iterator`(weight_utils.py)用**全局 rank** 决定 CUDA 卡号:

```python
device = torch.device(f"cuda:{rank}")
```

多节点下 node>0(如 TP8·PP2 或跨 2 节点 TP16)全局 rank 是 8..15,而每节点只有 8 张卡(0..7),于是 `cuda:8..15` 报 **`invalid device ordinal`**,多节点加载当场崩。

## 修改

改用 `torch.cuda.current_device()`(sglang 已分配给本 worker 的本地卡)。

- **数值透明**:device 只决定张量落哪张物理卡;读文件 / 切分 / 广播由 process group 决定,与之无关。单节点下 `rank == current_device`,等价无副作用。
- 与 vLLM [PR #34070](https://github.com/vllm-project/vllm/pull/34070) 同款修复。

另外逐 chunk 及时释放整文件 GPU buffer(`del t` + `fb.close()`),对齐 vLLM 迭代器,压住加载期显存峰值。

## 验证

Kimi-K2.6-w4a16,**跨 2 个 DCU 节点 TP8·PP2**,sglang `0.5.12+das.opt1.dtk2604`,`--load-format fastsafetensors` 走 shca IB(IBext_v8):16 rank 加载完成、**无 `invalid device ordinal`**(不打此补丁必崩)。
