### PR TITLE
fix(fst): reclaim reserved memory after fastsafetensors weight load

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -732,6 +732,30 @@ class DefaultModelLoader(BaseModelLoader):
     def load_weights_and_postprocess(model, weights, target_device):
         model.load_weights(weights)
 
+        # [FST-RECLAIM] empty_cache AFTER load_weights, BEFORE process_weights.
+        # fastsafetensors reads each whole safetensors file onto the GPU, pushing
+        # torch's reserved high-water mark up. By the end of load_weights those
+        # whole-file buffers are already freed (fb.close), so they sit as
+        # reclaimable RESERVED. Returning them to the OS here -- before
+        # process_weights_after_loading allocates repacked/quantized tensors into
+        # (and fragments) that space -- recovers ~10GB/rank of serving headroom.
+        # Mirrors the torch.npu.empty_cache() sglang already does for NPU in the
+        # loop below; extended to CUDA/HIP (DCU), which upstream omitted.
+        #
+        # Gated to fst only: it is the sole loader that leaves reserved >> allocated
+        # (other loaders stage weights on CPU, reserved ~= allocated), so this is a
+        # pure no-op sync elsewhere and every non-fst path is left unchanged. Uses
+        # the same check as this file's other fst branches
+        # (get_global_server_args().load_format == LoadFormat.FASTSAFETENSORS); both
+        # symbols are module-level imports here. synchronize() first drains fst's
+        # async copies/broadcasts so empty_cache can return the full amount at once.
+        if (
+            torch.cuda.is_available()
+            and get_global_server_args().load_format == LoadFormat.FASTSAFETENSORS
+        ):
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+
         for _, module in model.named_modules():
             quant_method = getattr(module, "quant_method", None)
             if quant_method is not None:


### PR DESCRIPTION
## 问题

fastsafetensors 把每个 safetensors 文件整体读上 GPU,顶高 torch 的 **reserved** 高水位(Kimi-K2.6-w4a16 TP8·PP2 约 55 GB/rank)。`load_weights` 结束时这些整文件 buffer 在 *allocated* 层面已释放(`fb.close`),但 **reserved** 没还给 OS;紧接着 `process_weights_after_loading` 把 repack/量化张量分配进那块空间并**切碎**它,导致后续 KV 定容时的 `empty_cache` 只能还 ~1.5 GB → reserved 卡在高位 → 超 mem-fraction 预算 → serve 报 *Not enough memory*。

## 修改

在 `DefaultModelLoader.load_weights_and_postprocess` 里、**`model.load_weights()` 之后、`process_weights` 循环之前**加 `torch.cuda.synchronize()` + `torch.cuda.empty_cache()` —— 趁 fst buffer 还没被切碎时干净回收。

- 对齐 sglang **已给 NPU** 在同一循环里做的 `torch.npu.empty_cache()`,把它扩到 **CUDA/HIP(DCU)**(上游漏了)。
- **仅在 `load_format == FASTSAFETENSORS` 时触发**(与本文件其他 fst 判断一致;`get_global_server_args` / `LoadFormat` 均为模块级 import)。其他加载器权重走 CPU(`reserved ≈ allocated`),该分支被跳过、字节不变。
- **零数值风险** —— 只动 allocator 状态,不碰权重 / 量化。

## 验证

Kimi-K2.6-w4a16,**跨 2 个 DCU 节点 TP8·PP2**,sglang `0.5.12+das.opt1.dtk2604`,fst 走 shca IB:实测 reserved **54.82 → 45.15 GB**(每 rank 回收 ~9.7–10.6 GB),avail mem 8.7 → **17.3 GB**;mem-fraction 0.85 + cuda graph 开即可 serve(此前需 0.90 + `--disable-cuda-graph`)。



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->