### PR TITLE
[sgl-diffusion] Improve Ulysses FSDP loading and fix Wan I2V precision

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -144,6 +144,9 @@ class WanI2V480PConfig(WanT2V480PConfig, WanI2VCommonConfig):
     def __post_init__(self) -> None:
         self.vae_config.load_encoder = True
         self.vae_config.load_decoder = True
+        # Wan I2V must match the official full-frame VAE encode/decode path.
+        self.vae_config.use_parallel_encode = False
+        self.vae_config.use_parallel_decode = False
 
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
         return ModelDeploymentConfig(
@@ -208,6 +211,9 @@ class Wan2_2_TI2V_5B_Config(WanT2V480PConfig, WanI2VCommonConfig):
     def __post_init__(self) -> None:
         self.vae_config.load_encoder = True
         self.vae_config.load_decoder = True
+        # Wan TI2V also feeds VAE latents into/out of the DiT like official Wan.
+        self.vae_config.use_parallel_encode = False
+        self.vae_config.use_parallel_decode = False
         self.dit_config.expand_timesteps = self.expand_timesteps
 
 

--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -176,6 +176,7 @@ class SamplingParams:
     # Profiling
     profile: bool = field(default=False, metadata={"batch_sig_exclude": True})
     num_profiled_timesteps: int = field(default=5, metadata={"batch_sig_exclude": True})
+    profile_start_step: int = field(default=0, metadata={"batch_sig_exclude": True})
     profile_all_stages: bool = field(
         default=False, metadata={"batch_sig_exclude": True}
     )

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -51,6 +51,12 @@ def _server_args_for_transformer_component(
     return component_server_args
 
 
+def _should_use_streaming_state_dict_load(server_args: ServerArgs) -> bool:
+    sp_degree = getattr(server_args, "sp_degree", 1) or 1
+    ulysses_degree = getattr(server_args, "ulysses_degree", 1) or 1
+    return bool(sp_degree > 1 and ulysses_degree > 1)
+
+
 class TransformerLoader(ComponentLoader):
     """Shared loader for (video/audio) DiT transformers."""
 
@@ -135,6 +141,9 @@ class TransformerLoader(ComponentLoader):
             reduce_dtype=torch.float32,
             output_dtype=None,
             strict=False,
+            streaming_state_dict_load=_should_use_streaming_state_dict_load(
+                component_server_args
+            ),
         )
 
         # post-hooks (e.g., patch scales (nunchaku))

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -28,6 +28,7 @@ from sglang.multimodal_gen.runtime.layers.linear import UnquantizedLinearMethod
 from sglang.multimodal_gen.runtime.loader.utils import (
     get_param_names_mapping,
     hf_to_custom_state_dict,
+    iter_hf_to_custom_state_dict,
     set_default_torch_dtype,
 )
 from sglang.multimodal_gen.runtime.loader.weight_utils import (
@@ -197,6 +198,7 @@ def maybe_load_fsdp_model(
     output_dtype: torch.dtype | None = None,
     pin_cpu_memory: bool = True,
     strict: bool = True,
+    streaming_state_dict_load: bool = False,
 ) -> torch.nn.Module:
     """Load a model with optional FSDP (Fully Sharded Data Parallel) support.
 
@@ -260,17 +262,32 @@ def maybe_load_fsdp_model(
             pin_cpu_memory=pin_cpu_memory,
         )
 
-    weight_iterator = safetensors_weights_iterator(weight_dir_list)
     param_names_mapping_fn = get_param_names_mapping(model.param_names_mapping)
-    load_model_from_full_model_state_dict(
-        model,
-        weight_iterator,
-        device,
-        param_dtype,
-        strict=strict,
-        cpu_offload=cpu_offload,
-        param_names_mapping=param_names_mapping_fn,
-    )
+    if streaming_state_dict_load:
+        logger.info("Loading model weights with streaming state-dict load")
+        weight_iterator = safetensors_weights_iterator(
+            weight_dir_list, use_runai_model_streamer=False
+        )
+        load_model_from_streaming_state_dict(
+            model,
+            weight_iterator,
+            device,
+            param_dtype,
+            strict=strict,
+            cpu_offload=cpu_offload,
+            param_names_mapping=param_names_mapping_fn,
+        )
+    else:
+        weight_iterator = safetensors_weights_iterator(weight_dir_list)
+        load_model_from_full_model_state_dict(
+            model,
+            weight_iterator,
+            device,
+            param_dtype,
+            strict=strict,
+            cpu_offload=cpu_offload,
+            param_names_mapping=param_names_mapping_fn,
+        )
 
     for _, module in model.named_modules():
         quant_method = getattr(module, "quant_method", None)
@@ -691,4 +708,314 @@ def load_model_from_full_model_state_dict(
         sharded_sd[new_param_name] = nn.Parameter(sharded_tensor)
 
     # choose `assign=True` since we cannot call `copy_` on meta tensor
+    return model.load_state_dict(sharded_sd, strict=strict, assign=True)
+
+
+# TODO(mick): need refactor, to move out checkpoint-specific adjustments
+def load_model_from_streaming_state_dict(
+    model: FSDPModule | torch.nn.Module,
+    full_sd_iterator: Generator[tuple[str, torch.Tensor], None, None],
+    device: torch.device,
+    param_dtype: torch.dtype | None,
+    strict: bool = False,
+    cpu_offload: bool = False,
+    param_names_mapping: Callable[[str], tuple[str, Any, Any]] | None = None,
+) -> _IncompatibleKeys:
+    """Load weights while streaming HF tensors into their custom names.
+
+    Unlike load_model_from_full_model_state_dict, this avoids keeping the full
+    remapped checkpoint state dict resident at once. It still builds the final
+    load_state_dict payload, which contains materialized model parameters.
+    """
+    if param_names_mapping is None:
+        param_names_mapping = get_param_names_mapping({})
+
+    meta_sd = model.state_dict()
+    param_dict = dict(model.named_parameters())
+    is_fsdp_model = isinstance(model, FSDPModule) or any(
+        hasattr(p, "device_mesh") for p in meta_sd.values()
+    )
+
+    sharded_sd = {}
+    skipped_checkpoint_keys: list[str] = []
+    reverse_param_names_mapping = {}
+    loaded_checkpoint_dtypes: dict[str, torch.dtype] = {}
+    fp8_aux_param_sd: dict[str, torch.Tensor] = {}
+    non_quantized_dtype_mismatch_counts: Counter[tuple[torch.dtype, torch.dtype]] = (
+        Counter()
+    )
+    non_quantized_dtype_mismatch_examples: dict[
+        tuple[torch.dtype, torch.dtype], list[str]
+    ] = defaultdict(list)
+    quantized_dtype_mismatch_counts: Counter[tuple[torch.dtype, torch.dtype]] = (
+        Counter()
+    )
+    quantized_dtype_mismatch_examples: dict[
+        tuple[torch.dtype, torch.dtype], list[str]
+    ] = defaultdict(list)
+
+    streamed_sd_iterator = iter_hf_to_custom_state_dict(
+        full_sd_iterator,
+        param_names_mapping,
+        valid_target_names=set(meta_sd.keys()),
+    )
+    for target_param_name, full_tensor, reverse_entry in streamed_sd_iterator:
+        existing_dtype = loaded_checkpoint_dtypes.get(target_param_name)
+        if existing_dtype is not None and existing_dtype != full_tensor.dtype:
+            existing_is_quantized = existing_dtype in _QUANTIZED_DTYPES
+            current_is_quantized = full_tensor.dtype in _QUANTIZED_DTYPES
+            if existing_is_quantized and not current_is_quantized:
+                logger.debug(
+                    "Keeping quantized duplicate for %s: existing=%s new=%s",
+                    target_param_name,
+                    existing_dtype,
+                    full_tensor.dtype,
+                )
+                continue
+            if current_is_quantized and not existing_is_quantized:
+                logger.debug(
+                    "Replacing non-quantized duplicate for %s: existing=%s new=%s",
+                    target_param_name,
+                    existing_dtype,
+                    full_tensor.dtype,
+                )
+        loaded_checkpoint_dtypes[target_param_name] = full_tensor.dtype
+        reverse_param_names_mapping[target_param_name] = reverse_entry
+        if target_param_name.endswith(".weight_scale"):
+            fp8_aux_param_sd[target_param_name] = full_tensor
+
+        meta_sharded_param = meta_sd.get(target_param_name)
+        if meta_sharded_param is None:
+            if strict or is_fsdp_model:
+                raise ValueError(
+                    f"Parameter {target_param_name} not found in custom model state dict. The hf to custom mapping may be incorrect."
+                )
+            skipped_checkpoint_keys.append(target_param_name)
+            continue
+
+        target_dtype = meta_sharded_param.dtype
+        full_tensor = _maybe_dequantize_fp8(
+            full_tensor, target_dtype, target_param_name, fp8_aux_param_sd
+        )
+
+        if full_tensor.dtype != target_dtype:
+            mismatch_key = (full_tensor.dtype, target_dtype)
+            if (
+                full_tensor.dtype in _QUANTIZED_DTYPES
+                or target_dtype in _QUANTIZED_DTYPES
+            ):
+                quantized_dtype_mismatch_counts[mismatch_key] += 1
+                if (
+                    len(quantized_dtype_mismatch_examples[mismatch_key])
+                    < _DTYPE_MISMATCH_EXAMPLE_LIMIT
+                ):
+                    quantized_dtype_mismatch_examples[mismatch_key].append(
+                        target_param_name
+                    )
+            else:
+                non_quantized_dtype_mismatch_counts[mismatch_key] += 1
+                if (
+                    len(non_quantized_dtype_mismatch_examples[mismatch_key])
+                    < _DTYPE_MISMATCH_EXAMPLE_LIMIT
+                ):
+                    non_quantized_dtype_mismatch_examples[mismatch_key].append(
+                        target_param_name
+                    )
+
+        if not hasattr(meta_sharded_param, "device_mesh"):
+            full_tensor = full_tensor.to(device=device, dtype=target_dtype)
+            actual_param = _get_param_for_weight_loading(
+                model, param_dict, target_param_name
+            )
+            weight_loader = (
+                getattr(actual_param, "weight_loader", None)
+                if actual_param is not None
+                else None
+            )
+            if weight_loader is not None:
+                assert actual_param is not None
+                sharded_tensor = torch.empty_like(
+                    meta_sharded_param, device=device, dtype=target_dtype
+                )
+                requires_grad = getattr(meta_sharded_param, "requires_grad", False)
+                temp_param = _make_param_like(actual_param, sharded_tensor)
+                if not (
+                    sharded_tensor.is_floating_point() or sharded_tensor.is_complex()
+                ):
+                    requires_grad = False
+                temp_param.requires_grad = requires_grad
+                try:
+                    weight_loader(temp_param, full_tensor)
+                except AssertionError as exc:
+                    raise AssertionError(
+                        "Failed to shard/load parameter "
+                        f"{target_param_name}: full_tensor.shape={tuple(full_tensor.shape)}, "
+                        f"meta_sharded_param.shape={tuple(meta_sharded_param.shape)}, "
+                        f"temp_param.shape={tuple(temp_param.shape)}, "
+                        f"param_cls={type(actual_param).__name__}"
+                    ) from exc
+                sharded_tensor = temp_param.data
+            else:
+                sharded_tensor = full_tensor
+
+            if cpu_offload and not is_fsdp_model:
+                sharded_tensor = sharded_tensor.cpu()
+        else:
+            full_tensor = full_tensor.to(device=device, dtype=target_dtype)
+            actual_param = _get_param_for_weight_loading(
+                model, param_dict, target_param_name
+            )
+            weight_loader = (
+                getattr(actual_param, "weight_loader", None)
+                if actual_param is not None
+                else None
+            )
+            if weight_loader is not None:
+                assert actual_param is not None
+                tp_sharded_tensor = torch.empty(
+                    tuple(actual_param.shape),
+                    device=device,
+                    dtype=target_dtype,
+                )
+                temp_param = _make_param_like(actual_param, tp_sharded_tensor)
+                if not (
+                    tp_sharded_tensor.is_floating_point()
+                    or tp_sharded_tensor.is_complex()
+                ):
+                    temp_param.requires_grad = False
+                try:
+                    weight_loader(temp_param, full_tensor)
+                except AssertionError as exc:
+                    raise AssertionError(
+                        "Failed to TP-shard/load FSDP parameter "
+                        f"{target_param_name}: full_tensor.shape={tuple(full_tensor.shape)}, "
+                        f"meta_sharded_param.shape={tuple(meta_sharded_param.shape)}, "
+                        f"temp_param.shape={tuple(temp_param.shape)}, "
+                        f"param_cls={type(actual_param).__name__}"
+                    ) from exc
+                full_tensor = temp_param.data
+            sharded_tensor = distribute_tensor(
+                full_tensor,
+                meta_sharded_param.device_mesh,
+                meta_sharded_param.placements,
+            )
+            if cpu_offload:
+                sharded_tensor = sharded_tensor.to("cpu")
+
+        sharded_sd[target_param_name] = nn.Parameter(
+            sharded_tensor, requires_grad=False
+        )
+
+    model.reverse_param_names_mapping = reverse_param_names_mapping
+
+    if non_quantized_dtype_mismatch_counts:
+        logger.debug(
+            "Casting checkpoint tensors to target dtype during load: %s",
+            _format_dtype_mismatch_summary(
+                non_quantized_dtype_mismatch_counts,
+                non_quantized_dtype_mismatch_examples,
+            ),
+            main_process_only=True,
+            local_main_process_only=True,
+        )
+
+    if quantized_dtype_mismatch_counts:
+        logger.warning(
+            "Dtype mismatches detected for quantized parameters during load: %s",
+            _format_dtype_mismatch_summary(
+                quantized_dtype_mismatch_counts,
+                quantized_dtype_mismatch_examples,
+            ),
+            main_process_only=True,
+            local_main_process_only=True,
+        )
+
+    if skipped_checkpoint_keys:
+        logger.warning(
+            "Checkpoint keys not loaded (no matching model parameter) %s",
+            (
+                skipped_checkpoint_keys[:20]
+                if len(skipped_checkpoint_keys) > 20
+                else skipped_checkpoint_keys
+            ),
+        )
+        if len(skipped_checkpoint_keys) > 20:
+            logger.warning(
+                "... and %d more skipped keys.",
+                len(skipped_checkpoint_keys) - 20,
+            )
+
+    unused_keys = set(meta_sd.keys()) - set(sharded_sd.keys())
+    if unused_keys:
+        logger.warning("Found unloaded parameters in meta state dict: %s", unused_keys)
+
+    LEGACY_ALLOWED_NEW_PARAM_PATTERNS = [
+        "gate_compress",
+        "wcscales",
+        "wtscale",
+        "input_scale",
+        "weight_scale",
+        "bias",
+        "norm_q",
+        "norm_k",
+        "weight_scale",
+    ]
+    for new_param_name in unused_keys:
+        meta_sharded_param = meta_sd.get(new_param_name)
+        meta_sharded_param_dtype = meta_sharded_param.dtype
+        actual_param = param_dict.get(new_param_name)
+        missing_param_init = _resolve_missing_param_init(new_param_name, actual_param)
+
+        if missing_param_init is None and not any(
+            pattern in new_param_name for pattern in LEGACY_ALLOWED_NEW_PARAM_PATTERNS
+        ):
+            logger.error(
+                "Unsupported new parameter: %s. Allowed legacy patterns: %s",
+                new_param_name,
+                LEGACY_ALLOWED_NEW_PARAM_PATTERNS,
+            )
+            raise ValueError(
+                f"New parameter '{new_param_name}' is not supported. "
+                "Checkpoint-specific synthesized parameters should either match "
+                f"{LEGACY_ALLOWED_NEW_PARAM_PATTERNS} or declare missing_param_init."
+            )
+
+        if missing_param_init == "ones" or any(
+            p in new_param_name
+            for p in (
+                "wcscales",
+                "wtscale",
+                "input_scale",
+                "weight_scale",
+                "norm_q",
+                "norm_k",
+            )
+        ):
+            init_like = torch.ones_like
+        elif missing_param_init == "zeros" or missing_param_init is None:
+            init_like = torch.zeros_like
+        else:
+            raise ValueError(
+                f"Unsupported missing_param_init={missing_param_init!r} for {new_param_name}"
+            )
+
+        if not hasattr(meta_sharded_param, "device_mesh"):
+            sharded_tensor = init_like(
+                meta_sharded_param, device=device, dtype=meta_sharded_param_dtype
+            )
+            if cpu_offload and not is_fsdp_model:
+                sharded_tensor = sharded_tensor.cpu()
+        else:
+            full_tensor = init_like(
+                meta_sharded_param, device=device, dtype=meta_sharded_param_dtype
+            )
+            sharded_tensor = distribute_tensor(
+                full_tensor,
+                meta_sharded_param.device_mesh,
+                meta_sharded_param.placements,
+            )
+            if cpu_offload:
+                sharded_tensor = sharded_tensor.cpu()
+        sharded_sd[new_param_name] = nn.Parameter(sharded_tensor)
+
     return model.load_state_dict(sharded_sd, strict=strict, assign=True)

--- a/python/sglang/multimodal_gen/runtime/loader/utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/utils.py
@@ -175,6 +175,45 @@ def hf_to_custom_state_dict(
     return custom_param_sd, reverse_param_names_mapping
 
 
+def iter_hf_to_custom_state_dict(
+    hf_param_sd: dict[str, torch.Tensor] | Iterator[tuple[str, torch.Tensor]],
+    param_names_mapping: Callable[[str], tuple[str, Any, Any]],
+    valid_target_names: set[str] | None = None,
+) -> Iterator[tuple[str, torch.Tensor, tuple[str, Any, Any]]]:
+    """Yield custom-formatted checkpoint tensors without building a full dict."""
+    to_merge_params = defaultdict(dict)  # type: ignore
+    if isinstance(hf_param_sd, dict):
+        hf_param_sd = hf_param_sd.items()  # type: ignore
+    for source_param_name, full_tensor in hf_param_sd:  # type: ignore
+        target_param_name, merge_index, num_params_to_merge = param_names_mapping(
+            source_param_name
+        )
+        if (
+            valid_target_names is not None
+            and target_param_name != source_param_name
+            and source_param_name in valid_target_names
+            and target_param_name not in valid_target_names
+        ):
+            target_param_name = source_param_name
+            merge_index = None
+            num_params_to_merge = None
+        if target_param_name == "" or target_param_name is None:  # type: ignore[comparison-overlap]
+            continue
+        reverse_entry = (source_param_name, merge_index, num_params_to_merge)
+        if merge_index is not None:
+            to_merge_params[target_param_name][merge_index] = full_tensor
+            if len(to_merge_params[target_param_name]) == num_params_to_merge:
+                sorted_tensors = [
+                    to_merge_params[target_param_name][i]
+                    for i in range(num_params_to_merge)
+                ]
+                full_tensor = torch.cat(sorted_tensors, dim=0)
+                del to_merge_params[target_param_name]
+            else:
+                continue
+        yield target_param_name, full_tensor, reverse_entry
+
+
 class skip_init_modules:
     def __enter__(self):
         # Save originals

--- a/python/sglang/multimodal_gen/runtime/platforms/rocm.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/rocm.py
@@ -162,17 +162,9 @@ class RocmPlatform(Platform):
             try:
                 import flash_attn  # noqa: F401
 
-                from sglang.jit_kernel.flash_attention_v3 import _is_fa3_supported
                 from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (  # noqa: F401
                     FlashAttentionBackend,
                 )
-
-                if not _is_fa3_supported():
-                    logger.info(
-                        "FlashAttention backend now dispatches through FA3 "
-                        "(CUDA-only). Using Torch SDPA backend on ROCm."
-                    )
-                    target_backend = AttentionBackendEnum.TORCH_SDPA
 
                 if target_backend == AttentionBackendEnum.FA:
                     supported_sizes = FlashAttentionBackend.get_supported_head_sizes()


### PR DESCRIPTION
## Summary
- Add streaming FSDP state-dict loading for Ulysses/SP transformer loads.
- Force Wan I2V/TI2V to use full-frame VAE encode/decode for official-compatible precision.
- Add profile_start_step sampling parameter.
- Allow ROCm FlashAttention backend selection without the FA3 support gate.
