### PR TITLE
[sgl-diffusion] Fix Wan T2V VAE decode path

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -231,6 +231,10 @@ class Wan2_2_T2V_A14B_Config(WanT2V480PConfig):
     boundary_ratio: float | None = 0.875
 
     def __post_init__(self) -> None:
+        super().__post_init__()
+        # Match the official full-frame Wan VAE decode path for SP/Ulysses runs.
+        self.vae_config.use_parallel_encode = False
+        self.vae_config.use_parallel_decode = False
         self.dit_config.boundary_ratio = self.boundary_ratio
 
 


### PR DESCRIPTION
## Motivation
Fix Wan2.2 T2V A14B output quality under Ulysses/SP by matching the official full-frame Wan VAE decode path used by the fixed I2V/TI2V configs.

## Modifications
- Call base Wan T2V __post_init__ for Wan2_2_T2V_A14B_Config.
- Disable Wan VAE parallel encode/decode for Wan2.2 T2V A14B.

## Tests
- python -m py_compile on changed file.
- git diff --check.
- Static config assertions for Wan2_2_T2V_A14B_Config.
- End-to-end Wan2.2 T2V A14B 1280x720, 77 frames, 16 fps, 20 steps, Ulysses8/FSDP generation test.
- Quality metric laplacian_avg recovered from ~25241.70 to 83.06, close to official baseline ~98.91.
- Denoise avg 9.2079s/step, decode 26.57s, max peak memory 34604 MB.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->