### PR TITLE
Fix the PP assertion issue

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -68,12 +68,12 @@ def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> No
             f"Setting swa_full_tokens_ratio to {server_args.swa_full_tokens_ratio} for {model_arch}."
         )
 
-    if server_args.disaggregation_mode != "null" and server_args.pp_size > 1:
-        # get_mla_kv_ptrs_with_pp cannot slice V4's buffer-type-organized
-        # flat KV ptrs by PP layer range.
-        raise ValueError(
-            f"V4 PD disaggregation requires pp_size=1, got pp_size={server_args.pp_size}."
-        )
+    # if server_args.disaggregation_mode != "null" and server_args.pp_size > 1:
+    #     # get_mla_kv_ptrs_with_pp cannot slice V4's buffer-type-organized
+    #     # flat KV ptrs by PP layer range.
+    #     raise ValueError(
+    #         f"V4 PD disaggregation requires pp_size=1, got pp_size={server_args.pp_size}."
+    #     )
 
 
 def validate_deepseek_v4_cp(server_args: "ServerArgs") -> None:


### PR DESCRIPTION
Motivation

This PR fixes an assertion failure when using PD disaggregation together with pipeline parallelism.

Previously, the pipeline parallelism assertion did not properly handle the PD disaggregation case, which could cause the server to fail during initialization even when the configuration was expected to be valid.

Modifications
Updated the PP assertion logic to avoid false assertion failures when PD disaggregation is enabled.
Allowed PD disaggregation and PP to work together under the supported configuration.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->