### PR TITLE
[PD]解决qwen3.5-397b在pd分离场景下的精度问题

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -607,8 +607,8 @@ class CommonKVManager(BaseKVManager):
             and len(dst_kv_ptrs) >= 2 * main_total_layers
             and (is_compact_full_attention_layout or decode_has_appended_draft_kv)
         ):
-            # Decode can append draft/MTP KV after the main model layout:
-            # [K_main..., V_main..., K_draft..., V_draft...].  Also, hybrid
+            # Decode normalizes main and draft/MTP KV as:
+            # [K_main..., K_draft..., V_main..., V_draft...].  Hybrid
             # linear-attention models store only full-attention layers in the
             # KV pool, so PP stage model-layer ids must be converted to compact
             # full-attention KV indices before slicing the decode-side pointers.
@@ -635,8 +635,8 @@ class CommonKVManager(BaseKVManager):
             if compact_end_layer <= main_total_layers:
                 dst_k_ptrs = dst_kv_ptrs[compact_start_layer:compact_end_layer]
                 dst_v_ptrs = dst_kv_ptrs[
-                    main_total_layers
-                    + compact_start_layer : main_total_layers
+                    dst_num_total_layers
+                    + compact_start_layer : dst_num_total_layers
                     + compact_end_layer
                 ]
                 layers_current_pp_stage = len(src_k_ptrs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

hy3的修改影响到397b在pd分离下的精度问题

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
修复前，397b pd分离gsm8ks数据集精度为0.0：
root@luoyao:/workspace/dcu-sglang/benchmark/gsm8k# python3 bench_sglang.py --data-path /workspace/whl/test.jsonl --port 40001 --host http://127.0.0.1
[ROCT-Thunk-Interface/src/rocmgr.c:435, WARNING]: Version mismatch
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  return self._float_to_str(self.smallest_subnormal)

100%|...| 200/200 [00:21<00:00, 9.45it/s]
Accuracy: 0.000
Invalid: 0.545
Latency: 21.164 s
Output throughput: 1054.316 token/s
修复后，397b pd分离gsm8k数据集精度为0.925：
root@luoyao:/workspace/dcu-sglang/benchmark/gsm8k# curl http://127.0.0.1:40001/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "default",
  "messages": [
    {"role": "user", "content": "成都有哪些景点？给我用中文简单介绍一下"}
  ],
  "max_tokens": 200,
  "temperature": 0,
  "stream": false
}'

{"id":"55cfc3c6d92d46eb89180619ff055a99","object":"chat.completion","created":1783610291,"model":"default","choices":[{"index":0,"message":{"role":"assistant","content":"Thinking\nThinking Process:\n\n1. **Analyze the Request:**\n    * Topic: Chengdu attractions (成都有哪些景点).\n    * Language: Chinese (中文).\n    * Style: Simple introduction (简单介绍一下).\n\n2. **Identify Key Attractions in Chengdu:**\n    * Chengdu Research Base of Giant Panda Breeding (成都大熊猫繁育研究基地) - Must include, iconic.\n    * Jinli Ancient Street (锦里古街) - Culture, food, night view.\n    * Wuhou Shrine (武侯祠) - History, Three Kingdoms.\n    * Chunxi Road / Taikoo Li (春熙路/太古里) - Shopping, modern, IFS panda.\n    * Dujiangyan (都江堰) - Nearby, historical engineering.\n    * Qingcheng Mountain (青城山) - Nearby, Taoism, nature.\n    * ","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null}],"usage":{"prompt_tokens":19,"total_tokens":219,"completion_tokens":200,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}

root@luoyao:/workspace/dcu-sglang/benchmark/gsm8k#
root@luoyao:/workspace/dcu-sglang/benchmark/gsm8k# python3 bench_sglang.py --data-path /workspace/whl/test.jsonl --port 40001 --host http://127.0.0.1
[ROCT-Thunk-Interface/src/rocmgr.c:435, WARNING]: Version mismatch
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  return self._float_to_str(self.smallest_subnormal)

100%|...| 200/200 [00:22<00:00, 8.88it/s]
Accuracy: 0.925
Invalid: 0.000
Latency: 22.537 s
Output throughput: 1523.275 token/s

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->