### PR TITLE
fix: use lightop int8 deepep moe on dcu

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -81,9 +81,10 @@ if TYPE_CHECKING:
         DispatchOutput,
     )
 
-from deepgemm import m_grouped_w4a8_gemm_nt_masked, m_grouped_w8a8_gemm_nt_masked, m_grouped_i8_gemm_nt_contiguous, \
+from deepgemm import m_grouped_w4a8_gemm_nt_masked, m_grouped_w8a8_gemm_nt_masked, \
     m_grouped_fp8_gemm_nt_masked, m_grouped_bf16_gemm_nt_masked, m_grouped_fp8_gemm_nt_contiguous, \
     m_grouped_bf16_gemm_nt_contiguous
+from lightop import m_grouped_w8a8_gemm_nt_contig_asm as m_grouped_i8_gemm_nt_contiguous
 from lightop import fuse_silu_mul_quant_ep, fuse_silu_mul_quant, fuse_silu_mul_fp8_quant_ep, fuse_silu_and_mul, \
     fuse_silu_mul_fp8_quant
 from lightop import op as lightop_op
@@ -1188,13 +1189,23 @@ class DeepEPMoE(FusedMoE):
             return hidden_states.bfloat16()
 
         M, K = hidden_states.size()
-        N = self.w13_weight.size(1)
+        w13_shape = getattr(self, "_dsv4_w13_weight_shape", None)
+        if w13_shape is not None:
+            N = w13_shape[1]
+        else:
+            N = self.w13_weight.size(1)
+        w13_weight = getattr(self, "w13_weight_deepgemm", None)
+        w2_weight = getattr(self, "w2_weight_deepgemm", None)
+        if w13_weight is None:
+            w13_weight = self.w13_weight
+        if w2_weight is None:
+            w2_weight = self.w2_weight
         w13_weight_int8 = (
-            self.w13_weight,
+            w13_weight,
             (self.w13_weight_scale),
         )
         w2_weight_int8 = (
-            self.w2_weight,
+            w2_weight,
             (self.w2_weight_scale),
         )
 
@@ -1234,8 +1245,13 @@ class DeepEPMoE(FusedMoE):
             ),
         )
 
-        gateup_output = torch.zeros(
-            (all_tokens, N * 16),
+        gateup_output_factory = (
+            torch.empty
+            if all(count % 256 == 0 for count in num_recv_tokens_per_expert)
+            else torch.zeros
+        )
+        gateup_output = gateup_output_factory(
+            (all_tokens, N),
             device=hidden_states_device,
             dtype=torch.bfloat16,
         )

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors_moe_marlin.py
@@ -276,6 +276,36 @@ class CompressedTensorsW8A8Int8MarlinMoEMethod(CompressedTensorsMarlinMoEMethod)
             weight8bit_nt_kpack2_marlin,
         )
 
+        if self.use_deepep:
+            layer._dsv4_w13_weight_shape = tuple(layer.w13_weight.shape)
+            layer._dsv4_w2_weight_shape = tuple(layer.w2_weight.shape)
+            w13_marlin_list = []
+            for ii in range(layer.w13_weight.shape[0]):
+                w13_marlin_list.append(
+                    w8a8_nt_kpack2_marlin_weight(layer.w13_weight[ii])
+                )
+            w13_lightop = torch.stack(w13_marlin_list, dim=0)
+            layer.w13_weight = Parameter(w13_lightop, requires_grad=False)
+            layer.register_buffer(
+                "w13_weight_deepgemm", layer.w13_weight.data, persistent=False
+            )
+            del w13_marlin_list, w13_lightop
+            torch.cuda.empty_cache()
+
+            w2_marlin_list = []
+            for ii in range(layer.w2_weight.shape[0]):
+                w2_marlin_list.append(
+                    w8a8_nt_kpack2_marlin_weight(layer.w2_weight[ii])
+                )
+            w2_lightop = torch.stack(w2_marlin_list, dim=0)
+            layer.w2_weight = Parameter(w2_lightop, requires_grad=False)
+            layer.register_buffer(
+                "w2_weight_deepgemm", layer.w2_weight.data, persistent=False
+            )
+            del w2_marlin_list, w2_lightop
+            torch.cuda.empty_cache()
+            return
+
         w1_marlin_list = []
         for ii in range(layer.w13_weight.shape[0]):
             if not self.use_deepep:


### PR DESCRIPTION
## Motivation

This PR fixes DeepSeek-V4 INT8 DeepEP MoE serving on DCU/gfx936.

The original contiguous INT8 MoE path failed because `m_grouped_i8_gemm_nt_contiguous` expected W6-packed weights:

`m_grouped_i8_gemm_nt_contiguous expects W6 packed weight [E,K/64,N/16,4,16,16] from pack_int8_weight_enk_to_w6_low_latency`

After switching to DeepGEMM W6 packing, the runtime still failed on this platform:

`contiguous int8 kernel requires gfx938`

The target deployment environment is gfx936, so this PR routes the contiguous INT8 DeepEP MoE path through the LightOp gfx936-compatible kernel while preserving the DeepSeek-V4 INT8 layout.

## Modifications

- Added a DCU/gfx936-compatible contiguous INT8 MoE path by aliasing LightOp's `m_grouped_w8a8_gemm_nt_contig_asm` for the DeepEP contiguous INT8 GEMM call.
- Preserved the original routed expert weight shapes before packing so the MoE forward path can infer the correct output dimension.
- Added packed DeepGEMM/LightOp weight buffers for `w13` and `w2` in the compressed-tensors MoE Marlin loader.
- Packed expert weights from `[N, K]` into the layout required by the LightOp contiguous INT8 kernel.
- Fixed the DeepEP contiguous output allocation shape to use the true hidden/output dimension instead of the packed dimension.
- Kept the changes scoped to DeepSeek-V4 INT8 compressed-tensors MoE + DeepEP serving.

## Accuracy Tests

Tested with EvalScope GSM8K on DeepSeek-V4-Flash-INT8-Channel:

- Dataset: GSM8K
- Samples: 1319
- Result: `mean_acc = 0.9568`

Smoke accuracy test:

- GSM8K small run: `8/8`

Basic generation sanity checks also passed.

## Speed Tests and Profiling

Benchmark shape tested successfully:

- Input length: 4096
- Output length: 1
- Batch sizes: 1, 2, 4, 8, 16, 32, 64
- `ignore_eos=True`

The service starts successfully with:

- `tp=8`
- `dp=8`
- `enable-dp-attention`
- `enable-dp-lm-head`
- `moe-a2a-backend=deepep`
- `quantization=slimquant_marlin`
- `context_length=200000`
- EAGLE speculative decoding enabled

Runtime logs confirm LightOp gfx936 kernels are loaded successfully.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->