### PR TITLE
feat: support AITER W4A16 MOE_C prefill

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -10,17 +10,18 @@ import functools
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import torch
-import triton
 import torch.nn.functional as F
+import triton
 import triton.language as tl
+from lightop import get_moe_cuda_marlin_config, moe_gemm_marlin_w8a8_fp8
 
 from sglang.srt.environ import envs
-from lightop import moe_gemm_marlin_w8a8_fp8, get_moe_cuda_marlin_config
 from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
 from sglang.srt.layers.moe.utils import get_moe_padding_size
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     cpu_has_amx_support,
+    direct_register_custom_op,
     get_bool_env_var,
     is_cpu,
     is_cuda,
@@ -30,7 +31,6 @@ from sglang.srt.utils import (
     use_intel_xpu_backend,
 )
 from sglang.srt.utils.custom_op import register_custom_op
-from sglang.srt.utils import direct_register_custom_op
 
 from .fused_moe_triton_config import get_config_dtype_str, try_get_optimal_moe_config
 from .fused_moe_triton_kernels import (
@@ -40,6 +40,7 @@ from .fused_moe_triton_kernels import (
     support_tensor_descriptor,
 )
 from .moe_align_block_size import moe_align_block_size
+
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.topk import StandardTopKOutput
 
@@ -64,10 +65,7 @@ elif _is_cpu and _is_cpu_amx_available:
     pass
 elif _is_hip:
     from sgl_kernel import gelu_and_mul, silu_and_mul
-    if _use_lightop:
-        from lightop import op as ops
-        from lightop import fuse_silu_and_mul, fuse_silu_mul_fp8_quant
-        from vllm.model_executor.layers.fused_moe.moe_align_block_size import moe_align_block_size as moe_align_block_size_lightop
+
     if _use_aiter:
         try:
             from aiter import moe_sum
@@ -75,15 +73,16 @@ elif _is_hip:
             raise ImportError("aiter is required when SGLANG_USE_AITER is set to True")
     if _use_aiter_moe:
         try:
-            import aiter
             from aiter.moe import (
-                get_aiter_moe_config,
-                aiter_moe,
-                MoeSolutionType,
                 MoeQuantType,
+                MoeSolutionType,
+                aiter_moe,
+                get_aiter_moe_config,
             )
         except ImportError:
-            raise ImportError("aiter is required when SGLANG_ROCM_USE_AITER_MOE is set to True")
+            raise ImportError(
+                "aiter is required when SGLANG_ROCM_USE_AITER_MOE is set to True"
+            )
     # Note: vllm_ops is not needed for HIP when _use_aiter=False
     # because the code uses moe_sum_reduce_triton as fallback (line 619)
 elif _is_xpu:
@@ -104,8 +103,11 @@ if not _is_cuda and not _is_hip and not _is_xpu:
         # Fallback: vllm not available, will use native PyTorch implementations
         _has_vllm_ops = False
 from vllm.platforms import current_platform
+
 device_name = current_platform.get_device_name().replace(" ", "_")
-num_cus= torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+num_cus = torch.cuda.get_device_properties(
+    torch.cuda.current_device()
+).multi_processor_count
 
 padding_size = get_moe_padding_size(_use_aiter)
 
@@ -119,7 +121,7 @@ def inplace_fused_experts(
     topk_ids: torch.Tensor,
     b1: Optional[torch.Tensor] = None,
     b2: Optional[torch.Tensor] = None,
-    activation: int = 0,#0 silu 1 gelu
+    activation: int = 0,  # 0 silu 1 gelu
     is_gated: bool = True,
     apply_router_weight_on_input: bool = False,
     use_fp8_w8a8: bool = False,
@@ -183,7 +185,7 @@ def inplace_fused_experts_fake(
     topk_ids: torch.Tensor,
     b1: Optional[torch.Tensor] = None,
     b2: Optional[torch.Tensor] = None,
-    activation: int = 0,#0 silu 1 gelu
+    activation: int = 0,  # 0 silu 1 gelu
     is_gated: bool = True,
     apply_router_weight_on_input: bool = False,
     use_fp8_w8a8: bool = False,
@@ -223,7 +225,7 @@ def outplace_fused_experts(
     topk_ids: torch.Tensor,
     b1: Optional[torch.Tensor] = None,
     b2: Optional[torch.Tensor] = None,
-    activation: int = 0,#0 silu 1 gelu
+    activation: int = 0,  # 0 silu 1 gelu
     is_gated: bool = True,
     apply_router_weight_on_input: bool = False,
     use_fp8_w8a8: bool = False,
@@ -288,7 +290,7 @@ def outplace_fused_experts_fake(
     topk_ids: torch.Tensor,
     b1: Optional[torch.Tensor] = None,
     b2: Optional[torch.Tensor] = None,
-    activation: int = 0,#0 silu 1 gelu
+    activation: int = 0,  # 0 silu 1 gelu
     is_gated: bool = True,
     apply_router_weight_on_input: bool = False,
     use_fp8_w8a8: bool = False,
@@ -347,11 +349,15 @@ def fused_experts(
         or moe_runner_config.num_experts != moe_runner_config.num_local_experts
     )
     act_id = (
-        0 if (
+        0
+        if (
             moe_runner_config.activation == 0
-            or (isinstance(moe_runner_config.activation, str)
-                and moe_runner_config.activation.lower() == "silu")
-        ) else 1
+            or (
+                isinstance(moe_runner_config.activation, str)
+                and moe_runner_config.activation.lower() == "silu"
+            )
+        )
+        else 1
     )
     if moe_runner_config.inplace:
         assert not moe_runner_config.no_combine, "no combine + inplace makes no sense"
@@ -538,7 +544,7 @@ def fused_experts_impl_aiter(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
     inplace: bool = False,
-    activation: int = 0,#0 silu 1 gelu
+    activation: int = 0,  # 0 silu 1 gelu
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
     w1_zp: Optional[torch.Tensor] = None,
@@ -583,14 +589,12 @@ def fused_experts_impl_aiter(
         quant_type=quant_type,
     )
     force_w4a16_moec = _should_force_aiter_w4a16_moec(quant_type)
-    status, moe_cfg = _get_aiter_moe_config_w4a16(
-        config_kwargs, force_w4a16_moec
-    )
+    status, moe_cfg = _get_aiter_moe_config_w4a16(config_kwargs, force_w4a16_moec)
     if status:
-        assert moe_cfg.solution_type is not None, \
-            "status=True but solution_type is None"
-        assert moe_cfg.config is not None, \
-            "status=True but config is None"
+        assert (
+            moe_cfg.solution_type is not None
+        ), "status=True but solution_type is None"
+        assert moe_cfg.config is not None, "status=True but config is None"
         assert moe_cfg.solution_type in (
             MoeSolutionType.MOE_C,
             MoeSolutionType.ASM,
@@ -600,25 +604,17 @@ def fused_experts_impl_aiter(
         assert moe_cfg.quant_type in (
             MoeQuantType.W4A16,
             MoeQuantType.FP8_W8A8,
-        ), \
-            f"Unexpected quant_type: {moe_cfg.quant_type}"
-        dsv4_2604_submode = getattr(envs, "SGLANG_DSV4_2604_SUBMODE", None)
-        is_2604b = (
-            dsv4_2604_submode is not None
-            and dsv4_2604_submode.get() == "2604B"
-        )
-        if is_2604b:
-            deepseek_v4_moe_code_path_checker.observed += 1
+        ), f"Unexpected quant_type: {moe_cfg.quant_type}"
         # print(
         #     f"[get_config_w4a16] M={M}, K={K}, N1={N1}, N2={N2}, E={E}, top_k={topk_ids.shape[1]}, block_size={block_shape[1]}, dtype={hidden_states.dtype} "
         #     f"solution={moe_cfg.solution_type}, "
         #     f"config keys={list(moe_cfg.config.keys())}"
         # )
     else:
-        assert moe_cfg.solution_type is None, \
-            "status=False but solution_type is not None"
-        assert moe_cfg.config is None, \
-            "status=False but config is not None"
+        assert (
+            moe_cfg.solution_type is None
+        ), "status=False but solution_type is not None"
+        assert moe_cfg.config is None, "status=False but config is not None"
         print(
             f"[get_config_aiter_moe] M={M}, K={K}, N1={N1}, N2={N2}, E={E}, top_k={topk_ids.shape[1]}, block_size={block_size}, dtype={hidden_states.dtype}, quant_type={quant_type} "
             f"no solution found (expected on unsupported configs)"
@@ -633,7 +629,28 @@ def fused_experts_impl_aiter(
         w1_scale, w2_scale = _get_aiter_w4a16_moec_shuffled_scales(
             w1_scale, w2_scale, w1, w2, moe_cfg
         )
-    return aiter_moe(hidden_states, w1, w2, topk_weights, topk_ids, moe_cfg, inplace, activation, w1_scale, w2_scale, w1_zp, w2_zp, a1_scale, a2_scale, block_shape, E, None, routed_scaling_factor, output_dtype=hidden_states.dtype)
+    return aiter_moe(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        moe_cfg,
+        inplace,
+        activation,
+        w1_scale,
+        w2_scale,
+        w1_zp,
+        w2_zp,
+        a1_scale,
+        a2_scale,
+        block_shape,
+        E,
+        None,
+        routed_scaling_factor,
+        output_dtype=hidden_states.dtype,
+    )
+
 
 def _prepare_fused_moe_run(
     hidden_states: torch.Tensor,
@@ -1093,7 +1110,7 @@ def fused_experts_impl(
     b1: Optional[torch.Tensor] = None,
     b2: Optional[torch.Tensor] = None,
     inplace: bool = False,
-    activation: int = 0,#0 silu 1 gelu
+    activation: int = 0,  # 0 silu 1 gelu
     is_gated: bool = True,
     apply_router_weight_on_input: bool = False,
     use_fp8_w8a8: bool = False,
@@ -1115,14 +1132,34 @@ def fused_experts_impl(
     filter_expert: bool = True,
     swiglu_limit: Optional[float] = None,
 ):
-    if _use_aiter_moe and (use_int4_w4a16 or use_int8_w8a8 or use_fp8_w8a8) and hidden_states.dtype == torch.bfloat16:
+    if (
+        _use_aiter_moe
+        and (use_int4_w4a16 or use_int8_w8a8 or use_fp8_w8a8)
+        and hidden_states.dtype == torch.bfloat16
+    ):
         if use_int4_w4a16:
             quant_type = MoeQuantType.W4A16
         else:
             quant_type = MoeQuantType.FP8_W8A8
-        return fused_experts_impl_aiter(hidden_states, w1, w2, topk_weights, topk_ids, inplace, activation, w1_scale, w2_scale, w1_zp, w2_zp, a1_scale, a2_scale, block_shape, routed_scaling_factor, quant_type)
+        return fused_experts_impl_aiter(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            inplace,
+            activation,
+            w1_scale,
+            w2_scale,
+            w1_zp,
+            w2_zp,
+            a1_scale,
+            a2_scale,
+            block_shape,
+            routed_scaling_factor,
+            quant_type,
+        )
 
-    from sglang.srt.layers.moe.fused_moe_triton.moe_align_block_size import dcu_moe_align_block_size
     if isinstance(activation, int):
         activation = "silu" if activation == 0 else "gelu"
     padded_size = padding_size
@@ -1200,322 +1237,6 @@ def fused_experts_impl(
         hooks=None,
         swiglu_limit=swiglu_limit,
     )
-    topk = topk_ids.shape[1]
-    max_padded_tokens = (
-        min(M * topk, E + 1) * (max_block_m - 1) if down_moe_use_tma else 0
-    )
-    total_tokens = M * topk + max_padded_tokens
-    cache = torch.empty(
-        total_tokens * max(N, w2.shape[1]),
-        device=hidden_states.device,
-        dtype=hidden_states.dtype,
-    )
-    intermediate_cache3 = cache[: M * topk * w2.shape[1]].view(
-        (M, topk, w2.shape[1]),
-    )
-
-    compute_type = tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16
-
-    if no_combine:
-        assert not inplace
-        out_hidden_states = torch.empty(
-            (num_tokens, topk, w2.shape[1]),
-            device=hidden_states.device,
-            dtype=hidden_states.dtype,
-        )
-    elif inplace:
-        out_hidden_states = hidden_states
-    else:
-        out_hidden_states = torch.empty_like(hidden_states)
-
-    for chunk in range((num_tokens // CHUNK_SIZE) + 1):
-        begin_chunk_idx, end_chunk_idx = (
-            chunk * CHUNK_SIZE,
-            min((chunk + 1) * CHUNK_SIZE, num_tokens),
-        )
-        curr_hidden_states = hidden_states[begin_chunk_idx:end_chunk_idx]
-        tokens_in_chunk, _ = curr_hidden_states.shape
-
-        if tokens_in_chunk == 0:
-            break
-
-        if tokens_in_chunk < CHUNK_SIZE and chunk > 0:
-            # Adjust the intermediate cache size and config for the last
-            # chunk. Note that in most cases we only have one chunk
-            # so the cache size and config are already set correctly and
-            # do not need to be adjusted.
-            config, (down_config, _) = get_config_func(tokens_in_chunk)
-            down_moe_use_tma = (
-                _down_moe_use_tma()
-                and down_config is not None
-                and down_config.pop("USE_TMA", False)
-            )
-            intermediate_cache3 = intermediate_cache3[:tokens_in_chunk]
-
-        padded_tokens = (
-            min(tokens_in_chunk * topk, E + 1) * (config["BLOCK_SIZE_M"] - 1)
-            if down_moe_use_tma
-            else 0
-        )
-        total_tokens = tokens_in_chunk * topk + padded_tokens
-        intermediate_cache1 = cache[: total_tokens * N].view(
-            (total_tokens, N),
-        )
-        intermediate_cache2 = torch.empty(
-            (total_tokens, N // 2),
-            device=hidden_states.device,
-            dtype=hidden_states.dtype,
-        )
-
-        curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
-        curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
-
-        # use_fused_moe_sum_all_reduce = (
-        #     get_global_server_args().enable_fused_moe_sum_all_reduce
-        #     and (not no_combine)
-        #     and (curr_topk_ids.shape[1] > 2)
-        #     and (not use_int8_w8a16)
-        #     and (not use_int4_w4a16)
-        # )
-        if _use_lightop:
-            sorted_token_ids, expert_ids, num_tokens_post_padded = dcu_moe_align_block_size(
-                curr_topk_ids, config["BLOCK_SIZE_M"], E
-            )
-        else:
-            sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-                curr_topk_ids, config["BLOCK_SIZE_M"], E
-            )
-
-        invoke_fused_moe_kernel(
-            curr_hidden_states,
-            w1,
-            b1,
-            intermediate_cache1,
-            a1_scale,
-            w1_scale,
-            w1_zp,
-            curr_topk_weights,
-            curr_topk_ids,
-            sorted_token_ids,
-            expert_ids,
-            num_tokens_post_padded,
-            apply_router_weight_on_input,
-            topk_ids.shape[1],
-            config,
-            compute_type=compute_type,
-            use_fp8_w8a8=use_fp8_w8a8,
-            use_int8_w8a8=use_int8_w8a8,
-            use_int8_w8a16=use_int8_w8a16,
-            use_int4_w4a16=use_int4_w4a16,
-            per_channel_quant=per_channel_quant,
-            block_shape=block_shape,
-            c_sorted=down_moe_use_tma,
-            filter_expert=filter_expert,
-        )
-
-        # Activation function with multiplication
-        # print(f"activation: {activation} is_gated: {is_gated} gemm1_alpha: {gemm1_alpha} gemm1_limit: {gemm1_limit} filter_expert: {filter_expert} swiglu_limit: {swiglu_limit} _is_cuda or _is_hip or _is_xpu: {_is_cuda or _is_hip or _is_xpu}")
-        if activation == "silu" and is_gated:
-            # - gemm1_alpha != None: GPT-OSS-style swiglu(alpha, limit)
-            # - gemm1_alpha == None and gemm1_limit != None: silu+clamp+mul(limit-only)
-            if gemm1_alpha is not None:
-                assert gemm1_limit is not None
-                intermediate_cache2 = _swiglu_gpt_oss_sigmoid_alpha(
-                    intermediate_cache1.view(-1, N), gemm1_alpha, gemm1_limit
-                )
-            elif gemm1_limit is not None:
-                intermediate_cache2 = _swiglu_silu_clamp_mul(
-                    intermediate_cache1.view(-1, N), gemm1_limit
-                )
-            # elif _use_lightop:
-            elif False: #暂时关闭，开启后性能会很差
-                fuse_silu_and_mul(intermediate_cache1.view(-1, N), intermediate_cache2)
-            # elif _is_cuda or _is_hip or _is_xpu:
-            #     if not filter_expert:
-            #         silu_and_mul(intermediate_cache1.view(-1, N), intermediate_cache2)
-            #     else:
-            #         act_and_mul_triton(
-            #             intermediate_cache1.view(-1, N),
-            #             intermediate_cache2,
-            #             config,
-            #             curr_topk_ids,
-            #             expert_ids,
-            #             down_moe_use_tma,
-            #             activation,
-            #             swiglu_limit,
-            #         )
-            else:
-                if _has_vllm_ops:
-                    vllm_ops.silu_and_mul(
-                        intermediate_cache2, intermediate_cache1.view(-1, N)
-                    )
-                else:
-                    # Fallback: native PyTorch silu_and_mul
-                    x = intermediate_cache1.view(-1, N)
-                    d = x.shape[-1] // 2
-                    intermediate_cache2.copy_(F.silu(x[..., :d]) * x[..., d:])
-        elif activation == "gelu" and is_gated:
-            assert gemm1_alpha is None, "gemm1_alpha is not supported for gelu"
-            assert gemm1_limit is None, "gemm1_limit is not supported for gelu"
-            if _is_cuda or _is_hip:
-                if not filter_expert:
-                    gelu_and_mul(intermediate_cache1.view(-1, N), intermediate_cache2)
-                else:
-                    act_and_mul_triton(
-                        intermediate_cache1.view(-1, N),
-                        intermediate_cache2,
-                        config,
-                        curr_topk_ids,
-                        expert_ids,
-                        down_moe_use_tma,
-                        activation,
-                    )
-            else:
-                if _has_vllm_ops:
-                    vllm_ops.gelu_and_mul(
-                        intermediate_cache2, intermediate_cache1.view(-1, N)
-                    )
-                else:
-                    # Fallback: native PyTorch gelu_and_mul
-                    x = intermediate_cache1.view(-1, N)
-                    d = x.shape[-1] // 2
-                    intermediate_cache2.copy_(F.gelu(x[..., :d]) * x[..., d:])
-        # Activation function without multiplication
-        elif activation == "silu" and not is_gated:
-            intermediate_cache2 = F.silu(intermediate_cache1.view(-1, N))
-        elif activation == "gelu" and not is_gated:
-            intermediate_cache2 = F.gelu(intermediate_cache1.view(-1, N))
-        elif activation == "relu2" and not is_gated:
-            intermediate_cache2 = torch.square(F.relu(intermediate_cache1.view(-1, N)))
-        else:
-            raise ValueError(f"Unsupported activation: {activation=}, with {is_gated=}")
-
-        out_slice = None
-        if use_fused_moe_sum_all_reduce:
-            out_slice = out_hidden_states[begin_chunk_idx:end_chunk_idx]
-            out_slice.zero_()
-
-        invoke_fused_moe_kernel(
-            intermediate_cache2,
-            w2,
-            b2,
-            (
-                out_slice
-                if use_fused_moe_sum_all_reduce
-                else (
-                    intermediate_cache3
-                    if not no_combine and topk_ids.shape[1] != 1
-                    else out_hidden_states[begin_chunk_idx:end_chunk_idx].unsqueeze(0)
-                )
-            ),
-            a2_scale,
-            w2_scale,
-            w2_zp,
-            curr_topk_weights,
-            curr_topk_ids,
-            sorted_token_ids,
-            expert_ids,
-            num_tokens_post_padded,
-            not apply_router_weight_on_input,
-            1,
-            down_config or config,
-            compute_type=compute_type,
-            use_fp8_w8a8=use_fp8_w8a8,
-            use_int8_w8a8=use_int8_w8a8,
-            use_int8_w8a16=use_int8_w8a16,
-            use_int4_w4a16=use_int4_w4a16,
-            per_channel_quant=per_channel_quant,
-            block_shape=block_shape,
-            a_use_tma=down_moe_use_tma,
-            b_use_tma=down_moe_use_tma,
-            filter_expert=filter_expert,
-            fuse_sum_all_reduce=use_fused_moe_sum_all_reduce,
-            router_topk=curr_topk_ids.shape[1],
-        )
-
-        if routed_scaling_factor is None:
-            routed_scaling_factor = 1.0
-
-        if no_combine:
-            pass
-        elif _is_cuda:
-            if use_fused_moe_sum_all_reduce:
-                if routed_scaling_factor is None:
-                    routed_scaling_factor = 1.0
-                if routed_scaling_factor != 1.0:
-                    assert out_slice is not None
-                    out_slice.mul_(routed_scaling_factor)
-            elif topk_ids.shape[1] == 1 and routed_scaling_factor == 1.0:
-                pass  # we write directly into out_hidden_states
-            elif topk_ids.shape[1] == 2 and routed_scaling_factor == 1.0:
-                torch.add(
-                    intermediate_cache3[:, 0],
-                    intermediate_cache3[:, 1],
-                    out=out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                ).squeeze(dim=1)
-            else:
-                # According to micro benchmark results, torch.compile can get better performance for small token.
-                if tokens_in_chunk <= 32:
-                    moe_sum_reduce_torch_compile(
-                        intermediate_cache3.view(*intermediate_cache3.shape),
-                        out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                        routed_scaling_factor,
-                    )
-                else:
-                    moe_sum_reduce(
-                        intermediate_cache3.view(*intermediate_cache3.shape),
-                        out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                        routed_scaling_factor,
-                    )
-
-        elif _is_hip:
-            if _use_aiter:
-                moe_sum(
-                    intermediate_cache3.view(*intermediate_cache3.shape),
-                    out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                )
-            else:
-                # According to micro benchmark results, torch.compile can get better performance for small token.
-                if _use_lightop:
-                        ops.moe_sum(
-                        intermediate_cache3.view(*intermediate_cache3.shape),
-                        out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                        factor=routed_scaling_factor,
-                        expect_m=-1,
-                    )
-                elif tokens_in_chunk <= 32:
-                    moe_sum_reduce_torch_compile(
-                        intermediate_cache3.view(*intermediate_cache3.shape),
-                        out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                        routed_scaling_factor,
-                    )
-                else:
-                    moe_sum_reduce_triton(
-                        intermediate_cache3.view(*intermediate_cache3.shape),
-                        out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                        routed_scaling_factor,
-                    )
-        elif _is_xpu:
-            moe_sum_reduce(
-                intermediate_cache3.view(*intermediate_cache3.shape),
-                out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                routed_scaling_factor,
-            )
-        else:
-            if _has_vllm_ops:
-                vllm_ops.moe_sum(
-                    intermediate_cache3.view(*intermediate_cache3.shape),
-                    out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                )
-            else:
-                # Fallback: use triton moe_sum_reduce when vllm is not available
-                moe_sum_reduce_triton(
-                    intermediate_cache3.view(*intermediate_cache3.shape),
-                    out_hidden_states[begin_chunk_idx:end_chunk_idx],
-                    routed_scaling_factor,
-                )
-
-    return out_hidden_states
 
 
 def fused_moe(
@@ -1622,6 +1343,7 @@ def fused_moe(
         block_shape=block_shape,
     )
 
+
 @triton.jit
 def _per_token_quant_fp8(
     x_ptr,
@@ -1632,15 +1354,14 @@ def _per_token_quant_fp8(
     N,
     BLOCK: tl.constexpr,
     fp8_min,
-    fp8_max
+    fp8_max,
 ):
     row_id = tl.program_id(0)
 
     cols = tl.arange(0, BLOCK)
     mask = cols < N
 
-    x = tl.load(x_ptr + row_id * stride_x + cols, mask=mask,
-                other=0.0).to(tl.float32)
+    x = tl.load(x_ptr + row_id * stride_x + cols, mask=mask, other=0.0).to(tl.float32)
     absmax = tl.maximum(tl.max(tl.abs(x)), 1e-10)
     scale_x = absmax / fp8_max
     x_q = tl.clamp(x / scale_x, min=fp8_min, max=fp8_max).to(xq_ptr.dtype.element_ty)
@@ -1652,17 +1373,15 @@ def per_token_quant_fp8(x):
     M = x.numel() // x.shape[-1]
     N = x.shape[-1]
     x_q = torch.empty_like(x, device=x.device, dtype=torch.float8_e4m3fn)
-    scales = torch.empty(x.shape[:-1] + (1, ),
-                         device=x.device,
-                         dtype=torch.float32)
+    scales = torch.empty(x.shape[:-1] + (1,), device=x.device, dtype=torch.float32)
     BLOCK = triton.next_power_of_2(N)
     # heuristics for number of warps
     num_warps = min(max(BLOCK // 256, 1), 8)
     finfo = torch.finfo(x_q.dtype)
     fp8_min = finfo.min
     fp8_max = finfo.max
-    #assert x.is_contiguous()
-    _per_token_quant_fp8[(M, )](
+    # assert x.is_contiguous()
+    _per_token_quant_fp8[(M,)](
         x,
         x_q,
         scales,
@@ -1673,9 +1392,10 @@ def per_token_quant_fp8(x):
         num_warps=num_warps,
         num_stages=1,
         fp8_min=fp8_min,
-        fp8_max=fp8_max
+        fp8_max=fp8_max,
     )
     return x_q, scales
+
 
 def fused_moe_fp8_w8a8(
     hidden_states: torch.Tensor,
@@ -1729,13 +1449,18 @@ def fused_moe_fp8_w8a8(
     - torch.Tensor: The output tensor after applying the MoE layer.
     """
     # from sglang.srt.layers.moe.fused_moe_triton.moe_align_block_size import dcu_moe_align_block_size
-    from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import dcu_moe_align_block_size
+    from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+        dcu_moe_align_block_size,
+    )
 
     assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
     assert w1.is_contiguous(), "Expert weights1 must be contiguous"
     assert w2.is_contiguous(), "Expert weights2 must be contiguous"
     # assert hidden_states.dtype in [torch.float16, torch.bfloat16]
-    if hidden_states_fp8_input is not None and hidden_states_scale_fp8_input is not None:
+    if (
+        hidden_states_fp8_input is not None
+        and hidden_states_scale_fp8_input is not None
+    ):
         hidden_states_fp8 = hidden_states_fp8_input
         hidden_states_scale_fp8 = hidden_states_scale_fp8_input
         if hidden_states_scale_fp8.dim() == hidden_states_fp8.dim() - 1:
@@ -1771,7 +1496,8 @@ def fused_moe_fp8_w8a8(
             global_num_experts = E
 
         sorted_token_ids, expert_ids, num_tokens_post_padded = dcu_moe_align_block_size(
-            topk_ids, block_size_m, global_num_experts)
+            topk_ids, block_size_m, global_num_experts
+        )
 
         # TODO: tune this further for specific models
         # intermediate_cache2 = torch.empty(
@@ -1784,9 +1510,9 @@ def fused_moe_fp8_w8a8(
             device=hidden_states.device,
             dtype=hidden_states.dtype,
         )
-        intermediate_cache1 = intermediate_cache13[:m * topk_ids.shape[1] * n1]
+        intermediate_cache1 = intermediate_cache13[: m * topk_ids.shape[1] * n1]
         intermediate_cache1 = intermediate_cache1.view(-1, n1)
-        intermediate_cache3 = intermediate_cache13[:m * topk_ids.shape[1] * k]
+        intermediate_cache3 = intermediate_cache13[: m * topk_ids.shape[1] * k]
         intermediate_cache3 = intermediate_cache3.view(-1, k)
 
         intermediate_cache1 = moe_gemm_marlin_w8a8_fp8(
@@ -1804,7 +1530,9 @@ def fused_moe_fp8_w8a8(
         )
         from lightop import fuse_silu_mul_fp8_quant
 
-        fp8_cache2, fp8_cache2_scale = fuse_silu_mul_fp8_quant(intermediate_cache1, fp8type=0)
+        fp8_cache2, fp8_cache2_scale = fuse_silu_mul_fp8_quant(
+            intermediate_cache1, fp8type=0
+        )
 
         intermediate_cache3 = moe_gemm_marlin_w8a8_fp8(
             fp8_cache2,
@@ -1823,7 +1551,7 @@ def fused_moe_fp8_w8a8(
 
         if routed_scaling_factor is None:
             routed_scaling_factor = 1.0
-        from lightop import op as ops # 报错缺少ops
+        from lightop import op as ops  # 报错缺少ops
 
         ops.moe_sum(
             intermediate_cache3,
@@ -1836,4 +1564,6 @@ def fused_moe_fp8_w8a8(
         )
         return output
     else:
-        raise RuntimeError("No MoE implementation available. Please set: export SGLANG_ROCM_USE_AITER_MOE=true and export SGLANG_USE_FP8_W8A8_MOE=0")
+        raise RuntimeError(
+            "No MoE implementation available. Please set: export SGLANG_ROCM_USE_AITER_MOE=true and export SGLANG_USE_FP8_W8A8_MOE=0"
+        )

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -53,6 +53,7 @@ _use_sgl_xpu = use_intel_xpu_backend()
 _is_musa = is_musa()
 _use_lightop = get_bool_env_var("SGLANG_USE_LIGHTOP")
 _use_aiter_moe = get_bool_env_var("SGLANG_ROCM_USE_AITER_MOE", default="true")
+_aiter_w4a16_moec_inplace_scale_keys: set[Any] = set()
 
 
 if _is_cuda:
@@ -451,6 +452,85 @@ def _shape_str(tensor: Optional[torch.Tensor]) -> str:
     return "None" if tensor is None else str(tuple(tensor.shape))
 
 
+def _should_force_aiter_w4a16_moec(quant_type: Optional["MoeQuantType"]) -> bool:
+    if quant_type != MoeQuantType.W4A16:
+        return False
+
+    try:
+        return get_global_server_args().disaggregation_mode == "prefill"
+    except Exception:
+        return False
+
+
+def _aiter_moec_solution_type(moe_cfg: Any) -> bool:
+    solution_type = getattr(moe_cfg, "solution_type", None)
+    if solution_type == MoeSolutionType.MOE_C:
+        return True
+    solution_type_str = str(solution_type).lower()
+    return solution_type_str in ("moe_c", "moec", "moesolutiontype.moe_c")
+
+
+def _get_aiter_moe_config_w4a16(config_kwargs: Dict[str, Any], force_moec: bool):
+    if not force_moec:
+        return get_aiter_moe_config(**config_kwargs)
+
+    try:
+        status, moe_cfg = get_aiter_moe_config(
+            **config_kwargs, spec_sol_type=MoeSolutionType.MOE_C
+        )
+    except TypeError as err:
+        raise RuntimeError(
+            "AITER W4A16 prefill requires MOE_C, but the installed "
+            "aiter get_aiter_moe_config does not support spec_sol_type."
+        ) from err
+
+    if status and _aiter_moec_solution_type(moe_cfg):
+        return status, moe_cfg
+
+    raise RuntimeError(
+        "AITER W4A16 prefill requires MOE_C, but "
+        f"get_aiter_moe_config returned status={status}, "
+        f"selected={getattr(moe_cfg, 'solution_type', None)}, "
+        f"config_kwargs={config_kwargs}."
+    )
+
+
+def _get_aiter_w4a16_moec_shuffled_scales(
+    w1_scale: Optional[torch.Tensor],
+    w2_scale: Optional[torch.Tensor],
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    moe_cfg: Any,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if w1_scale is None or w2_scale is None:
+        raise RuntimeError("AITER W4A16 MOE_C requires w1_scale and w2_scale.")
+
+    inplace_key = (
+        w1_scale.data_ptr(),
+        w2_scale.data_ptr(),
+        tuple(w1_scale.shape),
+        tuple(w2_scale.shape),
+        w1_scale.dtype,
+        w2_scale.dtype,
+        w1_scale.device,
+        w2_scale.device,
+    )
+    if inplace_key in _aiter_w4a16_moec_inplace_scale_keys:
+        return w1_scale, w2_scale
+
+    from aiter.moe import aiter_moe_shfl_scale
+
+    try:
+        shuffled_scales = aiter_moe_shfl_scale(w1_scale, w2_scale, moe_cfg, w1, w2)
+    except TypeError:
+        shuffled_scales = aiter_moe_shfl_scale(w1_scale, w2_scale, moe_cfg)
+    with torch.no_grad():
+        w1_scale.copy_(shuffled_scales[0])
+        w2_scale.copy_(shuffled_scales[1])
+    _aiter_w4a16_moec_inplace_scale_keys.add(inplace_key)
+    return w1_scale, w2_scale
+
+
 def fused_experts_impl_aiter(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -472,6 +552,8 @@ def fused_experts_impl_aiter(
     M, K = hidden_states.shape
     E, N1, _ = w1.shape
     _, N2, _ = w2.shape
+    if isinstance(activation, int):
+        activation = "silu" if activation == 0 else "gelu"
     is_channelwise_w8a8 = quant_type == MoeQuantType.FP8_W8A8 and block_shape is None
     if not is_channelwise_w8a8 and (block_shape is None or len(block_shape) < 2):
         raise ValueError(
@@ -489,8 +571,20 @@ def fused_experts_impl_aiter(
             f"a2_scale_shape={_shape_str(a2_scale)}"
         )
     block_size = 0 if is_channelwise_w8a8 else block_shape[1]
-    status, moe_cfg = get_aiter_moe_config(
-        M=M, E=E, N1=N1, N2=N2, K=K, top_k=topk_ids.shape[1], block_size=block_size, dtype=hidden_states.dtype, quant_type=quant_type,
+    config_kwargs = dict(
+        M=M,
+        E=E,
+        N1=N1,
+        N2=N2,
+        K=K,
+        top_k=topk_ids.shape[1],
+        block_size=block_size,
+        dtype=hidden_states.dtype,
+        quant_type=quant_type,
+    )
+    force_w4a16_moec = _should_force_aiter_w4a16_moec(quant_type)
+    status, moe_cfg = _get_aiter_moe_config_w4a16(
+        config_kwargs, force_w4a16_moec
     )
     if status:
         assert moe_cfg.solution_type is not None, \
@@ -530,6 +624,15 @@ def fused_experts_impl_aiter(
             f"no solution found (expected on unsupported configs)"
         )
 
+    if (
+        quant_type == MoeQuantType.W4A16
+        and status
+        and _aiter_moec_solution_type(moe_cfg)
+        and getattr(moe_cfg, "need_shuffle_scale", False)
+    ):
+        w1_scale, w2_scale = _get_aiter_w4a16_moec_shuffled_scales(
+            w1_scale, w2_scale, w1, w2, moe_cfg
+        )
     return aiter_moe(hidden_states, w1, w2, topk_weights, topk_ids, moe_cfg, inplace, activation, w1_scale, w2_scale, w1_zp, w2_zp, a1_scale, a2_scale, block_shape, E, None, routed_scaling_factor, output_dtype=hidden_states.dtype)
 
 def _prepare_fused_moe_run(


### PR DESCRIPTION
## Summary

- Force AITER W4A16 prefill to select the MOE_C solution.
- Shuffle W4A16 scales in place once when the selected MOE_C config requires it.
- Normalize integer activation values before invoking AITER MoE.

## Validation

- `python -m py_compile python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py`
- `git diff --check`
- DCU/ROCm+AITER hardware validation was not run locally.

## Suggested runtime coverage

- W4A16 prefill on first and repeated requests across different token counts.
- Disaggregated prefill and decode paths.
- Numerical comparison against a reference implementation.

## Merge cleanup

- [ ] Delete the use_moe_w4a16 source branch after this PR is merged (repository-wide automatic deletion is currently disabled).



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->