### PR TITLE
[feat][mimo pro] allow atten tp size to be 1 when enable MTP

### DIFF
--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -80,15 +80,19 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
+    get_bool_env_var,
+    is_dcu,
     is_non_idle_and_non_empty,
     make_layers,
-    is_dcu,
-    get_bool_env_var
 )
+
 _is_dcu = is_dcu()
 if _is_dcu:
     from lightop import mimo_v2_split_rope_vscale_kv_store
-    _use_lightop_rotary_embedding_fuse=get_bool_env_var("SGLANG_USE_FUSED_RMSNORM_ROPE")
+
+    _use_lightop_rotary_embedding_fuse = get_bool_env_var(
+        "SGLANG_USE_FUSED_RMSNORM_ROPE"
+    )
 
 MiMoV2Config = None
 
@@ -125,6 +129,56 @@ def load_mimo_v2_qkv_proj_weight(
         )
 
     default_weight_loader(param, loaded_weight.chunk(tp_size, dim=0)[tp_rank])
+
+
+def load_mimo_v2_qkv_proj_weight_v2(
+    name: str,
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    expected_fused_tp_size: Optional[int],
+    config: MiMoV2Config,
+):
+    attn_tp_size = get_attention_tp_size()
+
+    if attn_tp_size == 1 and expected_fused_tp_size is not None:
+        fused_tp = expected_fused_tp_size
+        layer_id = get_layer_id(name)
+        is_swa = (
+            layer_id is not None
+            and hasattr(config, "hybrid_layer_pattern")
+            and config.hybrid_layer_pattern[layer_id] == 1
+        )
+        # MTP layer always uses SWA
+        is_mtp = "mtp_block" in name or "mtp.layers" in name
+        if is_swa or is_mtp:
+            total_q = config.swa_num_attention_heads * config.swa_head_dim
+            total_k = config.swa_num_key_value_heads * config.swa_head_dim
+            total_v = config.swa_num_key_value_heads * getattr(
+                config, "swa_v_head_dim", config.swa_head_dim
+            )
+        else:
+            total_q = config.num_attention_heads * config.head_dim
+            total_k = config.num_key_value_heads * config.head_dim
+            total_v = config.num_key_value_heads * getattr(
+                config, "v_head_dim", config.head_dim
+            )
+        per_rank_q = total_q // fused_tp
+        per_rank_k = total_k // fused_tp
+        per_rank_v = total_v // fused_tp
+        per_rank_total = per_rank_q + per_rank_k + per_rank_v
+
+        chunks = loaded_weight.split([per_rank_total] * fused_tp, dim=0)
+        q_parts = [ch[:per_rank_q] for ch in chunks]
+        k_parts = [ch[per_rank_q : per_rank_q + per_rank_k] for ch in chunks]
+        v_parts = [
+            ch[per_rank_q + per_rank_k : per_rank_q + per_rank_k + per_rank_v]
+            for ch in chunks
+        ]
+
+        reordered = torch.cat(q_parts + k_parts + v_parts, dim=0)
+        default_weight_loader(param, reordered)
+    else:
+        load_mimo_v2_qkv_proj_weight(name, param, loaded_weight, expected_fused_tp_size)
 
 
 class MiMoV2MLP(nn.Module):
@@ -556,7 +610,7 @@ class MiMoV2Attention(nn.Module):
             self.kv_cache_dtype = torch.bfloat16
         self.page_size = get_global_server_args().page_size
         self.layer_id = layer_id
-        
+
     def _get_lightop_mha_kv_args(self, forward_batch: ForwardBatch):
         pool = forward_batch.token_to_kv_pool
         loc = forward_batch.out_cache_loc
@@ -573,7 +627,7 @@ class MiMoV2Attention(nn.Module):
             else:
                 k_buffer, v_buffer = pool.full_kv_pool.get_kv_buffer(layer_id_pool)
         else:
-            logger.error('mimo v2 kv pool is not healthy: missing layers_mapping')
+            logger.error("mimo v2 kv pool is not healthy: missing layers_mapping")
             return None
         return k_buffer, v_buffer, loc
 
@@ -625,7 +679,7 @@ class MiMoV2Attention(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        
+
         if _is_dcu and _use_lightop_rotary_embedding_fuse:
             kv_args = self._get_lightop_mha_kv_args(forward_batch)
             if kv_args is None:
@@ -639,7 +693,7 @@ class MiMoV2Attention(nn.Module):
                 )
                 self.rotary_emb.cos_sin_cache = cos_sin_cache
 
-            q, k, v =  mimo_v2_split_rope_vscale_kv_store(
+            q, k, v = mimo_v2_split_rope_vscale_kv_store(
                 positions,
                 qkv,
                 self.q_size,
@@ -1384,64 +1438,9 @@ class MiMoV2ForCausalLM(nn.Module):
                     expected_fused_tp_size = get_mimo_v2_fused_qkv_expected_tp_size(
                         self.config
                     )
-                    attn_tp_size = get_attention_tp_size()
-
-                    if attn_tp_size == 1 and expected_fused_tp_size is not None:
-                        fused_tp = expected_fused_tp_size
-                        layer_id = get_layer_id(name)
-                        is_swa = (
-                            layer_id is not None
-                            and hasattr(self.config, "hybrid_layer_pattern")
-                            and self.config.hybrid_layer_pattern[layer_id] == 1
-                        )
-                        if is_swa and hasattr(self.config, "swa_num_attention_heads"):
-                            total_q = (
-                                self.config.swa_num_attention_heads
-                                * self.config.swa_head_dim
-                            )
-                            total_k = (
-                                self.config.swa_num_key_value_heads
-                                * self.config.swa_head_dim
-                            )
-                            total_v = self.config.swa_num_key_value_heads * getattr(
-                                self.config, "swa_v_head_dim", self.config.swa_head_dim
-                            )
-                        else:
-                            total_q = (
-                                self.config.num_attention_heads * self.config.head_dim
-                            )
-                            total_k = (
-                                self.config.num_key_value_heads * self.config.head_dim
-                            )
-                            total_v = self.config.num_key_value_heads * getattr(
-                                self.config, "v_head_dim", self.config.head_dim
-                            )
-                        per_rank_q = total_q // fused_tp
-                        per_rank_k = total_k // fused_tp
-                        per_rank_v = total_v // fused_tp
-                        per_rank_total = per_rank_q + per_rank_k + per_rank_v
-
-                        chunks = loaded_weight.split([per_rank_total] * fused_tp, dim=0)
-                        q_parts = [ch[:per_rank_q] for ch in chunks]
-                        k_parts = [
-                            ch[per_rank_q : per_rank_q + per_rank_k] for ch in chunks
-                        ]
-                        v_parts = [
-                            ch[
-                                per_rank_q
-                                + per_rank_k : per_rank_q
-                                + per_rank_k
-                                + per_rank_v
-                            ]
-                            for ch in chunks
-                        ]
-
-                        reordered = torch.cat(q_parts + k_parts + v_parts, dim=0)
-                        default_weight_loader(param, reordered)
-                    else:
-                        load_mimo_v2_qkv_proj_weight(
-                            name, param, loaded_weight, expected_fused_tp_size
-                        )
+                    load_mimo_v2_qkv_proj_weight_v2(
+                        name, param, loaded_weight, expected_fused_tp_size, self.config
+                    )
                 continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/python/sglang/srt/models/mimo_v2_nextn.py
+++ b/python/sglang/srt/models/mimo_v2_nextn.py
@@ -44,7 +44,7 @@ from sglang.srt.models.mimo_v2 import (
     MiMoV2Attention,
     MiMoV2ForCausalLM,
     MiMoV2MLP,
-    load_mimo_v2_qkv_proj_weight,
+    load_mimo_v2_qkv_proj_weight_v2,
 )
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix
@@ -306,13 +306,14 @@ class MiMoV2MTP(MiMoV2ForCausalLM):
             if "qkv_proj" in name:
                 if name in params_dict:
                     param = params_dict[name]
-                    load_mimo_v2_qkv_proj_weight(
+                    load_mimo_v2_qkv_proj_weight_v2(
                         name,
                         param,
                         loaded_weight,
                         expected_fused_tp_size=get_mimo_v2_fused_qkv_expected_tp_size(
                             self.config
                         ),
+                        config=self.config,
                     )
                 continue
 


### PR DESCRIPTION

## Motivation

**Background from #78** : When `attn_tp_size == 1`, the attention layer does not perform tensor-parallel splitting, but the fused QKV projection weights from the checkpoint are still stored in a TP-interleaved layout. This causes a mismatch in the weight loader, which previously required `effective_attn_tp_size` to match `expected_attn_tp_size`. This commit allows `attn_tp_size == 1` by reordering and loading the fused QKV weights in full without TP splitting.

**New changes in this PR**: Additionally, when enable MTP with `--speculative-algorithm EAGLE`, the `MiMoV2MTP` (Multi-Token Prediction) model was not handled by the `load_mimo_v2_qkv_proj_weight_v2` function. The MTP layers always use SWA (Sliding Window Attention) attention heads, and their fused QKV weights need the same reordering logic. The `get_layer_id` utility cannot extract a layer ID from MTP parameter names (e.g., `model.mtp_block.self_attn.qkv_proj`), so `is_swa` detection fails for MTP layers, causing incorrect weight loading. This fix explicitly detects MTP layers by checking `"mtp_block"` or `"mtp.layers"` in the parameter name and uses the SWA head dimensions for those layers.

## Modifications

- **`python/sglang/srt/models/mimo_v2.py`**: When `attn_tp_size == 1`, the weight loader reorders the fused QKV weights from the interleaved TP layout back to a contiguous Q/K/V order and loads them in full via `default_weight_loader`, bypassing the normal `load_mimo_v2_qkv_proj_weight` path. Added MTP layer detection (`is_mtp`) to ensure SWA head dimensions are used for MTP layers, since `get_layer_id` cannot extract a layer ID from MTP parameter names and `is_swa` detection would otherwise fail.
- **`python/sglang/srt/models/mimo_v2_nextn.py`**: Updated the `load_weights` method to call `load_mimo_v2_qkv_proj_weight_v2` (instead of the commented-out `load_mimo_v2_qkv_proj_weight`) for fused QKV projection weights, passing the config for proper MTP layer handling.

## Accuracy Tests
<img width="1062" height="210" alt="img_v3_0213k_e8b66b19-cc49-4552-9349-89798bcdb5ag" src="https://github.com/user-attachments/assets/68dae409-a591-4b81-9fd6-d70ae72b1a08" />

<img width="1029" height="142" alt="img_v3_0213k_e328acce-08d7-4c04-a35c-32076b102cbg" src="https://github.com/user-attachments/assets/63d6524f-63ec-47f1-81b7-8a7e3f72be5e" />


## Speed Tests and Profiling

The trace stay same as #78 

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->