### PR TITLE
Fix dsv4 full token pool

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -260,8 +260,8 @@ class PrefillBootstrapQueue:
         self.bootstrap_port = bootstrap_port
         self.queue: List[Req] = []
         self.gloo_group = gloo_group
-        self.max_total_num_tokens = max_total_num_tokens
         self.scheduler = scheduler
+        self.max_total_num_tokens = max_total_num_tokens
         self.transfer_backend = transfer_backend
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get() and self.is_mla_backend:
             raise RuntimeError(
@@ -270,12 +270,31 @@ class PrefillBootstrapQueue:
             )
         self.kv_manager = self._init_kv_manager()
 
-        if self.scheduler.tp_worker.is_hybrid_swa:
-            # FIXME: current SWA allocation allocate full kv cache size in prefill
+        use_dsv4_full_token_pool = (
+            self.scheduler.tp_worker.is_hybrid_swa
+            and isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool)
+            and envs.SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL.get()
+        )
+        if use_dsv4_full_token_pool:
+            self.max_total_num_tokens = (
+                self.scheduler.tp_worker.model_runner.max_token_pool_size
+            )
+            logger.info(
+                "DeepSeek-V4 PD prefill admission uses full token pool capacity: %d",
+                self.max_total_num_tokens,
+            )
+        elif self.scheduler.tp_worker.is_hybrid_swa:
+            # Legacy fallback for hybrid-SWA pools that allocate SWA KV for the
+            # full prompt during PD prefill.
             self.max_total_num_tokens = min(
                 self.max_total_num_tokens,
                 self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
             )
+            if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                logger.info(
+                    "DeepSeek-V4 PD prefill admission uses legacy SWA pool cap: %d",
+                    self.max_total_num_tokens,
+                )
 
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -258,6 +258,9 @@ class Envs:
     SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS = EnvStr("{}")
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
+    # DeepSeek-V4 only needs the SWA tail during PD prefill/decode transfer.
+    # Set to false to restore the legacy admission cap based on the SWA pool.
+    SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL = EnvBool(True)
     # Extra slots in req_to_token_pool for decode workers (only effective when
     # max_num_reqs > 32). Increases pool capacity so more KV cache transfers
     # can overlap with decode execution without raising max_running_requests.


### PR DESCRIPTION
修复dpskv4模型单次请求的输入被限制成SWA pool长度的问题，可以通过SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL环境变量控制

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->