### PR TITLE
V0.5.12 dev bug

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2014,9 +2014,11 @@ class DeepseekV2AttentionMLA(
             )
         else:
             if _use_fused_rms_quant and self.input_layernorm is not None:
-                # NOTE: suspected
                 if _rms_quant_path == 1:
-                # path 1
+                    # The fused rms-quant path updates `hidden_states` in-place
+                    # when `update_hd=True`. For the first layer there is no
+                    # residual baseline yet, so keep `hidden_states` intact and
+                    # save it as the baseline for following layers.
                     if forward_batch.residual_rms_per_quant_int8 is None:
                         qkv_latent, _ = self.fused_qkv_a_proj_with_mqa(
                             hidden_states, 
@@ -2025,13 +2027,16 @@ class DeepseekV2AttentionMLA(
                             update_hd=False)
                         forward_batch.residual_rms_per_quant_int8 = hidden_states
                     else:
+                        # Match the unfused PATH=0 semantics: RMSNorm should be
+                        # computed from the updated residual state, and the
+                        # shared residual tensor must be advanced in-place for
+                        # later attention/NSA users.
                         qkv_latent, _ = self.fused_qkv_a_proj_with_mqa(
                             hidden_states, 
                             rms_weight=self.input_layernorm.weight.data,
                             residual=forward_batch.residual_rms_per_quant_int8,
-                            update_hd=False)
+                            update_hd=True)
                 else:
-                # path 2
                     if forward_batch.residual_rms_per_quant_int8 is None: 
                         _normed = self.input_layernorm(hidden_states)
                         forward_batch.residual_rms_per_quant_int8 = hidden_states

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -459,7 +459,6 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
                 .to(device=x.device, dtype=torch.int32),
             ]
         )
-        cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
         # cu_seqlens must be on cpu because of npu_flash_attention_unpad operator restriction
         if is_npu():
             cu_seqlens = cu_seqlens.to("cpu")
@@ -540,8 +539,6 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
                 .to(device=x.device, dtype=torch.int32),
             ]
         )
-        cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
-
         return self.cuda_graph_runner.run(
             x=x,
             position_embeddings=position_embeddings,


### PR DESCRIPTION
## Motivation

This PR fixes two accuracy regressions observed on DCU backends:

1. Qwen2.5-VL with `mm_attention_backend=fa3` produced significantly degraded MMBench accuracy.
2. DeepSeek/GLM-style models with `SGLANG_USE_RMS_QUANT_PATH=1` could produce repeated or abnormal outputs on long prompts.

Both issues were caused by model-forward path inconsistencies rather than model quality itself.

## Modifications

- Fix Qwen2.5-VL FA3 visual attention `cu_seqlens` construction.
  - Removed redundant prepending of zero to `cu_seqlens`.
  - The duplicated leading zero could make FA3 varlen attention consume incorrect sequence boundaries and degrade multimodal accuracy.

- Fix RMS quant path residual update semantics in `deepseek_v2.py`.
  - For `SGLANG_USE_RMS_QUANT_PATH=1`, make the fused RMSNorm + quant path update `hidden_states` consistently with the non-quant path.
  - This ensures the shared residual tensor used by attention inputs / NSA indexer matches the expected `residual + hidden_states` RMSNorm semantics.
  - Fixes long-prompt repetition / precision abnormality when RMS quant path is enabled.

## Accuracy Tests

### Qwen2.5-VL-72B-Instruct-quantized.w8a8

Config:

- `mm_attention_backend=fa3`
- `attention_backend=fa3`
- `quantization=w8a8_int8`
- Dataset: `mm_bench`

Results:

- Before fix: overall score around `0.447`
- After fix:
  - quick validation, 200 samples: `0.90`
  - full 2000 samples: `0.8675`

### GLM / DeepSeek-style RMS quant path

Config:

- `SGLANG_USE_RMS_QUANT_PATH=1`
- Long prompt test

Result:

- Before fix: long-prompt generation could contain repeated / abnormal text.
- After fix: output is aligned with the `SGLANG_USE_RMS_QUANT_PATH=0` path and no longer shows the long-prompt repetition issue.

## Speed Tests and Profiling

No dedicated speed benchmark was run.

The changes are expected to have negligible performance impact:

- Qwen2.5-VL change only fixes sequence length metadata construction.
- RMS quant path change preserves the intended fused path and only corrects in-place update semantics.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->