### PR TITLE
feat: improve LTX-2 dynamic batching and TP loading

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
@@ -196,6 +196,10 @@ class LTX2PipelineConfig(PipelineConfig):
             auto_disable_component_offload_components=("dit",),
         )
 
+    def supports_dynamic_batching(self) -> bool:
+        """Allow text-only LTX batching; scheduler image_path gate rejects images."""
+        return True
+
     def prepare_latent_shape(self, batch, batch_size, num_frames):
         """Return unpacked latent shape [B, C, F, H, W]."""
         height = batch.height // self.vae_scale_factor

--- a/python/sglang/multimodal_gen/configs/sample/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/sample/ltx_2.py
@@ -11,7 +11,7 @@ class LTX2SamplingParams(SamplingParams):
 
     # Match the reference defaults used by ltx-pipelines (one-stage).
     # See: LTX-2/packages/ltx-pipelines/src/ltx_pipelines/utils/constants.py
-    seed: int = 10
+    seed: int = field(default=10, metadata={"batch_sig_exclude": True})
     generator_device: str = "cpu"
 
     # Video parameters
@@ -47,7 +47,7 @@ class LTX2SamplingParams(SamplingParams):
 class LTX23SamplingParams(LTX2SamplingParams):
     """Sampling parameters matching official LTX-2.3 one-stage defaults."""
 
-    seed: int = 42
+    seed: int = field(default=42, metadata={"batch_sig_exclude": True})
     generator_device: str = "cuda"
     guidance_scale: float = 3.0
     num_inference_steps: int = 30

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -52,9 +52,10 @@ def _server_args_for_transformer_component(
 
 
 def _should_use_streaming_state_dict_load(server_args: ServerArgs) -> bool:
+    tp_size = getattr(server_args, "tp_size", 1) or 1
     sp_degree = getattr(server_args, "sp_degree", 1) or 1
     ulysses_degree = getattr(server_args, "ulysses_degree", 1) or 1
-    return bool(sp_degree > 1 and ulysses_degree > 1)
+    return bool(tp_size > 1 or (sp_degree > 1 and ulysses_degree > 1))
 
 
 class TransformerLoader(ComponentLoader):

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -738,9 +738,9 @@ class LTX2Attention(nn.Module):
         if self.to_gate_logits is not None:
             gate_logits, _ = self.to_gate_logits(gate_input)
             b, t = out.shape[:2]
-            out = out.view(b, t, self.local_heads, self.dim_head)
+            out = out.reshape(b, t, self.local_heads, self.dim_head)
             out = out * (2.0 * torch.sigmoid(gate_logits).unsqueeze(-1))
-            out = out.view(b, t, self.local_heads * self.dim_head)
+            out = out.reshape(b, t, self.local_heads * self.dim_head)
 
         out_flat = out.flatten(2)
         out_proj, _ = self.to_out[0](out_flat)

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -1661,6 +1661,14 @@ class ServerArgs(DisaggArgsMixin):
             )
 
     def _validate_parallelism(self):
+        if self.use_fsdp_inference and self.tp_size > 1:
+            raise ValueError(
+                "FSDP inference cannot be combined with tensor parallelism. "
+                "FSDP assumes identical parameter replicas across its shard group, "
+                "but TP ranks own different parameter shards. Disable "
+                "--use-fsdp-inference when --tp-size is greater than 1."
+            )
+
         if self.sp_degree > self.num_gpus or self.num_gpus % self.sp_degree != 0:
             raise ValueError(
                 f"num_gpus ({self.num_gpus}) must be >= and divisible by sp_degree ({self.sp_degree})"


### PR DESCRIPTION
## Summary
- enable dynamic batching for text-only LTX-2 requests while allowing each request to use its own seed
- use streaming transformer state-dict loading for tensor parallelism and reject the incompatible FSDP-inference-plus-TP combination
- handle non-contiguous LTX gated-attention outputs produced by distributed execution

## Behavior notes
- image-conditioned requests remain excluded from dynamic batching by the scheduler `image_path` admission gate
- the three commits preserve their original hashes and are based on an ancestor of the current `v0.5.12_dev`

## Validation
- `python -m py_compile` passed for all five modified Python files
- `python -m pytest -q python/sglang/multimodal_gen/test/unit/test_server_args.py`: 46 passed, 1 unrelated existing failure in `TestPipelineResolutionCliOverride` for Qwen-Image-Layered resolution lookup

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->