### PR TITLE
support megamoe cp

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -74,7 +74,12 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
             f"got {server_args.cp_strategy}"
         )
 
+    # The unified CP flags may have been mirrored to the generic legacy alias
+    # before the model-specific dsv4 attention backend was resolved.  DSV4
+    # uses the DSA runtime alias, so keep the two mutually-exclusive legacy
+    # flags normalized here as well.
     server_args.enable_dsa_prefill_context_parallel = True
+    server_args.enable_prefill_context_parallel = False
     server_args.dsa_prefill_cp_mode = "round-robin-split"
     server_args.enable_dp_attention = True
     server_args.moe_dense_tp_size = 1

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -85,6 +85,12 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
     assert (
         server_args.tp_size <= 8
     ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
+    if server_args.moe_a2a_backend not in ("none", "deepep", "megamoe"):
+        raise ValueError(
+            "DeepSeekV4 CP supports moe_a2a_backend in "
+            "('none', 'deepep', 'megamoe'), "
+            f"got {server_args.moe_a2a_backend!r}."
+        )
     logger.warning(
         "Disabling SGLANG_OPT_FLASHMLA_SPARSE_PREFILL because DeepSeekV4 "
         "context parallelism is enabled."

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1903,7 +1903,12 @@ def _page_size_default(view: Any) -> dict:
 
 @register_post_process
 def _data_parallelism_defaults(view: Any) -> dict:
-    if view.dp_size == 1:
+    # Context parallelism still uses the DP-attention scheduler control path
+    # to keep all attention-CP ranks on the same batch, even when there is only
+    # one data-parallel replica.  Model hooks enable it before this generic
+    # default runs; do not overwrite that decision or CP ranks can enter MLP
+    # collectives with different local scheduler states.
+    if view.dp_size == 1 and not view.enable_prefill_cp:
         return {"enable_dp_attention": False, "enable_dp_lm_head": False}
     return {}
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -388,11 +388,7 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
                 aiter_can_use_preshuffle_paged_mqa,
             )
 
-            if (
-                is_hip()
-                and not is_dcu()
-                and not aiter_can_use_preshuffle_paged_mqa()
-            ):
+            if is_hip() and not is_dcu() and not aiter_can_use_preshuffle_paged_mqa():
                 # Legacy ROCm DSA path: aiter's gluon paged-MQA kernel is
                 # unavailable (Triton<3.5 and AITER_ENABLE_AOT_GLUON_PA_MQA_LOGITS
                 # not set, or SGLANG_DSA_HIP_DISABLE_PRESHUFFLE=1 / SGLANG_USE_AITER=0).

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -57,6 +57,7 @@ _MEGA_MOE_DCU_BACKEND_LL = "ll"
 _MEGA_MOE_DCU_BACKEND_NORMAL = "normal"
 _MEGA_MOE_DCU_NORMAL_LL_TOKEN_THRESHOLD_ENV = "MEGAMOE_DCU_NORMAL_LL_TOKEN_THRESHOLD"
 _MEGA_MOE_DCU_NORMAL_LL_TOKEN_THRESHOLD = 496
+_MEGA_MOE_DCU_K3_TAIL_REDUCE_ENV = "K3_USE_ASM_TAIL_REDUCE"
 
 logger = logging.getLogger(__name__)
 
@@ -112,12 +113,18 @@ def _get_dcu_normal_ll_token_threshold() -> int:
 def _select_dcu_megamoe_backend(selector_tokens: int) -> str:
     if selector_tokens < 0:
         raise ValueError("MegaMoE backend selector token count must be non-negative")
+    if is_dsa_enable_prefill_cp():
+        # CP prefill uses the rank-barrier + local-reduce path. The standalone
+        # DCU LL/tail-reduce path can VMFault under sustained CP traffic.
+        os.environ.setdefault(_MEGA_MOE_DCU_K3_TAIL_REDUCE_ENV, "0")
     if _is_pd_prefill_instance():
         return _MEGA_MOE_DCU_BACKEND_NORMAL
 
     mode = os.environ.get(_MEGA_MOE_DCU_BACKEND_ENV, _MEGA_MOE_DCU_BACKEND_AUTO)
     mode = mode.strip().lower()
     if mode == _MEGA_MOE_DCU_BACKEND_AUTO:
+        if is_dsa_enable_prefill_cp():
+            return _MEGA_MOE_DCU_BACKEND_NORMAL
         return (
             _MEGA_MOE_DCU_BACKEND_LL
             if selector_tokens <= _get_dcu_normal_ll_token_threshold()
@@ -386,7 +393,14 @@ def _run_mega_routed(
         envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
     )
     global_num_tokens = get_dp_global_num_tokens()
-    dispatch_num_tokens = max(global_num_tokens) if global_num_tokens else num_tokens
+    # CP has already split the padded prefill batch across attention ranks at
+    # this point.  Using the DP-global token count here would size and select
+    # the MegaMoE dispatch as if every CP rank still owned the full batch.
+    dispatch_num_tokens = (
+        max(global_num_tokens)
+        if global_num_tokens and not is_dsa_enable_prefill_cp()
+        else num_tokens
+    )
     assert dispatch_num_tokens <= num_max_tokens_per_rank, (
         f"mega MoE: max_tokens_per_rank={dispatch_num_tokens} exceeds cap "
         f"SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK="

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -289,7 +289,7 @@ def _get_mega_moe_symm_buffer(
     return buf
 
 
-def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bool:
+def should_use_mega_moe(moe: DeepseekV2MoE, hidden_states: torch.Tensor) -> bool:
     if not get_moe_a2a_backend().is_megamoe():
         return False
     if not getattr(moe.experts, "_mega_moe_weights_built", False):
@@ -316,9 +316,9 @@ def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bo
 
 
 def forward_mega_moe(
-    moe: "DeepseekV2MoE",
+    moe: DeepseekV2MoE,
     hidden_states: torch.Tensor,
-    forward_batch: Optional["ForwardBatch"] = None,
+    forward_batch: Optional[ForwardBatch] = None,
     input_ids_global: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     num_tokens = hidden_states.shape[0]
@@ -353,9 +353,9 @@ def forward_mega_moe(
 
 
 def _run_mega_routed(
-    moe: "DeepseekV2MoE",
+    moe: DeepseekV2MoE,
     hidden_states: torch.Tensor,
-    forward_batch: Optional["ForwardBatch"],
+    forward_batch: Optional[ForwardBatch],
     input_ids_global: Optional[torch.Tensor],
     num_tokens: int,
 ) -> torch.Tensor:
@@ -525,7 +525,7 @@ def _run_deep_gemm_dcu_w8a8_mega_moe(
     hidden_states: torch.Tensor,
     topk_ids: Optional[torch.Tensor],
     topk_weights: Optional[torch.Tensor],
-    moe: "DeepseekV2MoE",
+    moe: DeepseekV2MoE,
     buf,
     num_tokens: int,
     hidden_size: int,
@@ -564,7 +564,7 @@ def _run_standalone_dcu_w8a8_mega_moe(
     hidden_states: torch.Tensor,
     topk_ids: Optional[torch.Tensor],
     topk_weights: Optional[torch.Tensor],
-    moe: "DeepseekV2MoE",
+    moe: DeepseekV2MoE,
     buf,
     num_tokens: int,
     hidden_size: int,
@@ -651,7 +651,6 @@ def _transpose_mega_moe_sf_for_utccp(sf: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(sf).copy_(result)
 
 
-
 def build_mega_moe_experts_weights(experts) -> None:
     from deep_gemm import (
         transform_sf_into_required_layout,
@@ -695,7 +694,9 @@ def build_mega_moe_experts_weights(experts) -> None:
         # the deep-ep path consumes the non-transposed interleaved scale and a
         # swizzle-aware activation kernel. L2 weight is untouched by the mega
         # transform, so the existing `w2_weight.data` is shared directly.
-        w13_interleaved, w13_sf_interleaved = _interleave_mega_moe_l1_weights((w13, w13_sf))
+        w13_interleaved, w13_sf_interleaved = _interleave_mega_moe_l1_weights(
+            (w13, w13_sf)
+        )
         w13_sf_utccp = _transpose_mega_moe_sf_for_utccp(w13_sf_interleaved)
         w2_sf_utccp = _transpose_mega_moe_sf_for_utccp(w2_sf)
 

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -25,6 +25,7 @@ import torch
 from sglang.jit_kernel.dsv4 import mega_moe_pre_dispatch
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
+from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
 from sglang.srt.layers.dp_attention import get_dp_global_num_tokens
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.model_executor.runner import get_is_capture_mode
@@ -299,7 +300,7 @@ def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bo
         return not _IS_DCU or _is_standalone_megamoe_runtime()
 
     global_num_tokens = get_dp_global_num_tokens()
-    if global_num_tokens:
+    if global_num_tokens and not is_dsa_enable_prefill_cp():
         max_tokens_per_rank = max(global_num_tokens)
     else:
         max_tokens_per_rank = hidden_states.shape[0]

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -183,7 +183,14 @@ def prepare_mlp_sync_batch_raw(
             or num_tokens_for_logprob == local_batch.batch_size()
         )
 
-    skip_all_gather = envs.SGLANG_SCHEDULER_SKIP_ALL_GATHER.get()
+    # With a single DP replica and no residual attention-TP/MLP-TP gather,
+    # every CP rank receives the same work through the CP control broadcast.
+    # The scheduler metadata all-gather is therefore redundant and can hang
+    # on DCU CPU process groups during the idle loop.  Reuse the established
+    # skip path, which records each rank's local token count as required by CP.
+    skip_all_gather = envs.SGLANG_SCHEDULER_SKIP_ALL_GATHER.get() or (
+        dp_size == 1 and attn_tp_size == 1 and not require_mlp_tp_gather
+    )
     can_cuda_graph = (
         local_batch is None
         or local_batch.forward_mode.is_decode_or_idle()

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -40,6 +40,7 @@ from sglang.jit_kernel.dsv4 import (
     sglang_per_token_group_quant_fp8_dsv4_wo_a,
 )
 from sglang.kernels.ops.attention.deepseek_v4_rope import (
+    apply_rotary_emb_triton,
     v4_rope_inplace_npu,
 )
 from sglang.srt.compilation.compilation_config import register_split_op
@@ -88,7 +89,6 @@ from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
-from sglang.kernels.ops.attention.deepseek_v4_rope import apply_rotary_emb_triton
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.utils.cp_utils import (
@@ -175,6 +175,7 @@ _use_aiter_tilelang_mhc = get_bool_env_var("SGLANG_ROCM_USE_AITER_TILELANG_MHC")
 
 if _is_dcu:
     from lightop import op
+
     if _use_aiter_tilelang_mhc:
         from aiter.ops.tilelang import mhc_post_fwd, mhc_pre_big_fuse
 
@@ -635,9 +636,7 @@ class MQALayer(MqaAttentionBase):
         )
 
         self.use_fused_qk_norm_rope = (
-            _is_hip
-            and not _is_dcu
-            and envs.SGLANG_OPT_USE_FUSED_QK_NORM_ROPE.get()
+            _is_hip and not _is_dcu and envs.SGLANG_OPT_USE_FUSED_QK_NORM_ROPE.get()
         )
 
         # KV cache write is always fused into the K kernel
@@ -2090,12 +2089,16 @@ class DeepseekV4Model(nn.Module):
         else:
             self.embed_tokens = PPMissingLayer()
         self.rms_norm_eps = config.rms_norm_eps
-        use_stream_pool = _is_dcu or _is_cuda or (
-            _is_hip
-            and not _is_dcu
-            and (
-                envs.SGLANG_ROCM_USE_MULTI_STREAM.get()
-                or envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get()
+        use_stream_pool = (
+            _is_dcu
+            or _is_cuda
+            or (
+                _is_hip
+                and not _is_dcu
+                and (
+                    envs.SGLANG_ROCM_USE_MULTI_STREAM.get()
+                    or envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get()
+                )
             )
         )
         num_alt_streams = 5 if (_is_cuda or _is_dcu) else 2
@@ -3037,8 +3040,10 @@ class DeepseekV4ForCausalLM(nn.Module):
                                     fused_weight = torch.cat(
                                         [bucket["q"], bucket["kv"]], dim=0
                                     )
-                                    param_name = maybe_remap_compressed_tensors_scale_name(
-                                        param_name
+                                    param_name = (
+                                        maybe_remap_compressed_tensors_scale_name(
+                                            param_name
+                                        )
                                     )
                                     param = params_dict[param_name]
                                     weight_loader = auto_weight_loader(param)

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1778,12 +1778,14 @@ class DeepseekV4DecoderLayer(nn.Module):
             and getattr(self.mlp, "_shared_expert_tp1", False)
         )
         if _use_cp:
-            if get_moe_a2a_backend().is_none():
+            moe_a2a_backend = get_moe_a2a_backend()
+            if moe_a2a_backend.is_none():
                 hidden_states = dsa_cp_gather_hidden_states(hidden_states)
             else:
-                assert get_moe_a2a_backend().is_deepep(), (
-                    "CP requires DeepEP (moe_a2a_backend == deepep). "
-                    "Only DeepEP is tested with CP's per-rank token split."
+                assert moe_a2a_backend.is_deepep() or moe_a2a_backend.is_megamoe(), (
+                    "CP requires DeepEP or megaMoE "
+                    "(moe_a2a_backend == deepep or megamoe). "
+                    f"Got {moe_a2a_backend.value}."
                 )
         elif _use_tp_moe_gather:
             hidden_states, local_hidden_states = (

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -184,6 +184,7 @@ def is_npu() -> bool:
 
     return True
 
+
 @lru_cache(maxsize=1)
 def is_dcu() -> bool:
     if not is_hip():
@@ -208,6 +209,7 @@ def is_dcu_native_fp8_supported() -> bool:
     except Exception as e:
         logger.warning("DCU native FP8 detection failed: %s", e)
         return False
+
 
 @lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
@@ -3547,10 +3549,7 @@ def require_attn_tp_gather(server_args: ServerArgs):
         if server_args.enable_dp_attention:
             # Rank layout is (DP, CP, attention-TP).  A gather is required
             # only when the residual attention-TP dimension is larger than 1.
-            return (
-                server_args.dp_size * server_args.attn_cp_size
-                < server_args.tp_size
-            )
+            return server_args.dp_size * server_args.attn_cp_size < server_args.tp_size
         else:
             return True
     else:
@@ -4443,6 +4442,7 @@ def get_or_create_event_loop():
         asyncio.set_event_loop(loop)
         return loop
 
+
 def get_numa_node_count() -> int:
     """
     Get the number of NUMA nodes available on the system.
@@ -4584,6 +4584,8 @@ def bind_to_closest_numa_node_cuda():
     if is_numa_available() and nvgpu_available():
         node_id = get_current_device_numa_node_cuda()
         numa_bind_to_node(node_id)
+
+
 # from vllm
 class W8a8GetCacheJSON:
     _instance = None
@@ -4596,44 +4598,42 @@ class W8a8GetCacheJSON:
 
     def _initialize(self):
         current_folder_path = os.path.dirname(os.path.abspath(__file__))
-        json_folder_path=current_folder_path+'/../../lmslim/configs/w8a8'
+        json_folder_path = current_folder_path + "/../../lmslim/configs/w8a8"
 
-        self.triton_json_dir=(os.getenv('TRITON_JSON_DIR', json_folder_path))
-        self.triton_json_dict={}
-        self.triton_moejson_dict={}
-        self.triton_json_list=[]
-        self.weight_shapes=[]
-        self.moe_weight_shapes=[]
-        arch_name = torch.cuda.get_device_properties("cuda").gcnArchName.split(':')[0]
-        arch_cu = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+        self.triton_json_dir = os.getenv("TRITON_JSON_DIR", json_folder_path)
+        self.triton_json_dict = {}
+        self.triton_moejson_dict = {}
+        self.triton_json_list = []
+        self.weight_shapes = []
+        self.moe_weight_shapes = []
+        arch_name = torch.cuda.get_device_properties("cuda").gcnArchName.split(":")[0]
+        arch_cu = torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).multi_processor_count
 
-        device_name =arch_name+'_'+str(arch_cu)+'cu'
-        self.device_name=device_name
-        self.topk=1
-        self.quant_method=None
+        device_name = arch_name + "_" + str(arch_cu) + "cu"
+        self.device_name = device_name
+        self.topk = 1
+        self.quant_method = None
 
-    #析构函数，最后会生成model.json的配置文件
-    def gen_model_json(self,E:Optional[int]=0,block_size:Optional[list]=None):
-        json_dir = os.getenv('LMSLIM_TUNING_JSON', "None")
+    # 析构函数，最后会生成model.json的配置文件
+    def gen_model_json(self, E: Optional[int] = 0, block_size: Optional[list] = None):
+        json_dir = os.getenv("LMSLIM_TUNING_JSON", "None")
         if json_dir != "None" and os.path.exists(json_dir):
-            #生成模型配置文件
+            # 生成模型配置文件
             # logger.info("model_tuning.json is at LMSLIM_TUNING_JSON:%s", json_dir)
             config = {
                 "layers": {
                     "linear": {
                         "shapes": [],
-                        "m_range":"None",
-                    },
-                    "moe": {
-                        "shapes": [],
                         "m_range": "None",
-                        "topk": self.topk
-                    }
+                    },
+                    "moe": {"shapes": [], "m_range": "None", "topk": self.topk},
                 },
                 "quantization_config": {
                     "quant_method": self.quant_method,
-                    "weight_block_size": "None"
-                }
+                    "weight_block_size": "None",
+                },
             }
 
             # 处理 MoE shapes
@@ -4643,7 +4643,7 @@ class W8a8GetCacheJSON:
                         "E": shape[0],
                         "N1": shape[1],
                         "N2": shape[2],
-                        "K": shape[3],      # 默认值
+                        "K": shape[3],  # 默认值
                     }
                     config["layers"]["moe"]["shapes"].append(moe_config)
 
@@ -4651,90 +4651,113 @@ class W8a8GetCacheJSON:
                 config["layers"]["linear"]["shapes"].append(shape)
 
             if block_size is not None:
-                config["quantization_config"]["weight_block_size"]=block_size
+                config["quantization_config"]["weight_block_size"] = block_size
 
-            with open(json_dir+"/model.json", 'w') as f:
+            with open(json_dir + "/model.json", "w") as f:
                 json.dump(config, f, indent=4)
         # else:
         #     logger.info("LMSLIM_TUNING_JSON is not set")
 
-    def getspec_config(self,configs_dict,M,N,K):
+    def getspec_config(self, configs_dict, M, N, K):
         if f"{M}_{N}_{K}" in configs_dict:
             return configs_dict[f"{M}_{N}_{K}"]
         else:
             return None
 
-    def get_triton_cache(self,file_path,n,k):
-        #在非tuning的时候使用，当文件不存在则直接返回none
-        cache_json_file=file_path
+    def get_triton_cache(self, file_path, n, k):
+        # 在非tuning的时候使用，当文件不存在则直接返回none
+        cache_json_file = file_path
 
         if os.path.exists(file_path):
-        #try:
-            with open(cache_json_file, 'r') as file:
+            # try:
+            with open(cache_json_file, "r") as file:
                 cachedata = json.load(file)
         else:
             return None
 
-        #把所有的cache解析成key:config的形式：[M_N_K]:[config]
-        configs_dict={}
+        # 把所有的cache解析成key:config的形式：[M_N_K]:[config]
+        configs_dict = {}
         for key, value in cachedata.items():
             for sub_key, sub_value in value.items():
-                configs_key= f"{sub_key}_{key}"
-                configs_dict[configs_key]=sub_value
+                configs_key = f"{sub_key}_{key}"
+                configs_dict[configs_key] = sub_value
         return configs_dict
 
-    def get_w8a8json_name(self,n,k):
-        return self.triton_json_dir+f"/W8A8_{n}_{k}_{self.device_name}.json"
+    def get_w8a8json_name(self, n, k):
+        return self.triton_json_dir + f"/W8A8_{n}_{k}_{self.device_name}.json"
 
-    def get_blockint8_triton_cache(self,file_path,n,k,block_n,block_k):
-        cache_json_file=file_path
+    def get_blockint8_triton_cache(self, file_path, n, k, block_n, block_k):
+        cache_json_file = file_path
 
         if os.path.exists(file_path):
-        #try:
-            with open(cache_json_file, 'r') as file:
+            # try:
+            with open(cache_json_file, "r") as file:
                 cachedata = json.load(file)
         else:
             return None
 
-        #把所有的cache解析成key:config的形式：[M_N_K]:[config]
-        configs_dict={}
+        # 把所有的cache解析成key:config的形式：[M_N_K]:[config]
+        configs_dict = {}
         for key, value in cachedata.items():
             for sub_key, sub_value in value.items():
-                configs_key= f"{sub_key}_{key}"
-                configs_dict[configs_key]=sub_value
+                configs_key = f"{sub_key}_{key}"
+                configs_dict[configs_key] = sub_value
         return configs_dict
 
-    def get_blockint8json_name(self,n,k,block_n,block_k):
-        return self.triton_json_dir+f"/linear_{n}_{k}_block[{block_n},{block_k}]_{self.device_name}.json"
+    def get_blockint8json_name(self, n, k, block_n, block_k):
+        return (
+            self.triton_json_dir
+            + f"/linear_{n}_{k}_block[{block_n},{block_k}]_{self.device_name}.json"
+        )
 
-    def get_moeint8json_name(self,E,N1,N2,K,TOPK,
-                             block_size:Optional[list]=None,use_int4_w4a8:Optional[bool]=False):
+    def get_moeint8json_name(
+        self,
+        E,
+        N1,
+        N2,
+        K,
+        TOPK,
+        block_size: Optional[list] = None,
+        use_int4_w4a8: Optional[bool] = False,
+    ):
         if use_int4_w4a8:
             if block_size is not None:
-                return self.triton_json_dir+f"/MOE_W4A8INT8[{block_size[0]},{block_size[1]}]_E={E}_N1={N1}_N2={N2}_K={K}_TOPK{TOPK}_{self.device_name}.json"
+                return (
+                    self.triton_json_dir
+                    + f"/MOE_W4A8INT8[{block_size[0]},{block_size[1]}]_E={E}_N1={N1}_N2={N2}_K={K}_TOPK{TOPK}_{self.device_name}.json"
+                )
             else:
-                return self.triton_json_dir+f"/MOE_W4A8INT8_E={E}_N1={N1}_N2={N2}_K={K}_TOPK{TOPK}_{self.device_name}.json"
+                return (
+                    self.triton_json_dir
+                    + f"/MOE_W4A8INT8_E={E}_N1={N1}_N2={N2}_K={K}_TOPK{TOPK}_{self.device_name}.json"
+                )
         else:
             if block_size is not None:
-                return self.triton_json_dir+f"/MOE_BLOCKINT8[{block_size[0]},{block_size[1]}]_E={E}_N1={N1}_N2={N2}_K={K}_TOPK{TOPK}_{self.device_name}.json"
+                return (
+                    self.triton_json_dir
+                    + f"/MOE_BLOCKINT8[{block_size[0]},{block_size[1]}]_E={E}_N1={N1}_N2={N2}_K={K}_TOPK{TOPK}_{self.device_name}.json"
+                )
             else:
-                return self.triton_json_dir+f"/MOE_W8A8INT8_E={E}_N1={N1}_N2={N2}_K={K}_TOPK{TOPK}_{self.device_name}.json"
+                return (
+                    self.triton_json_dir
+                    + f"/MOE_W8A8INT8_E={E}_N1={N1}_N2={N2}_K={K}_TOPK{TOPK}_{self.device_name}.json"
+                )
 
-    def get_moeint8_triton_cache(self,file_path,E,N1,N2,K,TOPK):
-        cache_json_file=file_path
+    def get_moeint8_triton_cache(self, file_path, E, N1, N2, K, TOPK):
+        cache_json_file = file_path
 
         if os.path.exists(file_path):
-        #try:
-            with open(cache_json_file, 'r') as file:
+            # try:
+            with open(cache_json_file, "r") as file:
                 cachedata = json.load(file)
         else:
             return None
 
-        #把所有的cache解析成key:config的形式：[M_N_K]:[config1,config2]
-        configs_dict={}
+        # 把所有的cache解析成key:config的形式：[M_N_K]:[config1,config2]
+        configs_dict = {}
         for key, value in cachedata.items():
             for sub_key, sub_value in value.items():
-                configs_key= f"{sub_key}_{key}"
-                configs_dict[configs_key]=sub_value
+                configs_key = f"{sub_key}_{key}"
+                configs_dict[configs_key] = sub_value
 
         return configs_dict

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3497,7 +3497,12 @@ def require_mlp_tp_gather(server_args: ServerArgs):
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
     if server_args.enable_dp_attention:
-        assert server_args.dp_size > 1, "dp_size must be greater than 1"
+        if server_args.dp_size == 1:
+            assert server_args.enable_prefill_cp, (
+                "dp_size must be greater than 1 unless DP-attention control "
+                "broadcast is used by context parallelism"
+            )
+            return False
         if (
             server_args.moe_dense_tp_size is None
         ):  # TODO(ch-wan): some MoE models do not have dense layers
@@ -3540,7 +3545,12 @@ def require_attn_tp_gather(server_args: ServerArgs):
 
     if not get_moe_a2a_backend().is_none() or server_args.moe_dense_tp_size is not None:
         if server_args.enable_dp_attention:
-            return server_args.dp_size < server_args.tp_size
+            # Rank layout is (DP, CP, attention-TP).  A gather is required
+            # only when the residual attention-TP dimension is larger than 1.
+            return (
+                server_args.dp_size * server_args.attn_cp_size
+                < server_args.tp_size
+            )
         else:
             return True
     else:


### PR DESCRIPTION
## Motivation
Currently the megamoe is disabled in CP mode, and there is just a opened PR on the way: https://github.com/sgl-project/sglang/pull/29569.
megamoe cp to v0.5.15.post_dev

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
By reference, porting this PR and other bugfix for vmfault or accuracy issue, here is the final patch of megamoe + CP.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
100%|███████████████████████████████████████████████████████████████████| 1319/1319 [08:28<00:00,  2.59it/s]
Accuracy: 0.950
Invalid: 0.000
Latency: 508.516 s
Output throughput: 230.687 token/s

test flow and validation results: #https://kcnm6g5dkw5p.feishu.cn/wiki/TQFWw5cfMiinXpkI7Dwcr77anzc?from=from_copylink
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
Input_Len | Output_Len | Max_Concurrency | Mean TTFT (ms) DeepEP | Mean TTFT (ms)megamoe | Ratio
-- | -- | -- | -- | -- | --
4096 | 1 | 1 | 470.4551 | 448.5414 | 4.66%
4096 | 1 | 2 | 707.8938 | 656.9903 | 7.19%
4096 | 1 | 4 | 1481.2591 | 1065.1042 | 28.09%
4096 | 1 | 8 | 1957.3329 | 1770.3854 | 9.55%
4096 | 1 | 16 | 3113.1391 | 2823.3242 | 9.31%
4096 | 1 | 32 | 5157.4255 | 4594.7583 | 10.91%
4096 | 1 | 64 | 8904.6482 | 8165.5959 | 8.30%
16384 | 1 | 1 | 1135.3806 | 1060.9199 | 6.56%
16384 | 1 | 2 | 2032.3953 | 1871.5551 | 7.91%
16384 | 1 | 4 | 3209.1082 | 2931.9591 | 8.64%
16384 | 1 | 8 | 5266.0017 | 4817.1057 | 8.52%
16384 | 1 | 16 | 9240.5458 | 8419.6905 | 8.88%
16384 | 1 | 32 | 16915.02 | 15405.8986 | 8.92%
16384 | 1 | 64 | 32336.4651 | 29470.4322 | 8.86%
51200 | 1 | 1 | 3291.7604 | 3048.9863 | 7.38%
51200 | 1 | 2 | 6322.2534 | 5568.0176 | 11.93%
51200 | 1 | 4 | 9670.9968 | 8929.3 | 7.67%
51200 | 1 | 8 | 15731.3852 | 14513.4445 | 7.74%
51200 | 1 | 16 | 27769.6387 | 25653.0696 | 7.62%
51200 | 1 | 32 | 51230.748 | 47333.5978 | 7.61%
51200 | 1 | 64 | 98177.4555 | 94284.6681 | 3.97%
  |   |   |   |   | 9.06%

</byte-sheet-html-origin><!--EndFragment-->


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->