### PR TITLE
fix(dcu): use runtime server args in Qwen3.5 paths

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -586,8 +586,8 @@ class LayerCommunicator:
                         hidden_states, residual
                     )
             else:
-                enable_dp_attention = get_global_server_args().enable_dp_attention
-                moe_a2a_backend = get_global_server_args().moe_a2a_backend
+                enable_dp_attention = get_server_args().enable_dp_attention
+                moe_a2a_backend = get_server_args().moe_a2a_backend
                 if residual is None:
                     residual = hidden_states
 
@@ -637,7 +637,7 @@ class LayerCommunicator:
                             self.input_layernorm.weight.data,
                             self.input_layernorm.variance_epsilon,
                         )
-                    elif _use_fused_bailing_rms_quant and (enable_dp_attention is None or moe_a2a_backend is None) and get_global_server_args().ep_size == 1 and get_global_server_args().dp_size == 1: 
+                    elif _use_fused_bailing_rms_quant and (enable_dp_attention is None or moe_a2a_backend is None) and get_server_args().ep_size == 1 and get_server_args().dp_size == 1:
                         out_fp8, out_bs = rms_norm_per_token_fp8_quant(
                             hidden_states,
                             self.input_layernorm.weight,
@@ -702,7 +702,7 @@ class LayerCommunicator:
                             self.input_layernorm.variance_epsilon,
                             residual=residual,
                         )
-                    elif _use_fused_bailing_rms_quant and get_global_server_args().ep_size == 1 and get_global_server_args().dp_size == 1:
+                    elif _use_fused_bailing_rms_quant and get_server_args().ep_size == 1 and get_server_args().dp_size == 1:
                         out_fp8, out_bs = rms_norm_per_token_fp8_quant(
                             hidden_states,
                             self.input_layernorm.weight,

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -876,11 +876,11 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
 
         self.alt_stream = alt_stream
         self.page_size = 64
-        if get_global_server_args().kv_cache_dtype == "fp8_e4m3":
+        if get_server_args().kv_cache_dtype == "fp8_e4m3":
             self.kv_cache_dtype = torch.float8_e4m3fn
-        elif get_global_server_args().kv_cache_dtype == "fp8_e5m2":
+        elif get_server_args().kv_cache_dtype == "fp8_e5m2":
             self.kv_cache_dtype = torch.float8_e5m2
-        elif get_global_server_args().kv_cache_dtype in ("bf16", "bfloat16"):
+        elif get_server_args().kv_cache_dtype in ("bf16", "bfloat16"):
             self.kv_cache_dtype = torch.bfloat16
 
     def _apply_qk_norm(


### PR DESCRIPTION
## Summary

Fix Qwen3.5 runtime failures caused by stale `get_global_server_args()` usages after the SGLang v0.5.15 runtime-context migration.

## Changes

- Replace `get_global_server_args()` with `get_server_args()` in:
  - `python/sglang/srt/models/qwen3_5.py`
  - `python/sglang/srt/layers/communicator.py`
- Keep the existing KV-cache dtype, DP attention, MoE backend, EP and DP logic unchanged.
- Remove one trailing whitespace while updating `communicator.py`.

## Root Cause

SGLang v0.5.15 exposes process-wide server arguments through `runtime_context.get_server_args()`. Some Qwen3.5 and communication paths still referenced the legacy accessor without importing it, causing `NameError` during model initialization or CUDA Graph capture.

Example errors:

```text
NameError: name 'get_global_server_args' is not defined

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->