### PR TITLE
修复DeepseekV4精度问题

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -1032,7 +1032,18 @@ class DeepEPMoE(FusedMoE):
         )
         del input_tensor
 
-        q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant(gateup_output, fp8type=0)
+        swiglu_limit = self.moe_runner_config.swiglu_limit
+        if swiglu_limit is None:
+            q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant(
+                gateup_output,
+                fp8type=0,
+            )
+        else:
+            q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant(
+                gateup_output,
+                fp8type=0,
+                limit=swiglu_limit,
+            )
         del gateup_output
 
         down_output = torch.empty(
@@ -1618,9 +1629,21 @@ class DeepEPMoE(FusedMoE):
             expected_m,
         )
 
-        q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant_ep(input=gateup_output,
-                                                          fp8type=0,
-                                                          tokens_per_expert=masked_m)
+        swiglu_limit = self.moe_runner_config.swiglu_limit
+        if swiglu_limit is None:
+            q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant_ep(
+                input=gateup_output,
+                fp8type=0,
+                tokens_per_expert=masked_m,
+            )
+        else:
+            q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant_ep(
+                input=gateup_output,
+                fp8type=0,
+                tokens_per_expert=masked_m,
+                limit=swiglu_limit,
+            )
+            
         # The first-stage BF16 activation is no longer needed after quantization.
         # Releasing it here lowers peak memory during low-latency graph capture.
         del gateup_output


### PR DESCRIPTION
1、修复两个gemm之间的激活算子没有传入swiglu limit导致的deepseek v4模型精度掉点问题
2、lightop需要更新到0722之后的版本

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->