### PR TITLE
ci(hcu): add MiniMax-M2.7 two-node PD smoke

### DIFF
--- a/.github/workflows/hcu-pd-1p1d.yml
+++ b/.github/workflows/hcu-pd-1p1d.yml
@@ -1,0 +1,208 @@
+name: HCU MiniMax-M2.7 1P1D
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref, branch, tag, or SHA to test"
+        required: false
+        type: string
+        default: ""
+      image:
+        description: "HCU CI container image override"
+        required: false
+        type: string
+        default: ""
+      model_path:
+        description: "Shared MiniMax-M2.7 model path override"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hcu-pd-1p1d
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve HCU PD configuration
+    runs-on: ${{ vars.HCU_PD_PREFILL_RUNNER_LABEL }}
+    timeout-minutes: 30
+    outputs:
+      full_sha: ${{ steps.resolve.outputs.full_sha }}
+      target_ref: ${{ steps.resolve.outputs.target_ref }}
+      image: ${{ steps.resolve.outputs.image }}
+      image_id: ${{ steps.resolve.outputs.image_id }}
+      model_path: ${{ steps.resolve.outputs.model_path }}
+    steps:
+      - name: Validate variables and resolve immutable inputs
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_REF: ${{ inputs.ref || '' }}
+          INPUT_IMAGE: ${{ inputs.image || '' }}
+          INPUT_MODEL_PATH: ${{ inputs.model_path || '' }}
+          VAR_IMAGE: ${{ vars.HCU_CI_IMAGE || '' }}
+          PREFILL_RUNNER_LABEL: ${{ vars.HCU_PD_PREFILL_RUNNER_LABEL || '' }}
+          DECODE_RUNNER_LABEL: ${{ vars.HCU_PD_DECODE_RUNNER_LABEL || '' }}
+          PREFILL_IP: ${{ vars.HCU_PD_PREFILL_IP || '' }}
+          DECODE_IP: ${{ vars.HCU_PD_DECODE_IP || '' }}
+          PREFILL_IFNAME: ${{ vars.HCU_PD_PREFILL_IFNAME || '' }}
+          DECODE_IFNAME: ${{ vars.HCU_PD_DECODE_IFNAME || '' }}
+          PREFILL_IB_DEVICE: ${{ vars.HCU_PD_PREFILL_IB_DEVICE || '' }}
+          DECODE_IB_DEVICE: ${{ vars.HCU_PD_DECODE_IB_DEVICE || '' }}
+        run: |
+          set -euo pipefail
+
+          declare -A required_variables=(
+            [HCU_PD_PREFILL_RUNNER_LABEL]="${PREFILL_RUNNER_LABEL}"
+            [HCU_PD_DECODE_RUNNER_LABEL]="${DECODE_RUNNER_LABEL}"
+            [HCU_PD_PREFILL_IP]="${PREFILL_IP}"
+            [HCU_PD_DECODE_IP]="${DECODE_IP}"
+            [HCU_PD_PREFILL_IFNAME]="${PREFILL_IFNAME}"
+            [HCU_PD_DECODE_IFNAME]="${DECODE_IFNAME}"
+            [HCU_PD_PREFILL_IB_DEVICE]="${PREFILL_IB_DEVICE}"
+            [HCU_PD_DECODE_IB_DEVICE]="${DECODE_IB_DEVICE}"
+          )
+          for variable in "${!required_variables[@]}"; do
+            if [[ -z "${required_variables[${variable}]}" ]]; then
+              echo "::error::Repository variable ${variable} is empty."
+              exit 1
+            fi
+          done
+
+          target_ref="${INPUT_REF:-${GITHUB_SHA}}"
+          image="${INPUT_IMAGE:-${VAR_IMAGE}}"
+          model_path="${INPUT_MODEL_PATH:-/public/opendas/DL_DATA/llm-models/MiniMax-M2.7-Channel-FP8-w8a8}"
+          if [[ -z "${image}" ]]; then
+            echo "::error::Set vars.HCU_CI_IMAGE or provide the image input."
+            exit 1
+          fi
+
+          checkout_dir="${RUNNER_TEMP}/hcu-pd-resolve-${GITHUB_RUN_ID}"
+          rm -rf "${checkout_dir}"
+          git init "${checkout_dir}"
+          git -C "${checkout_dir}" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          auth="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
+          git \
+            -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth}" \
+            -c http.https://github.com.proxy= \
+            -c http.proxy= \
+            -c https.proxy= \
+            -C "${checkout_dir}" \
+            fetch --no-tags --depth=1 origin "${target_ref}"
+          full_sha="$(git -C "${checkout_dir}" rev-parse FETCH_HEAD)"
+
+          docker pull "${image}"
+          image_id="$(docker image inspect --format '{{.Id}}' "${image}")"
+
+          {
+            echo "full_sha=${full_sha}"
+            echo "target_ref=${target_ref}"
+            echo "image=${image}"
+            echo "image_id=${image_id}"
+            echo "model_path=${model_path}"
+          } >> "${GITHUB_OUTPUT}"
+
+  run-pd:
+    name: MiniMax-M2.7 ${{ matrix.role }}
+    needs: resolve
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          - role: prefill
+            runner_label: ${{ vars.HCU_PD_PREFILL_RUNNER_LABEL }}
+            local_ip: ${{ vars.HCU_PD_PREFILL_IP }}
+            peer_ip: ${{ vars.HCU_PD_DECODE_IP }}
+            ifname: ${{ vars.HCU_PD_PREFILL_IFNAME }}
+            ib_device: ${{ vars.HCU_PD_PREFILL_IB_DEVICE }}
+          - role: decode
+            runner_label: ${{ vars.HCU_PD_DECODE_RUNNER_LABEL }}
+            local_ip: ${{ vars.HCU_PD_DECODE_IP }}
+            peer_ip: ${{ vars.HCU_PD_PREFILL_IP }}
+            ifname: ${{ vars.HCU_PD_DECODE_IFNAME }}
+            ib_device: ${{ vars.HCU_PD_DECODE_IB_DEVICE }}
+    runs-on: ${{ matrix.runner_label }}
+    env:
+      HCU_PD_SHA: ${{ needs.resolve.outputs.full_sha }}
+      HCU_PD_TARGET_REF: ${{ needs.resolve.outputs.target_ref }}
+      HCU_PD_IMAGE: ${{ needs.resolve.outputs.image }}
+      HCU_PD_IMAGE_ID: ${{ needs.resolve.outputs.image_id }}
+      SGLANG_HCU_MINIMAX_M27_MODEL: ${{ needs.resolve.outputs.model_path }}
+      HCU_PD_PREFILL_IP: ${{ vars.HCU_PD_PREFILL_IP }}
+      HCU_PD_DECODE_IP: ${{ vars.HCU_PD_DECODE_IP }}
+      HCU_PD_LOCAL_IP: ${{ matrix.local_ip }}
+      HCU_PD_PEER_IP: ${{ matrix.peer_ip }}
+      HCU_PD_LOCAL_IFNAME: ${{ matrix.ifname }}
+      HCU_PD_LOCAL_IB_DEVICE: ${{ matrix.ib_device }}
+      HCU_PD_GID_INDEX: "3"
+      HCU_PD_SHARED_ROOT: /ci_public/sglang-das/hcu-pd
+      HCU_PD_WHEEL_ROOT: /ci_public/sglang-das/hcu-wheels
+      HCU_PD_SHARED_GID: "1002"
+    steps:
+      - name: Checkout immutable test SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          checkout_dir="${RUNNER_TEMP}/hcu-pd-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.role }}"
+          rm -rf "${checkout_dir}"
+          git init "${checkout_dir}"
+          git -C "${checkout_dir}" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          auth="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
+          git \
+            -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth}" \
+            -c http.https://github.com.proxy= \
+            -c http.proxy= \
+            -c https.proxy= \
+            -C "${checkout_dir}" \
+            fetch --no-tags --depth=1 origin "${HCU_PD_SHA}"
+          git -C "${checkout_dir}" checkout --force FETCH_HEAD
+          actual_sha="$(git -C "${checkout_dir}" rev-parse HEAD)"
+          if [[ "${actual_sha}" != "${HCU_PD_SHA}" ]]; then
+            echo "::error::Checkout SHA mismatch: ${actual_sha} != ${HCU_PD_SHA}"
+            exit 1
+          fi
+          echo "HCU_PD_CHECKOUT=${checkout_dir}" >> "${GITHUB_ENV}"
+
+      - name: Pull and verify the same container image
+        run: |
+          set -euo pipefail
+          docker pull "${HCU_PD_IMAGE}"
+          actual_image_id="$(docker image inspect --format '{{.Id}}' "${HCU_PD_IMAGE}")"
+          if [[ "${actual_image_id}" != "${HCU_PD_IMAGE_ID}" ]]; then
+            echo "::error::Image changed after resolution: ${actual_image_id} != ${HCU_PD_IMAGE_ID}"
+            exit 1
+          fi
+
+      - name: Run coordinated HCU PD smoke
+        run: |
+          set -euo pipefail
+          bash "${HCU_PD_CHECKOUT}/scripts/ci/hcu/hcu_ci_pd_controller.sh" \
+            run --role="${{ matrix.role }}"
+
+      - name: Cleanup exact PD container
+        if: always()
+        run: |
+          if [[ -n "${HCU_PD_CHECKOUT:-}" && -f "${HCU_PD_CHECKOUT}/scripts/ci/hcu/hcu_ci_pd_controller.sh" ]]; then
+            bash "${HCU_PD_CHECKOUT}/scripts/ci/hcu/hcu_ci_pd_controller.sh" \
+              cleanup --role="${{ matrix.role }}"
+          fi
+
+      - name: Add shared result location to summary
+        if: always()
+        run: |
+          {
+            echo "### HCU MiniMax-M2.7 ${{ matrix.role }}"
+            echo
+            echo "- Ref: \`${HCU_PD_TARGET_REF}\`"
+            echo "- SHA: \`${HCU_PD_SHA}\`"
+            echo "- Image ID: \`${HCU_PD_IMAGE_ID}\`"
+            echo "- Shared result: \`${HCU_PD_SHARED_ROOT}/run-${GITHUB_RUN_ID}/attempt-${GITHUB_RUN_ATTEMPT}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/nightly-test-hcu.yml
+++ b/.github/workflows/nightly-test-hcu.yml
@@ -814,7 +814,7 @@ jobs:
       HCU_CI_SKIP_REQUIREMENTS_INSTALL: ${{ vars.HCU_CI_SKIP_REQUIREMENTS_INSTALL || '' }}
       HCU_CI_SKIP_SGLANG_BUILD: ${{ vars.HCU_CI_SKIP_SGLANG_BUILD || '' }}
       HCU_CI_VISIBLE_DEVICES: ${{ matrix.visible_devices || vars.HCU_CI_VISIBLE_DEVICES || '' }}
-      HCU_CI_NETWORK_MODE: ${{ matrix.network_mode || 'host' }}
+      HCU_CI_NETWORK_MODE: ${{ matrix.network_mode || 'bridge' }}
       HCU_MODEL_EXTRA_HOST_PATHS: ${{ matrix.extra_model_paths || '' }}
       SGLANG_HCU_GSM8K_DATA_PATH: /public/opendas/DL_DATA/opencompass_data/gsm8k/test.jsonl
       SGLANG_HCU_MMLU_DATASET_PATH: /public/opendas/DL_DATA/llm-models/datasets/mmlu

--- a/python/sglang/test/hcu_pd_utils.py
+++ b/python/sglang/test/hcu_pd_utils.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+MINIMAX_M27_DEFAULT_MODEL_PATH = (
+    "/public/opendas/DL_DATA/llm-models/MiniMax-M2.7-Channel-FP8-w8a8"
+)
+MINIMAX_M27_MODEL_ENV = "SGLANG_HCU_MINIMAX_M27_MODEL"
+
+PREFILL_PORT = 30000
+DECODE_PORT = 30001
+ROUTER_PORT = 30002
+BOOTSTRAP_PORT = 8998
+
+MINIMAX_M27_COMMON_ENV = {
+    "SGLANG_USE_MODELSCOPE": "1",
+    "USE_HCU_CUSTOM_ALLREDUCE": "1",
+    "SGLANG_USE_AITER_AR": "1",
+    "SGL_CHUNKED_PREFIX_CACHE_THRESHOLD": "0",
+    "SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT": "1200",
+    "GLIBC_TUNABLES": "glibc.rtld.optional_static_tls=0x40000",
+    "SGLANG_USE_LIGHTOP": "1",
+    "VLLM_USE_LIGHTOP_MOE_ALIGN": "1",
+    "LMSLIM_USE_LIGHTOP": "1",
+    "SGLANG_KVALLOC_KERNEL": "1",
+    "SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO": "1",
+    "SGLANG_ASSIGN_EXTEND_CACHE_LOCS": "1",
+    "SGLANG_ASSIGN_REQ_TO_TOKEN_POOL": "1",
+    "SGLANG_GET_LAST_LOC": "1",
+    "SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON": "1",
+    "SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES": "1",
+    "ALLREDUCE_STREAM_WITH_COMPUTE": "1",
+}
+
+
+@dataclass(frozen=True)
+class HcuPDRoleConfig:
+    role: str
+    host_ip: str
+    ifname: str
+    ib_device: str
+
+    def __post_init__(self) -> None:
+        if self.role not in {"prefill", "decode"}:
+            raise ValueError(f"unsupported HCU PD role: {self.role}")
+        for field_name in ("host_ip", "ifname", "ib_device"):
+            if not getattr(self, field_name).strip():
+                raise ValueError(f"{field_name} must not be empty")
+
+    @property
+    def port(self) -> int:
+        return PREFILL_PORT if self.role == "prefill" else DECODE_PORT
+
+
+def resolve_minimax_m27_model_path() -> str:
+    return os.environ.get(MINIMAX_M27_MODEL_ENV, MINIMAX_M27_DEFAULT_MODEL_PATH).rstrip(
+        "/"
+    )
+
+
+def minimax_m27_pd_env(
+    role: HcuPDRoleConfig, *, gid_index: str = "3"
+) -> dict[str, str]:
+    env = dict(MINIMAX_M27_COMMON_ENV)
+    env.update(
+        {
+            "SGLANG_HOST_IP": role.host_ip,
+            "NCCL_SOCKET_IFNAME": role.ifname,
+            "GLOO_SOCKET_IFNAME": role.ifname,
+            "NCCL_IB_HCA": role.ib_device,
+            "MC_GID_INDEX": gid_index,
+        }
+    )
+    return env
+
+
+def _common_server_args(role: HcuPDRoleConfig, model_path: str) -> list[str]:
+    return [
+        "--model-path",
+        model_path,
+        "--quantization",
+        "w8a8_fp8",
+        "--kv-cache-dtype",
+        "fp8_e4m3",
+        "--trust-remote-code",
+        "--page-size",
+        "64",
+        "--dtype",
+        "bfloat16",
+        "--tool-call-parser",
+        "minimax-m2",
+        "--reasoning-parser",
+        "minimax-append-think",
+        "--mem-fraction-static",
+        "0.9",
+        "--attention-backend",
+        "fa3",
+        "--numa-node",
+        "0",
+        "0",
+        "0",
+        "0",
+        "1",
+        "1",
+        "1",
+        "1",
+        "--max-running-requests",
+        "512",
+        "--context-length",
+        "131072",
+        "--watchdog-timeout",
+        "3600",
+        "--disaggregation-mode",
+        role.role,
+        "--disaggregation-transfer-backend",
+        "mooncake",
+        "--disaggregation-bootstrap-port",
+        str(BOOTSTRAP_PORT),
+        "--disaggregation-ib-device",
+        role.ib_device,
+        "--host",
+        role.host_ip,
+        "--port",
+        str(role.port),
+        "--log-level",
+        "warning",
+        "--log-level-http",
+        "warning",
+    ]
+
+
+def minimax_m27_server_args(role: HcuPDRoleConfig, model_path: str) -> list[str]:
+    args = _common_server_args(role, model_path)
+    if role.role == "prefill":
+        args.extend(
+            [
+                "--tp-size",
+                "2",
+                "--pp-size",
+                "4",
+                "--dp-size",
+                "1",
+                "--chunked-prefill-size",
+                "4096",
+                "--load-balance-method",
+                "round_robin",
+            ]
+        )
+    else:
+        args.extend(
+            [
+                "--tp-size",
+                "8",
+                "--pp-size",
+                "1",
+                "--dp-size",
+                "1",
+                "--prefill-round-robin-balance",
+            ]
+        )
+    return args
+
+
+def minimax_m27_server_command(role: HcuPDRoleConfig, model_path: str) -> list[str]:
+    return [
+        "python3",
+        "-m",
+        "sglang.launch_server",
+        *minimax_m27_server_args(role, model_path),
+    ]
+
+
+def minimax_m27_router_command(prefill_ip: str, decode_ip: str) -> list[str]:
+    return [
+        "python3",
+        "-m",
+        "sglang_router.launch_router",
+        "--pd-disaggregation",
+        "--prefill",
+        f"http://{prefill_ip}:{PREFILL_PORT}",
+        str(BOOTSTRAP_PORT),
+        "--decode",
+        f"http://{decode_ip}:{DECODE_PORT}",
+        "--policy",
+        "cache_aware",
+        "--host",
+        prefill_ip,
+        "--port",
+        str(ROUTER_PORT),
+    ]

--- a/python/sglang/test/hcu_pd_utils.py
+++ b/python/sglang/test/hcu_pd_utils.py
@@ -1,16 +1,5 @@
-# Copyright 2026 Hygon Information Technology Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 

--- a/scripts/ci/hcu/hcu_ci_build_shared_wheels.sh
+++ b/scripts/ci/hcu/hcu_ci_build_shared_wheels.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+umask 0002
+
+MODE="${1:-}"
+if [[ "${MODE}" != "build" && "${MODE}" != "wait" ]]; then
+  echo "Usage: $0 build|wait" >&2
+  exit 2
+fi
+
+SHA="${HCU_PD_SHA:?HCU_PD_SHA is required}"
+CHECKOUT="${HCU_PD_CHECKOUT:-${GITHUB_WORKSPACE:-$PWD}}"
+IMAGE="${HCU_PD_IMAGE:?HCU_PD_IMAGE is required}"
+BUILD_IMAGE="${HCU_PD_BUILD_IMAGE:-harbor.sourcefind.cn:5443/dcu/admin/base/dev:rockylinux8.6-mpi5.0-gcc10.3-cmake3.29-py3.10-mkl2020.4.304}"
+WHEEL_ROOT="${HCU_PD_WHEEL_ROOT:-/ci_public/sglang-das/hcu-wheels}"
+WAIT_TIMEOUT="${HCU_PD_WHEEL_TIMEOUT:-10800}"
+SHARED_GID="${HCU_PD_SHARED_GID:-1002}"
+
+if [[ ! "${SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "HCU_PD_SHA must be a full lowercase Git SHA: ${SHA}" >&2
+  exit 2
+fi
+if [[ ! -d "${CHECKOUT}/python" || ! -d "${CHECKOUT}/sgl-kernel" ]]; then
+  echo "Invalid HCU PD checkout: ${CHECKOUT}" >&2
+  exit 2
+fi
+
+FINAL_DIR="${WHEEL_ROOT}/${SHA}"
+PIP_INDEX_URL="${HCU_PD_PIP_INDEX_URL:-http://10.16.1.201:9929/nightly/dtk2604/+simple/}"
+PIP_TRUSTED_HOST="${HCU_PD_PIP_TRUSTED_HOST:-10.16.1.201}"
+TORCH_VERSION="${HCU_PD_TORCH_VERSION:-2.10.0}"
+RESOURCE_SERVER="${HCU_PD_RESOURCE_SERVER:-http://10.16.1.201:8000}"
+DTK_PKG_URL="${HCU_PD_DTK_PKG_URL:-${RESOURCE_SERVER}/dtk-pkg/dtk26.04/DTK-26.04-rc4-centos8-x86_64.tar.gz}"
+PROTOC_URL="${HCU_PD_PROTOC_URL:-${RESOURCE_SERVER}/Jenkins/CompileDep/sglang/protoc-24.4-linux-x86_64.zip}"
+RUSTUP_INIT_URL="${HCU_PD_RUSTUP_INIT_URL:-${RESOURCE_SERVER}/Jenkins/CompileDep/sglang/rustup-init.sh}"
+RUSTUP_DIST_SERVER="${HCU_PD_RUSTUP_DIST_SERVER:-https://mirrors.tuna.tsinghua.edu.cn/rustup}"
+RUSTUP_UPDATE_ROOT="${HCU_PD_RUSTUP_UPDATE_ROOT:-https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup}"
+
+mkdir -p "${WHEEL_ROOT}"
+chmod 2775 "${WHEEL_ROOT}" || true
+chgrp "${SHARED_GID}" "${WHEEL_ROOT}" || true
+
+validate_bundle() {
+  local bundle_dir="$1"
+  python3 - "${bundle_dir}" "${SHA}" <<'PY_VALIDATE'
+import json
+import pathlib
+import sys
+
+bundle = pathlib.Path(sys.argv[1])
+expected_sha = sys.argv[2]
+manifest_path = bundle / "manifest.json"
+ready_path = bundle / "READY"
+if not ready_path.is_file() or not manifest_path.is_file():
+    raise SystemExit(1)
+manifest = json.loads(manifest_path.read_text())
+if manifest.get("commit_sha") != expected_sha:
+    raise SystemExit(1)
+kinds = {item.get("kind") for item in manifest.get("wheels", [])}
+if kinds != {"sglang", "sglang-kernel", "sglang-router"}:
+    raise SystemExit(1)
+for item in manifest["wheels"]:
+    path = bundle / item["path"]
+    if not path.is_file():
+        raise SystemExit(1)
+PY_VALIDATE
+}
+
+wait_for_bundle() {
+  local deadline=$((SECONDS + WAIT_TIMEOUT))
+  while (( SECONDS < deadline )); do
+    if validate_bundle "${FINAL_DIR}" 2>/dev/null; then
+      echo "${FINAL_DIR}"
+      return 0
+    fi
+    sleep 10
+  done
+  echo "Timed out waiting for shared HCU wheels: ${FINAL_DIR}" >&2
+  return 1
+}
+
+if validate_bundle "${FINAL_DIR}" 2>/dev/null; then
+  echo "Reusing shared HCU wheel bundle: ${FINAL_DIR}" >&2
+  echo "${FINAL_DIR}"
+  exit 0
+fi
+
+if [[ "${MODE}" == "wait" ]]; then
+  wait_for_bundle
+  exit $?
+fi
+
+RUN_KEY="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+LOCK_DIR="${WHEEL_ROOT}/.${SHA}.lock"
+TEMP_DIR="${WHEEL_ROOT}/.${SHA}.tmp-${RUN_KEY}-$$"
+
+if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+  echo "Another process is publishing ${SHA}; waiting for READY." >&2
+  wait_for_bundle
+  exit $?
+fi
+
+cleanup_build_state() {
+  if [[ -d "${TEMP_DIR}" ]]; then
+    rm -rf -- "${TEMP_DIR}"
+  fi
+  rmdir "${LOCK_DIR}" 2>/dev/null || true
+}
+trap cleanup_build_state EXIT INT TERM
+
+mkdir -p "${TEMP_DIR}/wheels"
+chmod 2775 "${TEMP_DIR}" "${TEMP_DIR}/wheels" || true
+chgrp "${SHARED_GID}" "${TEMP_DIR}" "${TEMP_DIR}/wheels" || true
+
+PACKAGE_VERSION="0.5.12+pd.g${SHA:0:12}"
+DTK_VERSION="$(
+  printf '%s' "${DTK_PKG_URL}" \
+    | grep -oP 'dtk\K[0-9]+\.[0-9]+' \
+    | head -1 \
+    | tr -d '.'
+)"
+if [[ -z "${DTK_VERSION}" ]]; then
+  echo "Cannot derive the DTK version from ${DTK_PKG_URL}" >&2
+  exit 2
+fi
+LOCAL_VERSION="das.dtk${DTK_VERSION}.torch${TORCH_VERSION//./}.g${SHA:0:12}"
+echo "Building HCU PD wheels for ${SHA} with ${BUILD_IMAGE}" >&2
+
+docker run --rm \
+  --network host \
+  --ipc host \
+  --privileged \
+  --user root \
+  -e "HCU_PD_PACKAGE_VERSION=${PACKAGE_VERSION}" \
+  -e "HCU_PD_LOCAL_VERSION=${LOCAL_VERSION}" \
+  -e "PIP_INDEX_URL=${PIP_INDEX_URL}" \
+  -e "PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST}" \
+  -e "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" \
+  -e "CARGO_NET_GIT_FETCH_WITH_CLI=true" \
+  -e "GIT_TERMINAL_PROMPT=0" \
+  -e "HCU_PD_TORCH_VERSION=${TORCH_VERSION}" \
+  -e "HCU_PD_DTK_PKG_URL=${DTK_PKG_URL}" \
+  -e "HCU_PD_PROTOC_URL=${PROTOC_URL}" \
+  -e "HCU_PD_RUSTUP_INIT_URL=${RUSTUP_INIT_URL}" \
+  -e "RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER}" \
+  -e "RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT}" \
+  -v "${CHECKOUT}:/source:ro" \
+  -v "${TEMP_DIR}:/publish" \
+  "${BUILD_IMAGE}" \
+  bash -lc '
+    set -euo pipefail
+    mkdir -p /root/.cargo
+    cat > /root/.cargo/config << "EOF_CARGO"
+[source.crates-io]
+replace-with = "rsproxy-sparse"
+
+[source.rsproxy-sparse]
+registry = "sparse+https://rsproxy.cn/index/"
+
+[net]
+retry = 5
+git-fetch-with-cli = true
+
+[http]
+low-speed-limit = 1
+EOF_CARGO
+    python3 -m pip install --no-cache-dir \
+      "torch==${HCU_PD_TORCH_VERSION}" \
+      build \
+      scikit-build-core \
+      cmake \
+      ninja \
+      wheel \
+      setuptools \
+      setuptools-scm \
+      setuptools-rust \
+      "maturin==1.9.6" \
+      ciupload \
+      auditwheel \
+      patchelf
+    wget -q "${HCU_PD_PROTOC_URL}" -O /tmp/protoc.zip
+    unzip -q -o /tmp/protoc.zip -d /usr/local
+    chmod +x /usr/local/bin/protoc
+    ln -sf /usr/local/bin/protoc /usr/bin/protoc
+    wget -q "${HCU_PD_RUSTUP_INIT_URL}" -O /tmp/rustup-init.sh
+    bash /tmp/rustup-init.sh -y
+    source /root/.cargo/env
+
+    wget -q "${HCU_PD_DTK_PKG_URL}" -O /tmp/dtk.tar.gz
+    rm -rf /opt/dtk /opt/dtk-*
+    tar -xzf /tmp/dtk.tar.gz -C /opt
+    mv /opt/dtk-* /opt/dtk
+    set +u
+    source /opt/dtk/env.sh
+    set -u
+    rustc --version
+    cargo --version
+    rm -rf /tmp/sglang-pd-source
+    mkdir -p /tmp/sglang-pd-source
+    mkdir -p /tmp/raw-wheels
+    cp -a /source/. /tmp/sglang-pd-source/
+
+    cd /tmp/sglang-pd-source/sgl-kernel
+    rm -rf build dist
+    SETUPTOOLS_SCM_PRETEND_VERSION="${HCU_PD_PACKAGE_VERSION}" \
+      python3 setup_hip.py bdist_wheel
+    cp -v dist/*.whl /tmp/raw-wheels/
+
+    cd /tmp/sglang-pd-source/python
+    rm -rf build dist
+    SETUPTOOLS_SCM_PRETEND_VERSION="${HCU_PD_PACKAGE_VERSION}" \
+      python3 -m build --wheel --no-isolation -Cfeatures=all_hip
+    cp -v dist/*.whl /tmp/raw-wheels/
+
+    cd /tmp/sglang-pd-source/sgl-model-gateway/bindings/python
+    RUSTUP_TOOLCHAIN=stable maturin build --release --skip-auditwheel
+    cp -v target/wheels/*.whl /tmp/raw-wheels/
+
+    mkdir -p /tmp/ci-repaired-wheels
+    for wheel in /tmp/raw-wheels/*.whl; do
+      CIUpload \
+        --repair \
+        --torch_version "${HCU_PD_TORCH_VERSION}" \
+        --set_local_version "${HCU_PD_LOCAL_VERSION}" \
+        --outputdir /tmp/ci-repaired-wheels \
+        -f "${wheel}"
+    done
+    for wheel in /tmp/ci-repaired-wheels/*.whl; do
+      if [[ "$(basename "${wheel}")" == sglang_router-* ]]; then
+        auditwheel repair \
+          --plat manylinux_2_28_x86_64 \
+          --wheel-dir /publish/wheels \
+          "${wheel}"
+      else
+        cp -v "${wheel}" /publish/wheels/
+      fi
+    done
+  '
+
+export SHA IMAGE BUILD_IMAGE PACKAGE_VERSION LOCAL_VERSION TEMP_DIR
+python3 - <<'PY_MANIFEST'
+import hashlib
+import json
+import os
+import pathlib
+
+temp_dir = pathlib.Path(os.environ["TEMP_DIR"])
+wheel_dir = temp_dir / "wheels"
+
+
+def wheel_kind(path: pathlib.Path) -> str | None:
+    name = path.name.lower().replace("-", "_")
+    if name.startswith("sglang_router_"):
+        return "sglang-router"
+    if name.startswith(("sglang_kernel_", "sgl_kernel_")):
+        return "sglang-kernel"
+    if name.startswith("sglang_"):
+        return "sglang"
+    return None
+
+
+found = {}
+for wheel in sorted(wheel_dir.glob("*.whl")):
+    kind = wheel_kind(wheel)
+    if kind is None:
+        continue
+    if kind in found:
+        raise SystemExit(f"duplicate {kind} wheels: {found[kind]} and {wheel}")
+    found[kind] = wheel
+
+expected = {"sglang", "sglang-kernel", "sglang-router"}
+if set(found) != expected:
+    raise SystemExit(f"wheel bundle mismatch: expected={expected}, found={set(found)}")
+
+wheels = []
+for kind in sorted(found):
+    path = found[kind]
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    wheels.append(
+        {
+            "kind": kind,
+            "path": str(path.relative_to(temp_dir)),
+            "filename": path.name,
+            "sha256": digest,
+            "size": path.stat().st_size,
+            "source": "repository-build",
+        }
+    )
+
+manifest = {
+    "repository": os.environ.get("GITHUB_REPOSITORY", ""),
+    "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+    "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+    "commit_sha": os.environ["SHA"],
+    "image": os.environ["IMAGE"],
+    "build_image": os.environ["BUILD_IMAGE"],
+    "package_version": os.environ["PACKAGE_VERSION"],
+    "local_version": os.environ["LOCAL_VERSION"],
+    "wheels": wheels,
+}
+(temp_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+PY_MANIFEST
+
+find "${TEMP_DIR}" -type d -exec chmod 2775 {} +
+find "${TEMP_DIR}" -type f -exec chmod 0664 {} +
+chgrp -R "${SHARED_GID}" "${TEMP_DIR}" || true
+printf '%s\n' "${SHA}" > "${TEMP_DIR}/READY"
+chmod 0664 "${TEMP_DIR}/READY"
+chgrp "${SHARED_GID}" "${TEMP_DIR}/READY" || true
+
+if [[ -e "${FINAL_DIR}" ]]; then
+  INVALID_DIR="${WHEEL_ROOT}/.${SHA}.invalid-$(date +%s)"
+  mv "${FINAL_DIR}" "${INVALID_DIR}"
+fi
+mv "${TEMP_DIR}" "${FINAL_DIR}"
+rmdir "${LOCK_DIR}" 2>/dev/null || true
+trap - EXIT INT TERM
+
+validate_bundle "${FINAL_DIR}"
+echo "Published shared HCU wheel bundle: ${FINAL_DIR}" >&2
+echo "${FINAL_DIR}"

--- a/scripts/ci/hcu/hcu_ci_build_shared_wheels.sh
+++ b/scripts/ci/hcu/hcu_ci_build_shared_wheels.sh
@@ -1,17 +1,6 @@
-#!/bin/bash
-# Copyright 2026 Hygon Information Technology Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#!/usr/bin/env bash
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 umask 0002

--- a/scripts/ci/hcu/hcu_ci_pd.py
+++ b/scripts/ci/hcu/hcu_ci_pd.py
@@ -1,17 +1,6 @@
 #!/usr/bin/env python3
-# Copyright 2026 Hygon Information Technology Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 

--- a/scripts/ci/hcu/hcu_ci_pd.py
+++ b/scripts/ci/hcu/hcu_ci_pd.py
@@ -1,0 +1,1265 @@
+#!/usr/bin/env python3
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import ipaddress
+import json
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HCU_PD_UTILS_PATH = REPO_ROOT / "python/sglang/test/hcu_pd_utils.py"
+HCU_PD_UTILS_SPEC = importlib.util.spec_from_file_location(
+    "_sglang_hcu_pd_utils", HCU_PD_UTILS_PATH
+)
+if HCU_PD_UTILS_SPEC is None or HCU_PD_UTILS_SPEC.loader is None:
+    raise RuntimeError(f"cannot load HCU PD utilities from {HCU_PD_UTILS_PATH}")
+HCU_PD_UTILS = importlib.util.module_from_spec(HCU_PD_UTILS_SPEC)
+sys.modules[HCU_PD_UTILS_SPEC.name] = HCU_PD_UTILS
+HCU_PD_UTILS_SPEC.loader.exec_module(HCU_PD_UTILS)
+
+BOOTSTRAP_PORT = HCU_PD_UTILS.BOOTSTRAP_PORT
+DECODE_PORT = HCU_PD_UTILS.DECODE_PORT
+MINIMAX_M27_MODEL_ENV = HCU_PD_UTILS.MINIMAX_M27_MODEL_ENV
+PREFILL_PORT = HCU_PD_UTILS.PREFILL_PORT
+ROUTER_PORT = HCU_PD_UTILS.ROUTER_PORT
+HcuPDRoleConfig = HCU_PD_UTILS.HcuPDRoleConfig
+minimax_m27_pd_env = HCU_PD_UTILS.minimax_m27_pd_env
+minimax_m27_router_command = HCU_PD_UTILS.minimax_m27_router_command
+minimax_m27_server_args = HCU_PD_UTILS.minimax_m27_server_args
+minimax_m27_server_command = HCU_PD_UTILS.minimax_m27_server_command
+resolve_minimax_m27_model_path = HCU_PD_UTILS.resolve_minimax_m27_model_path
+
+ROLE_PREFILL = "prefill"
+ROLE_DECODE = "decode"
+VALID_ROLES = {ROLE_PREFILL, ROLE_DECODE}
+COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+RUN_DIR_RE = re.compile(r"^run-[0-9]+$")
+
+
+class PDInfrastructureError(RuntimeError):
+    pass
+
+
+class PDPeerAbort(PDInfrastructureError):
+    pass
+
+
+def _now_payload() -> dict[str, Any]:
+    return {
+        "timestamp": time.time(),
+        "timestamp_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise PDInfrastructureError(f"required environment variable is empty: {name}")
+    return value
+
+
+def _safe_component(name: str, value: str) -> str:
+    if not COMPONENT_RE.fullmatch(value):
+        raise PDInfrastructureError(f"unsafe {name}: {value!r}")
+    return value
+
+
+def _set_shared_permissions(path: Path, *, is_dir: bool, gid: int) -> None:
+    desired_mode = 0o2775 if is_dir else 0o664
+    required_group_mode = 0o070 if is_dir else 0o060
+
+    try:
+        path.chmod(desired_mode)
+        if (
+            hasattr(os, "chown")
+            and hasattr(os, "getgid")
+            and hasattr(os, "getgroups")
+            and gid in {os.getgid(), *os.getgroups()}
+        ):
+            os.chown(path, -1, gid)
+    except PermissionError:
+        pass
+
+    stat_result = path.stat()
+    if os.name == "posix" and (
+        stat_result.st_gid != gid
+        or stat_result.st_mode & required_group_mode != required_group_mode
+    ):
+        raise PDInfrastructureError(
+            f"shared path has incompatible ownership or mode: {path} "
+            f"gid={stat_result.st_gid}, mode={oct(stat_result.st_mode & 0o7777)}, "
+            f"expected gid={gid} with group "
+            f"{'rwx' if is_dir else 'rw'} permission"
+        )
+
+
+def ensure_shared_dir(path: Path, gid: int) -> None:
+    missing_paths = []
+    cursor = path
+    while not cursor.exists():
+        missing_paths.append(cursor)
+        cursor = cursor.parent
+    path.mkdir(parents=True, exist_ok=True)
+    if not missing_paths:
+        _set_shared_permissions(path, is_dir=True, gid=gid)
+        return
+    for created_path in reversed(missing_paths):
+        _set_shared_permissions(created_path, is_dir=True, gid=gid)
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any], gid: int) -> None:
+    ensure_shared_dir(path.parent, gid)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        )
+        _set_shared_permissions(temporary, is_dir=False, gid=gid)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def write_json_once(path: Path, payload: dict[str, Any], gid: int) -> bool:
+    ensure_shared_dir(path.parent, gid)
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o664)
+    except FileExistsError:
+        return False
+    with os.fdopen(descriptor, "w") as stream:
+        json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+        stream.write("\n")
+    _set_shared_permissions(path, is_dir=False, gid=gid)
+    return True
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PDInfrastructureError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PDInfrastructureError(f"JSON object expected in {path}")
+    return payload
+
+
+def run_checked(
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+) -> str:
+    completed = subprocess.run(
+        command,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise PDInfrastructureError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n"
+            f"{completed.stdout[-8000:]}"
+        )
+    return completed.stdout.strip()
+
+
+@dataclass(frozen=True)
+class PDRunContext:
+    role: str
+    run_id: str
+    attempt: str
+    sha: str
+    target_ref: str
+    runner_name: str
+    hostname: str
+    image: str
+    image_id: str
+    model_path: str
+    local_ip: str
+    peer_ip: str
+    prefill_ip: str
+    decode_ip: str
+    ifname: str
+    ib_device: str
+    gid_index: str
+    checkout: Path
+    shared_root: Path
+    wheel_root: Path
+    shared_gid: int
+    peer_timeout: int
+    service_timeout: int
+    heartbeat_timeout: int
+    completion_timeout: int
+
+    @classmethod
+    def from_environment(cls, role: str) -> "PDRunContext":
+        if role not in VALID_ROLES:
+            raise PDInfrastructureError(f"unsupported role: {role}")
+        run_id = _safe_component("run ID", _require_env("GITHUB_RUN_ID"))
+        attempt = _safe_component(
+            "run attempt", os.environ.get("GITHUB_RUN_ATTEMPT", "1")
+        )
+        sha = _require_env("HCU_PD_SHA").lower()
+        if not SHA_RE.fullmatch(sha):
+            raise PDInfrastructureError(f"HCU_PD_SHA must be a full Git SHA: {sha}")
+
+        prefill_ip = _require_env("HCU_PD_PREFILL_IP")
+        decode_ip = _require_env("HCU_PD_DECODE_IP")
+        expected_local_ip = prefill_ip if role == ROLE_PREFILL else decode_ip
+        expected_peer_ip = decode_ip if role == ROLE_PREFILL else prefill_ip
+        local_ip = _require_env("HCU_PD_LOCAL_IP")
+        peer_ip = _require_env("HCU_PD_PEER_IP")
+        if local_ip != expected_local_ip or peer_ip != expected_peer_ip:
+            raise PDInfrastructureError(
+                f"role IP mismatch for {role}: local={local_ip}, peer={peer_ip}, "
+                f"expected local={expected_local_ip}, peer={expected_peer_ip}"
+            )
+        gid_index = os.environ.get("HCU_PD_GID_INDEX", "3").strip()
+        if not gid_index.isdigit():
+            raise PDInfrastructureError(
+                f"HCU_PD_GID_INDEX must be a non-negative integer: {gid_index!r}"
+            )
+
+        checkout = Path(
+            os.environ.get("HCU_PD_CHECKOUT", os.environ.get("GITHUB_WORKSPACE", ""))
+        ).resolve()
+        if not checkout.is_dir():
+            raise PDInfrastructureError(f"checkout does not exist: {checkout}")
+
+        return cls(
+            role=role,
+            run_id=run_id,
+            attempt=attempt,
+            sha=sha,
+            target_ref=os.environ.get("HCU_PD_TARGET_REF", sha),
+            runner_name=_require_env("RUNNER_NAME"),
+            hostname=socket.gethostname(),
+            image=_require_env("HCU_PD_IMAGE"),
+            image_id=_require_env("HCU_PD_IMAGE_ID"),
+            model_path=resolve_minimax_m27_model_path(),
+            local_ip=local_ip,
+            peer_ip=peer_ip,
+            prefill_ip=prefill_ip,
+            decode_ip=decode_ip,
+            ifname=_require_env("HCU_PD_LOCAL_IFNAME"),
+            ib_device=_require_env("HCU_PD_LOCAL_IB_DEVICE"),
+            gid_index=gid_index,
+            checkout=checkout,
+            shared_root=Path(
+                os.environ.get("HCU_PD_SHARED_ROOT", "/ci_public/sglang-das/hcu-pd")
+            ).resolve(),
+            wheel_root=Path(
+                os.environ.get("HCU_PD_WHEEL_ROOT", "/ci_public/sglang-das/hcu-wheels")
+            ).resolve(),
+            shared_gid=int(os.environ.get("HCU_PD_SHARED_GID", "1002")),
+            peer_timeout=int(os.environ.get("HCU_PD_PEER_TIMEOUT", "1800")),
+            service_timeout=int(os.environ.get("HCU_PD_SERVICE_TIMEOUT", "7200")),
+            heartbeat_timeout=int(os.environ.get("HCU_PD_HEARTBEAT_TIMEOUT", "180")),
+            completion_timeout=int(
+                os.environ.get("HCU_PD_COMPLETION_TIMEOUT", "10800")
+            ),
+        )
+
+    @property
+    def peer_role(self) -> str:
+        return ROLE_DECODE if self.role == ROLE_PREFILL else ROLE_PREFILL
+
+    @property
+    def run_dir(self) -> Path:
+        return self.shared_root / f"run-{self.run_id}" / f"attempt-{self.attempt}"
+
+    @property
+    def role_dir(self) -> Path:
+        return self.run_dir / self.role
+
+    @property
+    def peer_dir(self) -> Path:
+        return self.run_dir / self.peer_role
+
+    @property
+    def logs_dir(self) -> Path:
+        return self.run_dir / "logs"
+
+    @property
+    def results_dir(self) -> Path:
+        return self.run_dir / "results"
+
+    @property
+    def abort_path(self) -> Path:
+        return self.run_dir / "abort.json"
+
+    @property
+    def done_path(self) -> Path:
+        return self.run_dir / "done.json"
+
+    @property
+    def container_name(self) -> str:
+        return f"ci_sglang_hcu_pd_{self.run_id}_{self.attempt}_{self.role}"
+
+    @property
+    def role_port(self) -> int:
+        return PREFILL_PORT if self.role == ROLE_PREFILL else DECODE_PORT
+
+    @property
+    def wheel_bundle(self) -> Path:
+        return self.wheel_root / self.sha
+
+    def role_config(self) -> HcuPDRoleConfig:
+        return HcuPDRoleConfig(
+            role=self.role,
+            host_ip=self.local_ip,
+            ifname=self.ifname,
+            ib_device=self.ib_device,
+        )
+
+    def claim_payload(self) -> dict[str, Any]:
+        return {
+            **_now_payload(),
+            "role": self.role,
+            "run_id": self.run_id,
+            "run_attempt": self.attempt,
+            "commit_sha": self.sha,
+            "target_ref": self.target_ref,
+            "runner_name": self.runner_name,
+            "hostname": self.hostname,
+            "image": self.image,
+            "image_id": self.image_id,
+            "model_path": self.model_path,
+            "ip": self.local_ip,
+            "ifname": self.ifname,
+            "ib_device": self.ib_device,
+            "gid_index": self.gid_index,
+        }
+
+
+class Heartbeat:
+    def __init__(self, context: PDRunContext, interval: float = 10.0):
+        self.context = context
+        self.interval = interval
+        self.stop_event = threading.Event()
+        self.error: BaseException | None = None
+        self.thread = threading.Thread(
+            target=self._run, name=f"hcu-pd-{context.role}-heartbeat", daemon=True
+        )
+
+    def start(self) -> None:
+        self._write()
+        self.thread.start()
+
+    def _write(self) -> None:
+        atomic_write_json(
+            self.context.role_dir / "heartbeat.json",
+            {
+                **_now_payload(),
+                "role": self.context.role,
+                "runner_name": self.context.runner_name,
+                "hostname": self.context.hostname,
+            },
+            self.context.shared_gid,
+        )
+
+    def _run(self) -> None:
+        while not self.stop_event.wait(self.interval):
+            try:
+                self._write()
+            except BaseException as exc:
+                self.error = exc
+                return
+
+    def check(self) -> None:
+        if self.error is not None:
+            raise PDInfrastructureError(
+                f"heartbeat writer failed: {self.error}"
+            ) from self.error
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        if self.thread.is_alive():
+            self.thread.join(timeout=self.interval + 2)
+
+
+class PDOrchestrator:
+    def __init__(self, context: PDRunContext):
+        self.context = context
+        self.heartbeat = Heartbeat(context)
+        self.processes: dict[str, subprocess.Popen] = {}
+        self.log_streams: list[Any] = []
+
+    def prepare_layout(self) -> None:
+        for path in (
+            self.context.shared_root,
+            self.context.run_dir,
+            self.context.role_dir,
+            self.context.logs_dir,
+            self.context.results_dir,
+            self.context.wheel_root,
+        ):
+            ensure_shared_dir(path, self.context.shared_gid)
+
+    def prune_old_runs(self) -> None:
+        if self.context.role != ROLE_PREFILL:
+            return
+        cutoff = time.time() - 14 * 24 * 60 * 60
+        for candidate in self.context.shared_root.iterdir():
+            if not candidate.is_dir() or not RUN_DIR_RE.fullmatch(candidate.name):
+                continue
+            if candidate == self.context.run_dir.parent:
+                continue
+            if candidate.stat().st_mtime >= cutoff:
+                continue
+            if candidate.parent.resolve() != self.context.shared_root:
+                continue
+            shutil.rmtree(candidate)
+
+    def _check_abort(self) -> None:
+        if self.context.abort_path.exists():
+            payload = read_json(self.context.abort_path)
+            raise PDPeerAbort(
+                f"PD run aborted by {payload.get('role', 'unknown')}: "
+                f"{payload.get('error', payload)}"
+            )
+
+    def _peer_heartbeat_age(self) -> float | None:
+        path = self.context.peer_dir / "heartbeat.json"
+        if not path.exists():
+            return None
+        payload = read_json(path)
+        timestamp = float(payload.get("timestamp", 0))
+        return time.time() - timestamp
+
+    def _check_peer_alive(self) -> None:
+        age = self._peer_heartbeat_age()
+        if age is not None and age > self.context.heartbeat_timeout:
+            raise PDInfrastructureError(
+                f"{self.context.peer_role} heartbeat is stale: {age:.1f}s"
+            )
+        self.heartbeat.check()
+        self._check_abort()
+
+    def wait_for_path(
+        self, path: Path, *, timeout: float, require_peer_heartbeat: bool = True
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._check_abort()
+            self.heartbeat.check()
+            if path.exists():
+                return
+            if require_peer_heartbeat:
+                self._check_peer_alive()
+            time.sleep(2)
+        raise PDInfrastructureError(f"timed out waiting for {path}")
+
+    def write_claim_and_wait(self) -> dict[str, Any]:
+        atomic_write_json(
+            self.context.role_dir / "claim.json",
+            self.context.claim_payload(),
+            self.context.shared_gid,
+        )
+        self.heartbeat.start()
+        peer_claim_path = self.context.peer_dir / "claim.json"
+        self.wait_for_path(
+            peer_claim_path,
+            timeout=self.context.peer_timeout,
+            require_peer_heartbeat=False,
+        )
+        peer = read_json(peer_claim_path)
+        self._validate_peer_claim(peer)
+        return peer
+
+    def _validate_peer_claim(self, peer: dict[str, Any]) -> None:
+        expected = {
+            "role": self.context.peer_role,
+            "run_id": self.context.run_id,
+            "run_attempt": self.context.attempt,
+            "commit_sha": self.context.sha,
+            "target_ref": self.context.target_ref,
+            "image": self.context.image,
+            "image_id": self.context.image_id,
+            "model_path": self.context.model_path,
+            "ip": self.context.peer_ip,
+            "gid_index": self.context.gid_index,
+        }
+        mismatches = {
+            key: {"expected": value, "actual": peer.get(key)}
+            for key, value in expected.items()
+            if peer.get(key) != value
+        }
+        if peer.get("runner_name") == self.context.runner_name:
+            mismatches["runner_name"] = {
+                "expected": "different runners",
+                "actual": peer.get("runner_name"),
+            }
+        if peer.get("hostname") == self.context.hostname:
+            mismatches["hostname"] = {
+                "expected": "different physical hosts",
+                "actual": peer.get("hostname"),
+            }
+        if mismatches:
+            raise PDInfrastructureError(f"peer claim mismatch: {mismatches}")
+
+    def _check_port_available(self, host: str, port: int) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind((host, port))
+            except OSError as exc:
+                raise PDInfrastructureError(
+                    f"port is unavailable on {host}:{port}: {exc}"
+                ) from exc
+
+    def _interface_ipv4(self, ifname: str) -> str:
+        import fcntl
+        import struct
+
+        if len(ifname.encode()) > 15:
+            raise PDInfrastructureError(
+                f"network interface name is too long: {ifname!r}"
+            )
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            try:
+                request = struct.pack("256s", ifname.encode())
+                response = fcntl.ioctl(sock.fileno(), 0x8915, request)
+            except OSError as exc:
+                raise PDInfrastructureError(
+                    f"cannot read IPv4 address for {ifname}: {exc}"
+                ) from exc
+        return socket.inet_ntoa(response[20:24])
+
+    def preflight(self) -> dict[str, Any]:
+        if not Path(self.context.model_path).is_dir():
+            raise PDInfrastructureError(
+                f"MiniMax-M2.7 model directory is missing: {self.context.model_path}"
+            )
+        if not (Path(self.context.model_path) / "config.json").is_file():
+            raise PDInfrastructureError(
+                f"model config.json is missing: {self.context.model_path}"
+            )
+        if not any(Path(self.context.model_path).glob("*.safetensors")) and not any(
+            Path(self.context.model_path).glob("*.safetensors.index.json")
+        ):
+            raise PDInfrastructureError(
+                f"model weights are missing: {self.context.model_path}"
+            )
+
+        interface_ip = self._interface_ipv4(self.context.ifname)
+        if self.context.local_ip != interface_ip:
+            raise PDInfrastructureError(
+                f"{self.context.ifname} has IPv4 {interface_ip}, "
+                f"expected {self.context.local_ip}"
+            )
+
+        rdma_root = Path("/sys/class/infiniband") / self.context.ib_device
+        state_path = rdma_root / "ports" / "1" / "state"
+        if not state_path.is_file() or "ACTIVE" not in state_path.read_text():
+            raise PDInfrastructureError(
+                f"RDMA device is not ACTIVE: {self.context.ib_device}"
+            )
+        net_path = rdma_root / "device" / "net" / self.context.ifname
+        if not net_path.exists():
+            mapped_interfaces = sorted(
+                path.name for path in (rdma_root / "device" / "net").glob("*")
+            )
+            raise PDInfrastructureError(
+                f"RDMA mapping mismatch: {self.context.ib_device} maps to "
+                f"{mapped_interfaces}, expected {self.context.ifname}"
+            )
+        gid_path = rdma_root / "ports" / "1" / "gids" / self.context.gid_index
+        gid_type_path = (
+            rdma_root / "ports" / "1" / "gid_attrs" / "types" / self.context.gid_index
+        )
+        gid_ndev_path = (
+            rdma_root / "ports" / "1" / "gid_attrs" / "ndevs" / self.context.gid_index
+        )
+        if not all(path.is_file() for path in (gid_path, gid_type_path, gid_ndev_path)):
+            raise PDInfrastructureError(
+                f"RDMA GID index {self.context.gid_index} is unavailable on "
+                f"{self.context.ib_device}"
+            )
+        gid_value = gid_path.read_text().strip()
+        gid_type = gid_type_path.read_text().strip()
+        gid_ndev = gid_ndev_path.read_text().strip()
+        try:
+            mapped_ip = ipaddress.IPv6Address(gid_value).ipv4_mapped
+        except ipaddress.AddressValueError as exc:
+            raise PDInfrastructureError(
+                f"invalid RDMA GID value at index {self.context.gid_index}: "
+                f"{gid_value!r}"
+            ) from exc
+        if (
+            mapped_ip != ipaddress.IPv4Address(self.context.local_ip)
+            or gid_type != "RoCE v2"
+            or gid_ndev != self.context.ifname
+        ):
+            raise PDInfrastructureError(
+                f"RDMA GID mismatch at index {self.context.gid_index}: "
+                f"gid={gid_value}, type={gid_type}, ndev={gid_ndev}; "
+                f"expected IPv4={self.context.local_ip}, type=RoCE v2, "
+                f"ndev={self.context.ifname}"
+            )
+
+        image_id = run_checked(
+            ["docker", "image", "inspect", "--format", "{{.Id}}", self.context.image]
+        )
+        if image_id != self.context.image_id:
+            raise PDInfrastructureError(
+                f"local image ID changed: expected={self.context.image_id}, actual={image_id}"
+            )
+
+        hcu_output = run_checked(["hy-smi", "--showbus"])
+        hcu_count = len(set(re.findall(r"HCU\[(\d+)\]", hcu_output)))
+        if hcu_count != 8:
+            raise PDInfrastructureError(f"expected 8 HCUs, found {hcu_count}")
+
+        self._check_port_available(self.context.local_ip, self.context.role_port)
+        if self.context.role == ROLE_PREFILL:
+            self._check_port_available(self.context.local_ip, ROUTER_PORT)
+            self._check_port_available(self.context.local_ip, BOOTSTRAP_PORT)
+
+        probe_path = (
+            self.context.role_dir
+            / f".write-probe-{self.context.hostname}-{os.getpid()}"
+        )
+        probe_path.write_text("ok\n")
+        _set_shared_permissions(probe_path, is_dir=False, gid=self.context.shared_gid)
+        probe_path.unlink()
+
+        payload = {
+            **_now_payload(),
+            "role": self.context.role,
+            "hcu_count": hcu_count,
+            "image_id": image_id,
+            "model_path": self.context.model_path,
+            "ip": self.context.local_ip,
+            "ifname": self.context.ifname,
+            "ib_device": self.context.ib_device,
+            "gid_index": self.context.gid_index,
+            "gid": gid_value,
+            "gid_type": gid_type,
+            "rdma_state": state_path.read_text().strip(),
+        }
+        atomic_write_json(
+            self.context.role_dir / "preflight.json",
+            payload,
+            self.context.shared_gid,
+        )
+        return payload
+
+    def _open_log(self, name: str):
+        path = self.context.logs_dir / name
+        ensure_shared_dir(path.parent, self.context.shared_gid)
+        stream = path.open("ab", buffering=0)
+        _set_shared_permissions(path, is_dir=False, gid=self.context.shared_gid)
+        self.log_streams.append(stream)
+        return stream
+
+    def _run_monitored(
+        self,
+        name: str,
+        command: list[str],
+        *,
+        env: dict[str, str] | None,
+        timeout: float,
+        log_name: str,
+    ) -> None:
+        stream = self._open_log(log_name)
+        stream.write(f"$ {' '.join(command)}\n".encode())
+        process = subprocess.Popen(
+            command,
+            env=env,
+            stdout=stream,
+            stderr=subprocess.STDOUT,
+        )
+        deadline = time.monotonic() + timeout
+        while process.poll() is None:
+            if time.monotonic() >= deadline:
+                process.terminate()
+                raise PDInfrastructureError(f"{name} timed out after {timeout}s")
+            self._check_peer_alive()
+            time.sleep(5)
+        if process.returncode != 0:
+            tail = Path(stream.name).read_text(errors="replace")[-12000:]
+            raise PDInfrastructureError(
+                f"{name} failed with exit code {process.returncode}\n{tail}"
+            )
+
+    def ensure_shared_wheels(self) -> dict[str, Any]:
+        ready = self.context.wheel_bundle / "READY"
+        if self.context.role == ROLE_PREFILL and not ready.exists():
+            env = os.environ.copy()
+            env.update(
+                {
+                    "HCU_PD_SHA": self.context.sha,
+                    "HCU_PD_CHECKOUT": str(self.context.checkout),
+                    "HCU_PD_IMAGE": self.context.image,
+                    "HCU_PD_WHEEL_ROOT": str(self.context.wheel_root),
+                    "HCU_PD_SHARED_GID": str(self.context.shared_gid),
+                }
+            )
+            self._run_monitored(
+                "shared wheel build",
+                [
+                    "bash",
+                    str(
+                        self.context.checkout
+                        / "scripts/ci/hcu/hcu_ci_build_shared_wheels.sh"
+                    ),
+                    "build",
+                ],
+                env=env,
+                timeout=self.context.completion_timeout,
+                log_name="wheel-build.log",
+            )
+        else:
+            self.wait_for_path(
+                ready,
+                timeout=self.context.completion_timeout,
+                require_peer_heartbeat=True,
+            )
+
+        manifest = read_json(self.context.wheel_bundle / "manifest.json")
+        if manifest.get("commit_sha") != self.context.sha:
+            raise PDInfrastructureError(
+                f"wheel manifest SHA mismatch: {manifest.get('commit_sha')}"
+            )
+        kinds = {item.get("kind") for item in manifest.get("wheels", [])}
+        if kinds != {"sglang", "sglang-kernel", "sglang-router"}:
+            raise PDInfrastructureError(f"wheel bundle is incomplete: {kinds}")
+        for item in manifest["wheels"]:
+            path = self.context.wheel_bundle / item["path"]
+            if not path.is_file():
+                raise PDInfrastructureError(f"wheel is missing: {path}")
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            if digest != item.get("sha256"):
+                raise PDInfrastructureError(f"wheel checksum mismatch: {path}")
+        return manifest
+
+    def cleanup_container(self) -> None:
+        cleanup_script = (
+            self.context.checkout / "scripts/ci/hcu/hcu_ci_cleanup_container.sh"
+        )
+        env = os.environ.copy()
+        env.update(
+            {
+                "HCU_CI_CONTAINER_NAME": self.context.container_name,
+                "GITHUB_WORKSPACE": str(self.context.checkout),
+            }
+        )
+        completed = subprocess.run(
+            ["bash", str(cleanup_script)],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise PDInfrastructureError(
+                f"container cleanup failed: {completed.stdout[-4000:]}"
+            )
+
+    def start_container(self, manifest: dict[str, Any]) -> None:
+        self.cleanup_container()
+        env = os.environ.copy()
+        env.update(
+            {
+                "HCU_CI_IMAGE": self.context.image,
+                "HCU_CI_CONTAINER_NAME": self.context.container_name,
+                "HCU_CI_NETWORK_MODE": "host",
+                "HCU_CI_SHM_SIZE": "200g",
+                "HCU_CI_ENABLE_RDMA": "1",
+                "HCU_CI_SKIP_PULL": "1",
+                "HCU_MODEL_EXTRA_HOST_PATHS": "/public4",
+                "HCU_WHEEL_STAGING_ROOT": str(self.context.wheel_bundle),
+                "HCU_WHEEL_STAGING_CONTAINER_ROOT": "/hcu-pd-wheels",
+                "GITHUB_WORKSPACE": str(self.context.checkout),
+            }
+        )
+        run_checked(
+            [
+                "bash",
+                str(self.context.checkout / "scripts/ci/hcu/hcu_ci_start_container.sh"),
+            ],
+            env=env,
+            timeout=300,
+        )
+        actual_image_id = run_checked(
+            [
+                "docker",
+                "inspect",
+                "--format",
+                "{{.Image}}",
+                self.context.container_name,
+            ]
+        )
+        if actual_image_id != self.context.image_id:
+            raise PDInfrastructureError(
+                f"container image mismatch: expected={self.context.image_id}, "
+                f"actual={actual_image_id}"
+            )
+
+        hcu_count = run_checked(
+            [
+                "docker",
+                "exec",
+                self.context.container_name,
+                "python3",
+                "-c",
+                "import torch; print(torch.cuda.device_count())",
+            ],
+            timeout=120,
+        )
+        if hcu_count.splitlines()[-1].strip() != "8":
+            raise PDInfrastructureError(f"container does not see 8 HCUs: {hcu_count}")
+        memlock = run_checked(
+            [
+                "docker",
+                "exec",
+                self.context.container_name,
+                "bash",
+                "-lc",
+                "ulimit -l",
+            ]
+        )
+        if memlock.strip() != "unlimited":
+            raise PDInfrastructureError(
+                f"container memlock is not unlimited: {memlock}"
+            )
+
+        wheel_priority = {
+            "sglang-kernel": 0,
+            "sglang": 1,
+            "sglang-router": 2,
+        }
+        wheel_paths = [
+            f"/hcu-pd-wheels/{item['path']}"
+            for item in sorted(
+                manifest["wheels"], key=lambda item: wheel_priority[item["kind"]]
+            )
+        ]
+        run_checked(
+            [
+                "docker",
+                "exec",
+                self.context.container_name,
+                "python3",
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                "--no-deps",
+                *wheel_paths,
+            ],
+            timeout=900,
+        )
+        versions = run_checked(
+            [
+                "docker",
+                "exec",
+                self.context.container_name,
+                "python3",
+                "-c",
+                (
+                    "from importlib import metadata; "
+                    "print('|'.join(metadata.version(n) for n in "
+                    "('sglang','sglang-kernel','sglang-router')))"
+                ),
+            ]
+        )
+        atomic_write_json(
+            self.context.role_dir / "container.json",
+            {
+                **_now_payload(),
+                "container_name": self.context.container_name,
+                "image_id": actual_image_id,
+                "versions": versions,
+            },
+            self.context.shared_gid,
+        )
+
+    def _start_container_process(
+        self,
+        name: str,
+        command: list[str],
+        *,
+        env: dict[str, str],
+        log_name: str,
+    ) -> subprocess.Popen:
+        stream = self._open_log(log_name)
+        docker_command = ["docker", "exec", "-w", "/sglang-checkout"]
+        for key, value in sorted(env.items()):
+            docker_command.extend(["-e", f"{key}={value}"])
+        docker_command.extend([self.context.container_name, *command])
+        stream.write(f"$ {' '.join(docker_command)}\n".encode())
+        process = subprocess.Popen(
+            docker_command,
+            stdout=stream,
+            stderr=subprocess.STDOUT,
+        )
+        self.processes[name] = process
+        return process
+
+    def _http_json(self, url: str, timeout: float = 5.0) -> dict[str, Any]:
+        request = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            if response.status != 200:
+                raise PDInfrastructureError(
+                    f"unexpected HTTP status from {url}: {response.status}"
+                )
+            body = response.read()
+        if not body:
+            return {}
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            return {"text": body.decode(errors="replace")}
+        return payload if isinstance(payload, dict) else {"payload": payload}
+
+    def _wait_service(
+        self,
+        *,
+        base_url: str,
+        process: subprocess.Popen,
+        expected_model: str | None,
+        timeout: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        last_error: BaseException | None = None
+        while time.monotonic() < deadline:
+            self._check_peer_alive()
+            if process.poll() is not None:
+                raise PDInfrastructureError(
+                    f"service process exited early with code {process.returncode}"
+                )
+            try:
+                self._http_json(f"{base_url}/health")
+                if expected_model is None:
+                    return {}
+                model_info = self._http_json(f"{base_url}/model_info")
+                actual = str(model_info.get("model_path", "")).rstrip("/")
+                if actual != expected_model.rstrip("/"):
+                    raise PDInfrastructureError(
+                        f"model identity mismatch at {base_url}: "
+                        f"expected={expected_model!r}, actual={actual!r}"
+                    )
+                return model_info
+            except (
+                OSError,
+                urllib.error.URLError,
+                json.JSONDecodeError,
+                PDInfrastructureError,
+            ) as exc:
+                last_error = exc
+                time.sleep(5)
+        raise PDInfrastructureError(
+            f"service did not become ready at {base_url}: {last_error}"
+        )
+
+    def launch_role_service(self) -> dict[str, Any]:
+        role_config = self.context.role_config()
+        service_env = minimax_m27_pd_env(role_config, gid_index=self.context.gid_index)
+        service_env.update(
+            {
+                "HF_HUB_OFFLINE": "1",
+                "TRANSFORMERS_OFFLINE": "1",
+                "PYTHONUNBUFFERED": "1",
+                "NCCL_DEBUG": "INFO",
+                "SGLANG_IS_IN_CI": "1",
+                "SGLANG_IS_IN_CI_HCU": "1",
+            }
+        )
+        process = self._start_container_process(
+            self.context.role,
+            minimax_m27_server_command(role_config, self.context.model_path),
+            env=service_env,
+            log_name=f"{self.context.role}.log",
+        )
+        base_url = f"http://{self.context.local_ip}:{self.context.role_port}"
+        model_info = self._wait_service(
+            base_url=base_url,
+            process=process,
+            expected_model=self.context.model_path,
+            timeout=self.context.service_timeout,
+        )
+        payload = {
+            **_now_payload(),
+            "role": self.context.role,
+            "base_url": base_url,
+            "model_path": model_info.get("model_path"),
+            "launcher_pid": process.pid,
+        }
+        atomic_write_json(
+            self.context.role_dir / "ready.json",
+            payload,
+            self.context.shared_gid,
+        )
+        return payload
+
+    def launch_router(self) -> subprocess.Popen:
+        process = self._start_container_process(
+            "router",
+            minimax_m27_router_command(self.context.prefill_ip, self.context.decode_ip),
+            env={"PYTHONUNBUFFERED": "1"},
+            log_name="router.log",
+        )
+        self._wait_service(
+            base_url=f"http://{self.context.prefill_ip}:{ROUTER_PORT}",
+            process=process,
+            expected_model=None,
+            timeout=1800,
+        )
+        return process
+
+    def run_smoke_test(self) -> dict[str, Any]:
+        result_path = "/sglang-checkout/test-results/hcu-pd/smoke-result.json"
+        command = [
+            "docker",
+            "exec",
+            "-w",
+            "/sglang-checkout/test",
+            "-e",
+            "SGLANG_IS_IN_CI=1",
+            "-e",
+            "SGLANG_IS_IN_CI_HCU=1",
+            "-e",
+            "HCU_CI_USE_INSTALLED_WHEELS=1",
+            "-e",
+            f"HCU_PD_PREFILL_IP={self.context.prefill_ip}",
+            "-e",
+            f"HCU_PD_DECODE_IP={self.context.decode_ip}",
+            "-e",
+            f"{MINIMAX_M27_MODEL_ENV}={self.context.model_path}",
+            "-e",
+            f"HCU_PD_SMOKE_RESULT_PATH={result_path}",
+            self.context.container_name,
+            "python3",
+            "run_suite.py",
+            "--hw",
+            "hcu",
+            "--suite",
+            "nightly-hcu-disaggregation-16gpu",
+            "--nightly",
+        ]
+        self._run_monitored(
+            "MiniMax-M2.7 PD smoke",
+            command,
+            env=None,
+            timeout=1800,
+            log_name="smoke.log",
+        )
+        raw_result = run_checked(
+            [
+                "docker",
+                "exec",
+                self.context.container_name,
+                "cat",
+                result_path,
+            ]
+        )
+        try:
+            result = json.loads(raw_result)
+        except json.JSONDecodeError as exc:
+            raise PDInfrastructureError(
+                f"invalid smoke-result.json: {raw_result}"
+            ) from exc
+        atomic_write_json(
+            self.context.results_dir / "smoke-result.json",
+            result,
+            self.context.shared_gid,
+        )
+        return result
+
+    def wait_for_completion(self) -> dict[str, Any]:
+        deadline = time.monotonic() + self.context.completion_timeout
+        service = self.processes[self.context.role]
+        while time.monotonic() < deadline:
+            self._check_peer_alive()
+            if service.poll() is not None:
+                raise PDInfrastructureError(
+                    f"{self.context.role} service exited with code {service.returncode}"
+                )
+            if self.context.done_path.exists():
+                payload = read_json(self.context.done_path)
+                if not payload.get("success"):
+                    raise PDInfrastructureError(f"PD run failed: {payload}")
+                return payload
+            time.sleep(5)
+        raise PDInfrastructureError("timed out waiting for Prefill completion")
+
+    def run_core(self) -> dict[str, Any]:
+        self.prepare_layout()
+        self.prune_old_runs()
+        self.preflight()
+        self.write_claim_and_wait()
+        manifest = self.ensure_shared_wheels()
+        self.start_container(manifest)
+        role_ready = self.launch_role_service()
+
+        if self.context.role == ROLE_DECODE:
+            done = self.wait_for_completion()
+            return {"role_ready": role_ready, "done": done}
+
+        self.wait_for_path(
+            self.context.peer_dir / "ready.json",
+            timeout=self.context.service_timeout,
+            require_peer_heartbeat=True,
+        )
+        peer_ready = read_json(self.context.peer_dir / "ready.json")
+        if str(peer_ready.get("model_path", "")).rstrip("/") != self.context.model_path:
+            raise PDInfrastructureError(f"Decode model identity mismatch: {peer_ready}")
+        self.launch_router()
+        smoke = self.run_smoke_test()
+        return {"role_ready": role_ready, "peer_ready": peer_ready, "smoke": smoke}
+
+    def write_abort(self, error: BaseException) -> None:
+        write_json_once(
+            self.context.abort_path,
+            {
+                **_now_payload(),
+                "role": self.context.role,
+                "runner_name": self.context.runner_name,
+                "hostname": self.context.hostname,
+                "error_type": type(error).__name__,
+                "error": str(error),
+            },
+            self.context.shared_gid,
+        )
+
+    def execute(self) -> dict[str, Any]:
+        started_at = time.monotonic()
+        result: dict[str, Any] = {}
+        error: BaseException | None = None
+        cleanup_error: BaseException | None = None
+        try:
+            result = self.run_core()
+        except BaseException as exc:
+            error = exc
+            self.write_abort(exc)
+
+        try:
+            self.cleanup_container()
+        except BaseException as exc:
+            cleanup_error = exc
+            if error is None:
+                error = exc
+                self.write_abort(exc)
+
+        if self.context.role == ROLE_PREFILL:
+            done_payload = {
+                **_now_payload(),
+                "success": error is None,
+                "role": self.context.role,
+                "commit_sha": self.context.sha,
+                "image_id": self.context.image_id,
+                "duration_seconds": round(time.monotonic() - started_at, 3),
+                "error": None if error is None else str(error),
+            }
+            atomic_write_json(
+                self.context.done_path, done_payload, self.context.shared_gid
+            )
+
+        role_result = {
+            **_now_payload(),
+            "success": error is None,
+            "role": self.context.role,
+            "runner_name": self.context.runner_name,
+            "hostname": self.context.hostname,
+            "duration_seconds": round(time.monotonic() - started_at, 3),
+            "error": None if error is None else str(error),
+            "cleanup_error": None if cleanup_error is None else str(cleanup_error),
+            "result": result,
+        }
+        atomic_write_json(
+            self.context.role_dir / "result.json",
+            role_result,
+            self.context.shared_gid,
+        )
+        self.heartbeat.stop()
+        for stream in self.log_streams:
+            stream.close()
+
+        if error is not None:
+            raise error
+        return role_result
+
+
+def cleanup_only(context: PDRunContext) -> None:
+    orchestrator = PDOrchestrator(context)
+    orchestrator.cleanup_container()
+
+
+def _install_signal_handlers() -> None:
+    def handle_signal(signum, _frame):
+        raise PDInfrastructureError(f"received signal {signum}")
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Coordinate two-node HCU PD CI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("run", "preflight", "cleanup"):
+        command_parser = subparsers.add_parser(command)
+        command_parser.add_argument(
+            "--role", required=True, choices=sorted(VALID_ROLES)
+        )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    os.umask(0o002)
+    _install_signal_handlers()
+    try:
+        context = PDRunContext.from_environment(args.role)
+        orchestrator = PDOrchestrator(context)
+        if args.command == "cleanup":
+            orchestrator.cleanup_container()
+        elif args.command == "preflight":
+            orchestrator.prepare_layout()
+            print(json.dumps(orchestrator.preflight(), indent=2))
+        else:
+            print(json.dumps(orchestrator.execute(), ensure_ascii=False, indent=2))
+    except BaseException as exc:
+        print(f"[hcu-pd] {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/hcu/hcu_ci_pd_controller.sh
+++ b/scripts/ci/hcu/hcu_ci_pd_controller.sh
@@ -1,17 +1,6 @@
-#!/bin/bash
-# Copyright 2026 Hygon Information Technology Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#!/usr/bin/env bash
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/scripts/ci/hcu/hcu_ci_pd_controller.sh
+++ b/scripts/ci/hcu/hcu_ci_pd_controller.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [[ $# -ne 2 || ! "$1" =~ ^(run|preflight|cleanup)$ || "$2" != --role=* ]]; then
+  echo "Usage: $0 run|preflight|cleanup --role=prefill|decode" >&2
+  exit 2
+fi
+
+COMMAND="$1"
+ROLE="${2#--role=}"
+if [[ "${ROLE}" != "prefill" && "${ROLE}" != "decode" ]]; then
+  echo "Invalid HCU PD role: ${ROLE}" >&2
+  exit 2
+fi
+
+IMAGE="${HCU_PD_IMAGE:?HCU_PD_IMAGE is required}"
+CHECKOUT="${HCU_PD_CHECKOUT:-${GITHUB_WORKSPACE:-$PWD}}"
+RUN_ID="${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+ATTEMPT="${GITHUB_RUN_ATTEMPT:-1}"
+CONTROLLER_NAME="ci_sglang_hcu_pd_controller_${RUN_ID}_${ATTEMPT}_${ROLE}"
+
+if [[ ! -f "${CHECKOUT}/scripts/ci/hcu/hcu_ci_pd.py" ]]; then
+  echo "Invalid HCU PD checkout: ${CHECKOUT}" >&2
+  exit 2
+fi
+if [[ ! -S /var/run/docker.sock || ! -x /usr/bin/docker ]]; then
+  echo "Docker socket or static Docker CLI is unavailable." >&2
+  exit 2
+fi
+
+docker rm -f "${CONTROLLER_NAME}" >/dev/null 2>&1 || true
+
+DOCKER_GROUP="$(stat -c '%g' /var/run/docker.sock)"
+CONTROLLER_ARGS=(
+  --rm
+  --name "${CONTROLLER_NAME}"
+  --user "$(id -u):$(id -g)"
+  --group-add "${DOCKER_GROUP}"
+  --privileged
+  --network host
+  --uts host
+  --ipc host
+  -v /var/run/docker.sock:/var/run/docker.sock
+  -v /usr/bin/docker:/usr/bin/docker:ro
+  -v "${CHECKOUT}:${CHECKOUT}:ro"
+  -v /ci_public:/ci_public
+  -v /sys:/sys:ro
+  -w "${CHECKOUT}"
+)
+
+for path in /public /public4 /opt/hyhal; do
+  if [[ -e "${path}" ]]; then
+    CONTROLLER_ARGS+=(-v "${path}:${path}:ro")
+  fi
+done
+
+for device in /dev/kfd /dev/dri /dev/infiniband; do
+  if [[ -e "${device}" ]]; then
+    CONTROLLER_ARGS+=(-v "${device}:${device}")
+  fi
+done
+
+FORWARDED_ENV=(
+  GITHUB_REPOSITORY
+  GITHUB_RUN_ID
+  GITHUB_RUN_ATTEMPT
+  RUNNER_NAME
+  HCU_PD_SHA
+  HCU_PD_TARGET_REF
+  HCU_PD_IMAGE
+  HCU_PD_IMAGE_ID
+  HCU_PD_CHECKOUT
+  HCU_PD_PREFILL_IP
+  HCU_PD_DECODE_IP
+  HCU_PD_LOCAL_IP
+  HCU_PD_PEER_IP
+  HCU_PD_LOCAL_IFNAME
+  HCU_PD_LOCAL_IB_DEVICE
+  HCU_PD_GID_INDEX
+  HCU_PD_SHARED_ROOT
+  HCU_PD_WHEEL_ROOT
+  HCU_PD_SHARED_GID
+  HCU_PD_PEER_TIMEOUT
+  HCU_PD_SERVICE_TIMEOUT
+  HCU_PD_HEARTBEAT_TIMEOUT
+  HCU_PD_COMPLETION_TIMEOUT
+  SGLANG_HCU_MINIMAX_M27_MODEL
+)
+
+for variable in "${FORWARDED_ENV[@]}"; do
+  if [[ -v "${variable}" ]]; then
+    CONTROLLER_ARGS+=(-e "${variable}=${!variable}")
+  fi
+done
+
+exec docker run "${CONTROLLER_ARGS[@]}" \
+  "${IMAGE}" \
+  python3 "${CHECKOUT}/scripts/ci/hcu/hcu_ci_pd.py" \
+  "${COMMAND}" --role "${ROLE}"

--- a/scripts/ci/hcu/hcu_ci_publish_accuracy.py
+++ b/scripts/ci/hcu/hcu_ci_publish_accuracy.py
@@ -26,7 +26,14 @@ def _chmod_directory(path: Path) -> None:
 
 
 def _ensure_directory(path: Path) -> None:
-    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.mkdir(parents=True)
+    except FileExistsError:
+        if not path.is_dir():
+            raise NotADirectoryError(f"shared result path is not a directory: {path}")
+        if not os.access(path, os.W_OK | os.X_OK):
+            raise PermissionError(f"shared result directory is not writable: {path}")
+        return
     _chmod_directory(path)
 
 

--- a/scripts/ci/hcu/hcu_ci_start_container.sh
+++ b/scripts/ci/hcu/hcu_ci_start_container.sh
@@ -1,17 +1,6 @@
-#!/bin/bash
-# Copyright 2026 Hygon Information Technology Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#!/usr/bin/env bash
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/scripts/ci/hcu/hcu_ci_start_container.sh
+++ b/scripts/ci/hcu/hcu_ci_start_container.sh
@@ -34,10 +34,15 @@ set -euo pipefail
 #   HCU_MODEL_EXTRA_HOST_PATHS              Colon-separated host model roots to mount read-only
 #                                           at the same path inside the container.
 #   HCU_CI_NETWORK_MODE                     Docker network mode: host (default) or bridge.
+#   HCU_CI_SHM_SIZE                         Docker shared-memory size. Defaults to 32g.
+#   HCU_CI_ENABLE_RDMA                      Set to 1 to expose RDMA devices, lock memory,
+#                                           and add IPC_LOCK. Defaults to disabled.
 
 CUSTOM_IMAGE=""
 CONTAINER="${HCU_CI_CONTAINER:-${HCU_CI_CONTAINER_NAME:-ci_sglang}}"
 NETWORK_MODE="${HCU_CI_NETWORK_MODE:-host}"
+SHM_SIZE="${HCU_CI_SHM_SIZE:-32g}"
+ENABLE_RDMA="${HCU_CI_ENABLE_RDMA:-0}"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -72,6 +77,7 @@ esac
 
 echo "Using HCU image: ${IMAGE}"
 echo "Using HCU Docker network mode: ${NETWORK_MODE}"
+echo "Using HCU Docker shared-memory size: ${SHM_SIZE}"
 
 # Pull only if not already present locally, unless explicitly skipped.
 if [[ -z "${HCU_CI_SKIP_PULL:-}" ]] && ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
@@ -99,6 +105,26 @@ if [[ -n "${VISIBLE_DEVICES}" ]]; then
     VISIBLE_ENV_ARGS+=(-e "ROCR_VISIBLE_DEVICES=${VISIBLE_DEVICES}")
   fi
 fi
+
+RDMA_ARGS=()
+case "${ENABLE_RDMA}" in
+  1|true)
+    RDMA_ARGS+=(
+      --cap-add=IPC_LOCK
+      --ulimit memlock=-1:-1
+    )
+    if [[ -d /dev/infiniband ]]; then
+      RDMA_ARGS+=(-v /dev/infiniband:/dev/infiniband)
+    else
+      echo "Warning: HCU_CI_ENABLE_RDMA is set but /dev/infiniband is absent." >&2
+    fi
+    ;;
+  0|false|"") ;;
+  *)
+    echo "Error: HCU_CI_ENABLE_RDMA=${ENABLE_RDMA@Q}; expected 0, 1, false, or true." >&2
+    exit 1
+    ;;
+esac
 
 CACHE_HOST="${HCU_CACHE_HOST:-${HCU_CI_CACHE_HOST:-/home/runner/sgl-data}}"
 if [[ -d "${CACHE_HOST}" ]]; then
@@ -147,6 +173,7 @@ docker run -dt --user root --privileged \
   --network="${NETWORK_MODE}" \
   --ipc=host \
   ${DEVICE_FLAGS} \
+  "${RDMA_ARGS[@]}" \
   --ulimit nofile=65536:65536 \
   -v "${GITHUB_WORKSPACE:-$PWD}:/sglang-checkout" \
   -v /opt/hyhal:/opt/hyhal:ro \
@@ -155,7 +182,7 @@ docker run -dt --user root --privileged \
   ${WHEEL_STAGING_VOLUME} \
   "${EXTRA_MODEL_VOLUMES[@]}" \
   --group-add video \
-  --shm-size 32g \
+  --shm-size "${SHM_SIZE}" \
   --cap-add=SYS_PTRACE \
   -e HF_TOKEN="${HF_TOKEN:-}" \
   -e HF_HOME=/sgl-data/hf-cache \

--- a/scripts/ci/hcu/test_hcu_ci_notify_feishu.py
+++ b/scripts/ci/hcu/test_hcu_ci_notify_feishu.py
@@ -423,6 +423,27 @@ class ResultCollectionTest(unittest.TestCase):
 
 
 class SharedResultPublisherTest(unittest.TestCase):
+    def test_existing_shared_directory_does_not_require_ownership(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shared_root = Path(tmpdir)
+            with mock.patch.object(
+                Path,
+                "chmod",
+                side_effect=PermissionError("not the directory owner"),
+            ) as chmod:
+                publisher._ensure_directory(shared_root)
+            chmod.assert_not_called()
+
+    def test_existing_shared_directory_must_be_writable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shared_root = Path(tmpdir)
+            with mock.patch.object(publisher.os, "access", return_value=False):
+                with self.assertRaisesRegex(
+                    PermissionError,
+                    "shared result directory is not writable",
+                ):
+                    publisher._ensure_directory(shared_root)
+
     def test_publishes_partition_atomically_with_group_permissions(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/scripts/ci/hcu/test_hcu_ci_pd.py
+++ b/scripts/ci/hcu/test_hcu_ci_pd.py
@@ -1,17 +1,6 @@
 #!/usr/bin/env python3
-# Copyright 2026 Hygon Information Technology Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 

--- a/scripts/ci/hcu/test_hcu_ci_pd.py
+++ b/scripts/ci/hcu/test_hcu_ci_pd.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+from hcu_ci_pd import (
+    PDInfrastructureError,
+    PDOrchestrator,
+    PDRunContext,
+    ROLE_DECODE,
+    ROLE_PREFILL,
+    BOOTSTRAP_PORT,
+    DECODE_PORT,
+    PREFILL_PORT,
+    ROUTER_PORT,
+    HcuPDRoleConfig,
+    atomic_write_json,
+    ensure_shared_dir,
+    minimax_m27_pd_env,
+    minimax_m27_router_command,
+    minimax_m27_server_args,
+    read_json,
+    write_json_once,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+TEST_SHA = "1" * 40
+
+
+def _shared_gid() -> int:
+    return os.getgid() if hasattr(os, "getgid") else 0
+
+
+def _context(root: Path, role: str = ROLE_PREFILL) -> PDRunContext:
+    prefill_ip = "12.12.12.4"
+    decode_ip = "12.12.12.36"
+    return PDRunContext(
+        role=role,
+        run_id="1234",
+        attempt="1",
+        sha=TEST_SHA,
+        target_ref="test-ref",
+        runner_name=f"runner-{role}",
+        hostname=f"host-{role}",
+        image="registry/sglang:test",
+        image_id="sha256:test",
+        model_path="/models/MiniMax-M2.7",
+        local_ip=prefill_ip if role == ROLE_PREFILL else decode_ip,
+        peer_ip=decode_ip if role == ROLE_PREFILL else prefill_ip,
+        prefill_ip=prefill_ip,
+        decode_ip=decode_ip,
+        ifname="eth0",
+        ib_device="mlx5_0",
+        gid_index="3",
+        checkout=REPO_ROOT,
+        shared_root=root / "hcu-pd",
+        wheel_root=root / "hcu-wheels",
+        shared_gid=_shared_gid(),
+        peer_timeout=5,
+        service_timeout=5,
+        heartbeat_timeout=2,
+        completion_timeout=5,
+    )
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            body = b"OK"
+        elif self.path == "/model_info":
+            body = json.dumps({"model_path": "/models/MiniMax-M2.7"}).encode()
+        else:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args) -> None:
+        return
+
+
+class TestHcuPDUtils(unittest.TestCase):
+    def test_role_specific_server_topology(self) -> None:
+        prefill = HcuPDRoleConfig(
+            role=ROLE_PREFILL,
+            host_ip="12.12.12.4",
+            ifname="ens47f0np0",
+            ib_device="mlx5_6",
+        )
+        decode = HcuPDRoleConfig(
+            role=ROLE_DECODE,
+            host_ip="12.12.12.36",
+            ifname="eth0",
+            ib_device="mlx5_0",
+        )
+
+        prefill_args = minimax_m27_server_args(prefill, "/models/m27")
+        decode_args = minimax_m27_server_args(decode, "/models/m27")
+
+        self.assertEqual(prefill_args[prefill_args.index("--tp-size") + 1], "2")
+        self.assertEqual(prefill_args[prefill_args.index("--pp-size") + 1], "4")
+        self.assertEqual(
+            prefill_args[prefill_args.index("--port") + 1], str(PREFILL_PORT)
+        )
+        self.assertEqual(decode_args[decode_args.index("--tp-size") + 1], "8")
+        self.assertEqual(decode_args[decode_args.index("--pp-size") + 1], "1")
+        self.assertEqual(decode_args[decode_args.index("--port") + 1], str(DECODE_PORT))
+        self.assertEqual(
+            prefill_args[prefill_args.index("--disaggregation-ib-device") + 1],
+            "mlx5_6",
+        )
+        self.assertEqual(
+            decode_args[decode_args.index("--disaggregation-ib-device") + 1],
+            "mlx5_0",
+        )
+        self.assertEqual(
+            prefill_args[prefill_args.index("--watchdog-timeout") + 1], "3600"
+        )
+        self.assertEqual(
+            decode_args[decode_args.index("--watchdog-timeout") + 1], "3600"
+        )
+
+    def test_role_network_environment(self) -> None:
+        role = HcuPDRoleConfig(
+            role=ROLE_PREFILL,
+            host_ip="12.12.12.4",
+            ifname="ens47f0np0",
+            ib_device="mlx5_6",
+        )
+        env = minimax_m27_pd_env(role)
+        self.assertEqual(env["SGLANG_HOST_IP"], "12.12.12.4")
+        self.assertEqual(env["NCCL_SOCKET_IFNAME"], "ens47f0np0")
+        self.assertEqual(env["GLOO_SOCKET_IFNAME"], "ens47f0np0")
+        self.assertEqual(env["NCCL_IB_HCA"], "mlx5_6")
+        self.assertEqual(env["MC_GID_INDEX"], "3")
+
+    def test_router_contains_both_roles_and_bootstrap_port(self) -> None:
+        command = minimax_m27_router_command("12.12.12.4", "12.12.12.36")
+        self.assertIn(f"http://12.12.12.4:{PREFILL_PORT}", command)
+        self.assertIn(f"http://12.12.12.36:{DECODE_PORT}", command)
+        self.assertIn(str(BOOTSTRAP_PORT), command)
+        self.assertEqual(command[command.index("--port") + 1], str(ROUTER_PORT))
+
+
+class TestSharedState(unittest.TestCase):
+    def test_atomic_json_and_first_writer_wins(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = root / "state" / "result.json"
+            atomic_write_json(path, {"value": 1}, _shared_gid())
+            self.assertEqual(read_json(path), {"value": 1})
+            if os.name == "posix":
+                self.assertEqual(path.stat().st_mode & 0o777, 0o664)
+
+            once = root / "state" / "abort.json"
+            self.assertTrue(write_json_once(once, {"role": "prefill"}, _shared_gid()))
+            self.assertFalse(write_json_once(once, {"role": "decode"}, _shared_gid()))
+            self.assertEqual(read_json(once)["role"], "prefill")
+
+    @unittest.skipUnless(os.name == "posix", "POSIX permission semantics")
+    def test_existing_peer_owned_directory_only_needs_group_access(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "shared"
+            path.mkdir(mode=0o775)
+            path.chmod(0o2775)
+            with mock.patch.object(Path, "chmod", side_effect=PermissionError):
+                ensure_shared_dir(path, _shared_gid())
+
+    @unittest.skipUnless(os.name == "posix", "POSIX permission semantics")
+    def test_existing_directory_without_group_write_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "shared"
+            path.mkdir(mode=0o700)
+            path.chmod(0o700)
+            with mock.patch.object(Path, "chmod", side_effect=PermissionError):
+                with self.assertRaisesRegex(
+                    PDInfrastructureError, "incompatible ownership or mode"
+                ):
+                    ensure_shared_dir(path, _shared_gid())
+
+    def test_peer_claim_rejects_same_physical_host(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            context = _context(Path(temporary))
+            peer = {
+                **context.claim_payload(),
+                "role": ROLE_DECODE,
+                "runner_name": "runner-decode",
+                "hostname": context.hostname,
+                "ip": context.decode_ip,
+            }
+            with self.assertRaisesRegex(
+                PDInfrastructureError, "different physical hosts"
+            ):
+                PDOrchestrator(context)._validate_peer_claim(peer)
+
+    def test_peer_claim_rejects_different_image_id(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            context = _context(Path(temporary))
+            peer = {
+                **context.claim_payload(),
+                "role": ROLE_DECODE,
+                "runner_name": "runner-decode",
+                "hostname": "host-decode",
+                "ip": context.decode_ip,
+                "image_id": "sha256:different",
+            }
+            with self.assertRaisesRegex(PDInfrastructureError, "image_id"):
+                PDOrchestrator(context)._validate_peer_claim(peer)
+
+    def test_wheel_bundle_checks_all_three_wheels_and_sha256(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            context = _context(Path(temporary), ROLE_DECODE)
+            orchestrator = PDOrchestrator(context)
+            bundle = context.wheel_bundle
+            bundle.mkdir(parents=True)
+            wheels = []
+            for kind in ("sglang", "sglang-kernel", "sglang-router"):
+                wheel_path = bundle / f"{kind}.whl"
+                wheel_path.write_bytes(kind.encode())
+                wheels.append(
+                    {
+                        "kind": kind,
+                        "path": wheel_path.name,
+                        "sha256": hashlib.sha256(kind.encode()).hexdigest(),
+                    }
+                )
+            (bundle / "READY").write_text(TEST_SHA)
+            (bundle / "manifest.json").write_text(
+                json.dumps({"commit_sha": TEST_SHA, "wheels": wheels})
+            )
+
+            manifest = orchestrator.ensure_shared_wheels()
+            self.assertEqual(len(manifest["wheels"]), 3)
+
+            wheels[0]["sha256"] = "0" * 64
+            (bundle / "manifest.json").write_text(
+                json.dumps({"commit_sha": TEST_SHA, "wheels": wheels})
+            )
+            with self.assertRaisesRegex(PDInfrastructureError, "checksum mismatch"):
+                orchestrator.ensure_shared_wheels()
+
+    def test_http_health_accepts_plain_text_and_model_info_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            context = _context(Path(temporary))
+            orchestrator = PDOrchestrator(context)
+            server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthHandler)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                base_url = f"http://127.0.0.1:{server.server_port}"
+                self.assertEqual(
+                    orchestrator._http_json(f"{base_url}/health"),
+                    {"text": "OK"},
+                )
+                self.assertEqual(
+                    orchestrator._http_json(f"{base_url}/model_info")["model_path"],
+                    "/models/MiniMax-M2.7",
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/hcu/README.md
+++ b/test/registered/hcu/README.md
@@ -14,7 +14,7 @@ the convention used by `test/registered/amd/` and `test/registered/ascend/`.
 - `reranker/bw1100/` Reranker OpenAI API smoke tests.
 - `kernels/`         HCU-supported `sgl-kernel` whitelist tests.
 - `perf/`           Reserved for future BW1100 throughput / TTFT / TPOT / ITL benchmarks.
-- `disaggregation/`  Reserved for PD-disaggregation tests that need HCU-specific impls.
+- `disaggregation/bw1100/` Real two-node PD-disaggregation smoke tests.
 
 Broad HCU registrations for existing `test/registered/**` files live in their
 original feature directories.  The `test/registered/hcu/` subtree is only for
@@ -125,3 +125,23 @@ python3 test/run_suite.py --hw hcu --suite stage-b-test-1-hcu-small
 python3 test/run_suite.py --hw hcu --suite nightly-hcu-accuracy --nightly
 python3 test/run_suite.py --hw hcu --suite nightly-hcu-vlm --nightly
 ```
+
+## Two-node PD disaggregation
+
+`nightly-hcu-disaggregation-16gpu` is a real two-host suite. It is not a
+single-host emulation and must be launched through
+`.github/workflows/hcu-pd-1p1d.yml`.
+
+The initial MiniMax-M2.7 configuration uses eight BW1100 HCUs on each host:
+
+```text
+Prefill: TP2 / PP4 / DP1
+Decode:  TP8 / PP1 / DP1
+Router:  runs on the Prefill host
+KV:      Mooncake over one explicitly selected RDMA rail
+RoCE:    GID index 3 (IPv4 RoCE v2 on the selected rail)
+```
+
+The workflow verifies both service identities before sending requests through
+the Router. Direct execution of the registered test requires the P, D, and
+Router services to be running already.

--- a/test/registered/hcu/disaggregation/bw1100/test_minimax_m27_pd_hcu.py
+++ b/test/registered/hcu/disaggregation/bw1100/test_minimax_m27_pd_hcu.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import requests
+
+from sglang.test.ci.ci_register import register_hcu_ci
+from sglang.test.hcu_pd_utils import (
+    DECODE_PORT,
+    PREFILL_PORT,
+    ROUTER_PORT,
+    resolve_minimax_m27_model_path,
+)
+
+register_hcu_ci(
+    est_time=10800,
+    suite="nightly-hcu-disaggregation-16gpu",
+    nightly=True,
+)
+
+
+def _normalized_model_path(value: str) -> str:
+    return value.strip().rstrip("/")
+
+
+def _write_result(payload: dict) -> None:
+    result_path = os.environ.get("HCU_PD_SMOKE_RESULT_PATH")
+    if not result_path:
+        return
+    path = Path(result_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+    os.replace(temporary, path)
+
+
+class TestMiniMaxM27PDHCU(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.prefill_ip = os.environ["HCU_PD_PREFILL_IP"]
+        cls.decode_ip = os.environ["HCU_PD_DECODE_IP"]
+        cls.model_path = resolve_minimax_m27_model_path()
+        cls.prefill_url = f"http://{cls.prefill_ip}:{PREFILL_PORT}"
+        cls.decode_url = f"http://{cls.decode_ip}:{DECODE_PORT}"
+        cls.router_url = f"http://{cls.prefill_ip}:{ROUTER_PORT}"
+
+    def _assert_health_and_model(self, base_url: str) -> None:
+        response = requests.get(f"{base_url}/health", timeout=10)
+        self.assertEqual(response.status_code, 200, response.text)
+
+        response = requests.get(f"{base_url}/model_info", timeout=10)
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertEqual(
+            _normalized_model_path(payload.get("model_path", "")),
+            _normalized_model_path(self.model_path),
+            payload,
+        )
+
+    def _chat(self) -> dict:
+        response = requests.post(
+            f"{self.router_url}/v1/chat/completions",
+            json={
+                "model": self.model_path,
+                "messages": [
+                    {"role": "user", "content": "请只输出“北京”两个字，不要解释。"}
+                ],
+                "temperature": 0,
+                "max_tokens": 256,
+            },
+            timeout=180,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        choice = payload["choices"][0]
+        self.assertNotEqual(choice.get("finish_reason"), "length", payload)
+        content = choice["message"]["content"]
+        self.assertIsInstance(content, str)
+        self.assertTrue(content.strip(), payload)
+        self.assertNotIn("\ufffd", content)
+        final_content = content.rsplit("</think>", 1)[-1].strip()
+        self.assertIn("北京", final_content, payload)
+        return {
+            "content": content,
+            "finish_reason": choice.get("finish_reason"),
+        }
+
+    def test_minimax_m27_pd_smoke(self) -> None:
+        started_at = time.monotonic()
+        self._assert_health_and_model(self.prefill_url)
+        self._assert_health_and_model(self.decode_url)
+
+        single_response = self._chat()
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            concurrent_responses = list(pool.map(lambda _: self._chat(), range(4)))
+
+        _write_result(
+            {
+                "model": self.model_path,
+                "single_request": single_response,
+                "concurrent_request_count": len(concurrent_responses),
+                "duration_seconds": round(time.monotonic() - started_at, 3),
+                "passed": True,
+            }
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/hcu/disaggregation/bw1100/test_minimax_m27_pd_hcu.py
+++ b/test/registered/hcu/disaggregation/bw1100/test_minimax_m27_pd_hcu.py
@@ -1,16 +1,5 @@
-# Copyright 2026 Hygon Information Technology Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -218,6 +218,7 @@ NIGHTLY_SUITES = {
         "nightly-hcu-quant-opt",
         "nightly-hcu-functional-long",
         "nightly-hcu-api-models",
+        "nightly-hcu-disaggregation-16gpu",
     ],
 }
 

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -1,16 +1,6 @@
-# Modifications Copyright 2026 Hygon Information Technology Co., Ltd.
-#
-# Hygon modifications to this file are licensed under the Apache License,
-# Version 2.0 (the "License"); you may not use these modifications except
-# in compliance with the License. You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+# Modified by Hygon Information Technology Co., Ltd., 2026.
 
 import argparse
 import glob


### PR DESCRIPTION
## Summary
- add a manual-only two-node 16-HCU MiniMax-M2.7 1P1D smoke workflow
- coordinate prefill/decode runners through `/ci_public` and install the same SHA-scoped wheel set on both nodes
- validate runner roles, physical hosts, image IDs, model paths, RDMA rails, health endpoints, and process cleanup
- keep existing PR/nightly suites unchanged; no schedule, performance threshold, accuracy threshold, Feishu notification, GitHub Artifact, or PyPI upload

## Topology
- Prefill: 8 HCU, TP2 / PP4 / DP1, port 30000
- Decode: 8 HCU, TP8 / PP1 / DP1, port 30001
- Router: prefill node, port 30002
- Mooncake bootstrap: port 8998

## Validation
- offline unit tests: 10 passed
- actionlint: passed
- bash syntax checks: passed
- Black and git diff checks: passed
- HCU suite registration check: passed
- disposable Ubuntu 22 wheel installation and Router startup: passed
- real two-node strict smoke: passed (single request plus four concurrent requests, final answer `??`, no truncation)
- cleanup verified: no residual containers, processes, target ports, or HCU allocations

Strict run logs and results:
`/ci_public/sglang-das/hcu-pd/run-2026072805/attempt-1/`







<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->