### PR TITLE
ci: add HCU PD disaggregation smoke tests

### DIFF
--- a/test/registered/hcu/disaggregation/pd_hcu_utils.py
+++ b/test/registered/hcu/disaggregation/pd_hcu_utils.py
@@ -7,6 +7,7 @@ import os
 import unittest
 from pathlib import Path
 
+from sglang.test.ci.ci_register import register_hcu_ci
 from sglang.test.hcu_utils import assert_generate_non_empty
 from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
@@ -16,9 +17,6 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     popen_launch_pd_server,
 )
-
-from sglang.test.ci.ci_register import register_hcu_ci
-
 
 register_hcu_ci(
     est_time=1,
@@ -41,14 +39,10 @@ BACKEND_MODULES = {
 
 def parse_backend_names(value: str | None = None) -> list[str]:
     raw = (
-        os.environ.get("SGLANG_HCU_PD_BACKENDS", "mooncake")
-        if value is None
-        else value
+        os.environ.get("SGLANG_HCU_PD_BACKENDS", "mooncake") if value is None else value
     )
     names = list(
-        dict.fromkeys(
-            item.strip().lower() for item in raw.split(",") if item.strip()
-        )
+        dict.fromkeys(item.strip().lower() for item in raw.split(",") if item.strip())
     )
     unknown = [name for name in names if name not in BACKEND_MODULES]
     if unknown:

--- a/test/registered/hcu/disaggregation/pd_hcu_utils.py
+++ b/test/registered/hcu/disaggregation/pd_hcu_utils.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+
+from sglang.test.hcu_utils import assert_generate_non_empty
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+    get_rdma_devices_args,
+)
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_pd_server,
+)
+
+
+DEFAULT_HCU_PD_MODEL = (
+    "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-0.5B-Instruct"
+)
+SUPPORTED_BACKENDS = ("mooncake", "nixl", "mori")
+BACKEND_MODULES = {
+    "mooncake": "mooncake",
+    "nixl": "nixl",
+    "mori": "mori",
+}
+
+
+def parse_backend_names(value: str | None = None) -> list[str]:
+    raw = (
+        os.environ.get("SGLANG_HCU_PD_BACKENDS", "mooncake")
+        if value is None
+        else value
+    )
+    names = list(
+        dict.fromkeys(
+            item.strip().lower() for item in raw.split(",") if item.strip()
+        )
+    )
+    unknown = [name for name in names if name not in BACKEND_MODULES]
+    if unknown:
+        raise ValueError(
+            f"Unsupported HCU PD backend(s): {unknown}; "
+            f"expected one of {list(SUPPORTED_BACKENDS)}"
+        )
+    if not names:
+        raise ValueError("At least one HCU PD backend must be selected.")
+    return names
+
+
+def backend_module_name(backend: str) -> str:
+    try:
+        return BACKEND_MODULES[backend.lower()]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported HCU PD backend: {backend}") from exc
+
+
+def transfer_backend_available(backend: str) -> bool:
+    return importlib.util.find_spec(backend_module_name(backend)) is not None
+
+
+def require_transfer_backend(backend: str):
+    module_name = backend_module_name(backend)
+    if not transfer_backend_available(backend):
+        raise unittest.SkipTest(
+            f"HCU PD backend '{backend}' is blocked: Python module "
+            f"'{module_name}' is not installed in this image."
+        )
+    try:
+        return importlib.import_module(module_name)
+    except BaseException as exc:
+        raise AssertionError(
+            f"HCU PD backend '{backend}' module '{module_name}' exists "
+            f"but failed to import: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def resolve_model_path() -> str:
+    model_path = os.environ.get("SGLANG_HCU_PD_MODEL", DEFAULT_HCU_PD_MODEL)
+    if not Path(model_path).is_dir():
+        if "SGLANG_HCU_PD_MODEL" in os.environ:
+            raise AssertionError(
+                f"SGLANG_HCU_PD_MODEL points to a missing directory: {model_path}"
+            )
+        raise unittest.SkipTest(f"Default HCU PD model is not available: {model_path}")
+    return model_path
+
+
+def active_rdma_devices() -> list[str]:
+    ib_root = Path("/sys/class/infiniband")
+    if not ib_root.is_dir():
+        return []
+
+    devices = []
+    for device in sorted(ib_root.iterdir()):
+        state_file = device / "ports" / "1" / "state"
+        try:
+            state = state_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if "ACTIVE" in state.upper():
+            devices.append(device.name)
+    return devices
+
+
+def resolve_rdma_args() -> list[str]:
+    devices = os.environ.get("SGLANG_TEST_RDMA_DEVICE")
+    if not devices:
+        active_devices = active_rdma_devices()
+        devices = (
+            ",".join(active_devices) if active_devices else get_rdma_devices_args()
+        )
+    return ["--disaggregation-ib-device", devices] if devices else []
+
+
+def require_hcu_devices(minimum: int) -> list[str]:
+    try:
+        import torch
+    except BaseException as exc:
+        raise unittest.SkipTest(f"DTK PyTorch is not importable: {exc}") from exc
+
+    if not torch.cuda.is_available():
+        raise unittest.SkipTest("DTK PyTorch reports no visible HCU devices.")
+    count = torch.cuda.device_count()
+    if count < minimum:
+        raise unittest.SkipTest(
+            f"HCU PD smoke requires at least {minimum} visible devices; found {count}."
+        )
+    return [torch.cuda.get_device_name(index) for index in range(count)]
+
+
+class HcuPDServerBase(PDDisaggregationServerBase):
+    pd_backend = "mooncake"
+    required_gpus = 2
+    port_delta = 0
+    prefill_tp = 1
+    prefill_pp = 1
+    decode_tp = 1
+    decode_base_gpu_id = 1
+    disable_overlap_schedule = False
+
+    @classmethod
+    def setUpClass(cls):
+        require_hcu_devices(cls.required_gpus)
+        require_transfer_backend(cls.pd_backend)
+        super().setUpClass()
+
+        cls.model = resolve_model_path()
+        cls.transfer_backend = [
+            "--disaggregation-transfer-backend",
+            cls.pd_backend,
+        ]
+        cls.rdma_devices = resolve_rdma_args()
+        cls._shift_ports()
+
+        try:
+            cls.launch_all()
+        except BaseException:
+            super().tearDownClass()
+            raise
+
+    @classmethod
+    def _shift_ports(cls):
+        if not cls.port_delta:
+            return
+        cls.lb_port = str(int(cls.lb_port) + cls.port_delta)
+        cls.prefill_port = str(int(cls.prefill_port) + cls.port_delta)
+        cls.decode_port = str(int(cls.decode_port) + cls.port_delta)
+        cls.bootstrap_port = str(int(cls.bootstrap_port) + cls.port_delta)
+        cls.prefill_url = f"http://{cls.base_host}:{cls.prefill_port}"
+        cls.decode_url = f"http://{cls.base_host}:{cls.decode_port}"
+        cls.lb_url = f"http://{cls.base_host}:{cls.lb_port}"
+        cls.base_url = cls.lb_url
+
+    @classmethod
+    def _common_server_args(cls, mode: str) -> list[str]:
+        return [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            mode,
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--attention-backend",
+            "fa3",
+            "--page-size",
+            "64",
+            "--log-level",
+            "warning",
+            "--log-level-http",
+            "warning",
+        ]
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = cls._common_server_args("prefill") + [
+            "--tp-size",
+            str(cls.prefill_tp),
+        ]
+        if cls.prefill_pp > 1:
+            prefill_args += ["--pp-size", str(cls.prefill_pp)]
+        if cls.disable_overlap_schedule:
+            prefill_args.append("--disable-overlap-schedule")
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = cls._common_server_args("decode") + [
+            "--tp-size",
+            str(cls.decode_tp),
+            "--base-gpu-id",
+            str(cls.decode_base_gpu_id),
+        ]
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def assert_generate_smoke(self):
+        output = assert_generate_non_empty(
+            self.lb_url,
+            text="The capital of China is",
+            max_new_tokens=8,
+        )
+        self.assertGreater(len(output.strip()), 0)

--- a/test/registered/hcu/disaggregation/pd_hcu_utils.py
+++ b/test/registered/hcu/disaggregation/pd_hcu_utils.py
@@ -17,6 +17,16 @@ from sglang.test.test_utils import (
     popen_launch_pd_server,
 )
 
+from sglang.test.ci.ci_register import register_hcu_ci
+
+
+register_hcu_ci(
+    est_time=1,
+    suite="nightly-hcu",
+    nightly=True,
+    disabled="Support module only; covered by test_pd_hcu_utils.py.",
+)
+
 
 DEFAULT_HCU_PD_MODEL = (
     "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-0.5B-Instruct"

--- a/test/registered/hcu/disaggregation/test_pd_basic_hcu.py
+++ b/test/registered/hcu/disaggregation/test_pd_basic_hcu.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+
+from sglang.test.ci.ci_register import register_hcu_ci
+
+try:
+    from .pd_hcu_utils import HcuPDServerBase
+except ImportError:
+    from pd_hcu_utils import HcuPDServerBase
+
+
+register_hcu_ci(est_time=600, suite="nightly-hcu", nightly=True)
+
+
+class TestHcuPDBasic(HcuPDServerBase):
+    pd_backend = os.environ.get("SGLANG_HCU_PD_BACKEND", "mooncake")
+
+    def test_generate_smoke(self):
+        self.assert_generate_smoke()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/hcu/disaggregation/test_pd_environment_hcu.py
+++ b/test/registered/hcu/disaggregation/test_pd_environment_hcu.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import unittest
+
+from sglang.srt.disaggregation.utils import (
+    KVClassType,
+    TransferBackend,
+    get_kv_class,
+)
+from sglang.test.ci.ci_register import register_hcu_ci
+
+try:
+    from .pd_hcu_utils import (
+        active_rdma_devices,
+        require_hcu_devices,
+        require_transfer_backend,
+        transfer_backend_available,
+    )
+except ImportError:
+    from pd_hcu_utils import (
+        active_rdma_devices,
+        require_hcu_devices,
+        require_transfer_backend,
+        transfer_backend_available,
+    )
+
+
+register_hcu_ci(est_time=60, suite="stage-b-test-1-hcu-small")
+
+
+class TestHcuPDEnvironment(unittest.TestCase):
+    def test_hcu_devices_are_visible(self):
+        device_names = require_hcu_devices(2)
+        print(f"HCU PD visible devices ({len(device_names)}): {device_names}")
+        self.assertGreaterEqual(len(device_names), 2)
+
+    def test_rdma_devices_are_active(self):
+        devices = active_rdma_devices()
+        print(f"HCU PD active RDMA devices ({len(devices)}): {devices}")
+        self.assertTrue(devices, "No active RDMA device was found in sysfs.")
+
+    def test_router_is_importable(self):
+        router = importlib.import_module("sglang_router")
+        self.assertIsNotNone(router)
+
+    def test_mooncake_sglang_adapter_is_importable(self):
+        require_transfer_backend("mooncake")
+        manager_cls = get_kv_class(TransferBackend.MOONCAKE, KVClassType.MANAGER)
+        self.assertIsNotNone(manager_cls)
+
+    def test_optional_backend_inventory(self):
+        inventory = {
+            backend: transfer_backend_available(backend)
+            for backend in ("mooncake", "nixl", "mori")
+        }
+        print(f"HCU PD transport inventory: {inventory}")
+        self.assertTrue(inventory["mooncake"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/hcu/disaggregation/test_pd_hcu_utils.py
+++ b/test/registered/hcu/disaggregation/test_pd_hcu_utils.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_hcu_ci
+
+try:
+    from .pd_hcu_utils import (
+        backend_module_name,
+        parse_backend_names,
+        resolve_model_path,
+        resolve_rdma_args,
+    )
+except ImportError:
+    from pd_hcu_utils import (
+        backend_module_name,
+        parse_backend_names,
+        resolve_model_path,
+        resolve_rdma_args,
+    )
+
+
+register_hcu_ci(est_time=30, suite="stage-b-test-1-hcu-small")
+
+
+class TestHcuPDUtils(unittest.TestCase):
+    def test_parse_backend_names_normalizes_and_deduplicates(self):
+        self.assertEqual(
+            parse_backend_names(" Mooncake,nixl,mooncake "),
+            ["mooncake", "nixl"],
+        )
+
+    def test_parse_backend_names_rejects_unknown_backend(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported HCU PD backend"):
+            parse_backend_names("mooncake,unknown")
+
+    def test_backend_module_mapping(self):
+        self.assertEqual(backend_module_name("mooncake"), "mooncake")
+        self.assertEqual(backend_module_name("nixl"), "nixl")
+        self.assertEqual(backend_module_name("mori"), "mori")
+
+    def test_resolve_model_path_accepts_existing_override(self):
+        with tempfile.TemporaryDirectory() as model_dir:
+            with patch.dict(
+                os.environ,
+                {"SGLANG_HCU_PD_MODEL": model_dir},
+                clear=False,
+            ):
+                self.assertEqual(resolve_model_path(), model_dir)
+
+    def test_resolve_model_path_rejects_missing_override(self):
+        with patch.dict(
+            os.environ,
+            {"SGLANG_HCU_PD_MODEL": "/missing/hcu-pd-model"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(AssertionError, "missing directory"):
+                resolve_model_path()
+
+    def test_resolve_rdma_args_prefers_explicit_environment(self):
+        with patch.dict(
+            os.environ,
+            {"SGLANG_TEST_RDMA_DEVICE": "mlx5_1,mlx5_5"},
+            clear=False,
+        ):
+            self.assertEqual(
+                resolve_rdma_args(),
+                ["--disaggregation-ib-device", "mlx5_1,mlx5_5"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/hcu/disaggregation/test_pd_pp_hcu.py
+++ b/test/registered/hcu/disaggregation/test_pd_pp_hcu.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+
+from sglang.test.ci.ci_register import register_hcu_ci
+
+try:
+    from .pd_hcu_utils import HcuPDServerBase
+except ImportError:
+    from pd_hcu_utils import HcuPDServerBase
+
+
+register_hcu_ci(est_time=900, suite="nightly-hcu", nightly=True)
+
+
+class TestHcuPDPipelineParallel(HcuPDServerBase):
+    pd_backend = os.environ.get("SGLANG_HCU_PD_BACKEND", "mooncake")
+    required_gpus = 6
+    port_delta = 100
+    prefill_tp = 2
+    prefill_pp = 2
+    decode_tp = 2
+    decode_base_gpu_id = 4
+    disable_overlap_schedule = True
+
+    def test_generate_smoke(self):
+        self.assert_generate_smoke()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/hcu/disaggregation/test_pd_transfer_backends_hcu.py
+++ b/test/registered/hcu/disaggregation/test_pd_transfer_backends_hcu.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from sglang.test.ci.ci_register import register_hcu_ci
+
+try:
+    from .pd_hcu_utils import HcuPDServerBase, parse_backend_names
+except ImportError:
+    from pd_hcu_utils import HcuPDServerBase, parse_backend_names
+
+
+register_hcu_ci(est_time=1200, suite="nightly-hcu", nightly=True)
+
+
+def _make_backend_test(backend: str, index: int):
+    class TestHcuPDTransferBackend(HcuPDServerBase):
+        pd_backend = backend
+        port_delta = 20 * (index + 1)
+
+        def test_generate_smoke(self):
+            self.assert_generate_smoke()
+
+    TestHcuPDTransferBackend.__name__ = f"TestHcuPD{backend.title()}Transfer"
+    TestHcuPDTransferBackend.__qualname__ = TestHcuPDTransferBackend.__name__
+    TestHcuPDTransferBackend.__module__ = __name__
+    return TestHcuPDTransferBackend
+
+
+for _index, _backend in enumerate(parse_backend_names()):
+    globals()[f"TestHcuPD{_backend.title()}Transfer"] = _make_backend_test(
+        _backend,
+        _index,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an HCU PD test helper using the existing SGLang disaggregation fixtures and router
- add Mooncake basic, transfer-engine, and PP smoke coverage with real generation requests
- add HCU environment preflight and helper unit tests
- keep NIXL and MORI selectable through `SGLANG_HCU_PD_BACKENDS` when their image dependencies are available

## Scope

This PR adds 6 new files under `test/registered/hcu/disaggregation/` only. It does not modify SGLang runtime source, existing AMD tests, workflows, or documentation.

The default backend is Mooncake, so the current image collects 14 runnable tests without producing expected skips for unavailable optional backends.

## Validation

- `git diff --check`
- exact copyright-header and Python syntax validation for all 6 files
- default collection: 14 tests
- helper and HCU environment preflight: 11 passed
- Mooncake basic PD smoke: passed with a real `/generate` request
- Mooncake transfer-engine smoke: passed with a real `/generate` request
- Mooncake PP smoke (prefill TP2/PP2 + decode TP2): passed with a real `/generate` request

NIXL and MORI runtime execution is not claimed because those Python modules are not installed in the current HCU CI image.





<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->