### PR TITLE
fix(hcu): correct GLM-4.7 FP8 MoE scaling and initialization

### DIFF
--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -511,13 +511,26 @@ class Glm4MoeSparseMoeBlock(nn.Module):
                     # For compressed-tensors ptpc model, don't need to check the weight_block_size
                     pass
                 else:
-                    assert (
-                        self.shared_experts.gate_up_proj.quant_method.quant_config.weight_block_size
-                        == self.shared_experts.down_proj.quant_method.quant_config.weight_block_size
+                    gate_up_quant_config = getattr(
+                        self.shared_experts.gate_up_proj.quant_method,
+                        "quant_config",
+                        None,
                     )
-                    self.shared_experts_weight_block_size = (
-                        self.shared_experts.gate_up_proj.quant_method.quant_config.weight_block_size
+                    down_proj_quant_config = getattr(
+                        self.shared_experts.down_proj.quant_method,
+                        "quant_config",
+                        None,
                     )
+                    if (
+                        gate_up_quant_config is not None
+                        or down_proj_quant_config is not None
+                    ):
+                        assert getattr(
+                            gate_up_quant_config, "weight_block_size", None
+                        ) == getattr(down_proj_quant_config, "weight_block_size", None)
+                        self.shared_experts_weight_block_size = getattr(
+                            gate_up_quant_config, "weight_block_size", None
+                        )
 
         self.top_k = config.num_experts_per_tok
 
@@ -635,7 +648,9 @@ class Glm4MoeSparseMoeBlock(nn.Module):
             topk_output = self.topk.empty_topk_output(hidden_states.device)
 
         final_hidden_states = self.experts(hidden_states, topk_output)
-        if not _is_cuda and not _use_aiter:
+        # HCU's Triton MoE fallback applies routed_scaling_factor in
+        # moe_sum_reduce_triton; applying it again here would yield factor^2.
+        if not _is_cuda and not _is_hcu and not _use_aiter:
             final_hidden_states *= self.routed_scaling_factor
         if shared_output is not None:
             with use_symmetric_memory(


### PR DESCRIPTION
## 动机

GLM-4.7 的 HCU channel-FP8 路径会对 `routed_scaling_factor` 做两次缩放：一次在 HCU Triton MoE 的 sum-reduce 路径中，另一次在模型 wrapper 中。当模型系数为 2.5 时，routed expert 的实际缩放变为 6.25，导致严重精度回退。此外，shared FP8 expert 初始化假设每种线性量化方法都提供 `quant_config`，而 `W8A8Fp8LinearMethod` 并不具备该属性。

## 修改内容

- 在 `Glm4MoeSparseMoeBlock.forward_normal` 中排除 HCU 的框架侧 routed-expert scaling；HCU MoE 由 `moe_sum_reduce_triton` 负责该缩放。
- 读取 shared expert 的 `weight_block_size` 前安全获取 `quant_config`；当任一 quant config 存在时，仍保留两侧 block size 一致性断言。



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->