### PR TITLE
[fix] Fixed accuracy issue caused by aiter‑moe in Qwen3.6‑35B‑A3B‑W8A8

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -378,7 +378,7 @@ def _get_aiter_w8a8_weights_for_solution(
     layer = quant_info.layer
 
     with torch.no_grad():
-        w1_moe_c = moe_layout_shuffle_gemm1(quant_info.w13_weight).view(
+        w1_moe_c = moe_layout_shuffle_gemm2(quant_info.w13_weight).view(
             *quant_info.w13_weight.shape
         )
         w2_moe_c = moe_layout_shuffle_gemm2(quant_info.w2_weight).view(
@@ -460,6 +460,7 @@ def _run_aiter_w8a8(
         gemm1_alpha=runner_config.gemm1_alpha,
         gemm1_limit=runner_config.gemm1_clamp_limit,
     )
+
     return AiterRunnerOutput(hidden_states=output)
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -104,12 +104,10 @@ def process_weights_after_loading_aiter_w8a8_int8(layer: torch.nn.Module) -> Non
 
     moe_runner_config = getattr(layer, "moe_runner_config", None)
     if getattr(layer, "apply_router_weight_on_input", False) or (
-        moe_runner_config is not None
-        and moe_runner_config.apply_router_weight_on_input
+        moe_runner_config is not None and moe_runner_config.apply_router_weight_on_input
     ):
         raise RuntimeError(
-            "AITER W8A8 INT8 MoE does not support "
-            "apply_router_weight_on_input=True."
+            "AITER W8A8 INT8 MoE does not support " "apply_router_weight_on_input=True."
         )
 
     setattr(layer, "_aiter_w8a8_int8_original_w13_shape", tuple(layer.w13_weight.shape))
@@ -122,12 +120,10 @@ def process_weights_after_loading_aiter_w8a8_fp8(layer: torch.nn.Module) -> None
 
     moe_runner_config = getattr(layer, "moe_runner_config", None)
     if getattr(layer, "apply_router_weight_on_input", False) or (
-        moe_runner_config is not None
-        and moe_runner_config.apply_router_weight_on_input
+        moe_runner_config is not None and moe_runner_config.apply_router_weight_on_input
     ):
         raise RuntimeError(
-            "AITER FP8 W8A8 MoE does not support "
-            "apply_router_weight_on_input=True."
+            "AITER FP8 W8A8 MoE does not support " "apply_router_weight_on_input=True."
         )
 
     setattr(layer, "_aiter_w8a8_fp8_original_w13_shape", tuple(layer.w13_weight.shape))
@@ -353,7 +349,7 @@ def _get_aiter_w8a8_weights_for_solution(
     moe_config,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     from aiter.moe import MoeSolutionType
-    from aiter.ops.shuffle import moe_layout_shuffle_gemm1, moe_layout_shuffle_gemm2
+    from aiter.ops.shuffle import moe_layout_shuffle_gemm2
 
     solution_type = moe_config.solution_type
     need_shuffle = getattr(
@@ -372,9 +368,7 @@ def _get_aiter_w8a8_weights_for_solution(
     if quant_info.moe_c_weight_layout:
         return quant_info.w13_weight, quant_info.w2_weight
 
-    cache_prefix = (
-        "_aiter_w8a8_fp8" if quant_info.use_fp8_w8a8 else "_aiter_w8a8_int8"
-    )
+    cache_prefix = "_aiter_w8a8_fp8" if quant_info.use_fp8_w8a8 else "_aiter_w8a8_int8"
     layer = quant_info.layer
 
     with torch.no_grad():
@@ -405,8 +399,7 @@ def _run_aiter_w8a8(
     assert not runner_config.no_combine, "no_combine=True is not supported by AITER"
     if runner_config.apply_router_weight_on_input:
         raise RuntimeError(
-            "AITER W8A8 MoE does not support "
-            "apply_router_weight_on_input=True."
+            "AITER W8A8 MoE does not support " "apply_router_weight_on_input=True."
         )
 
     hidden_states = runner_input.hidden_states
@@ -424,9 +417,7 @@ def _run_aiter_w8a8(
         activation,
         quant_info,
     )
-    w1, w2 = _get_aiter_w8a8_weights_for_solution(
-        quant_info, moe_config
-    )
+    w1, w2 = _get_aiter_w8a8_weights_for_solution(quant_info, moe_config)
     routed_scaling_factor = (
         runner_config.routed_scaling_factor
         if runner_config.routed_scaling_factor is not None
@@ -460,7 +451,6 @@ def _run_aiter_w8a8(
         gemm1_alpha=runner_config.gemm1_alpha,
         gemm1_limit=runner_config.gemm1_clamp_limit,
     )
-
     return AiterRunnerOutput(hidden_states=output)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix accuracy regression of Qwen3.6‑35B‑A3B‑W8A8 caused by aiter‑moe implementation.
The original aiter‑moe path produces incorrect output logits under A3B W8A8 quantization, leading to obvious accuracy degradation. This PR fixes this issue to ensure numerical correctness for quantized MoE inference.

## Modifications

Fix numerical bug inside aiter.py for aiter‑moe kernel path
Correct computation logic for Qwen3.6‑35B‑A3B‑W8A8  MoE forward pass
No changes to other kernel paths or non‑MoE workflows

## Accuracy Tests

Verified on Qwen3.6‑35B‑A3B‑W8A8. Accuracy metric of gms8k and humaneval returns to expected normal level after the fix.

<img width="1527" height="474" alt="gsm8k" src="https://github.com/user-attachments/assets/88e8a0d8-76fc-4428-8ade-02df015294fd" />
<img width="1520" height="466" alt="humaneval" src="https://github.com/user-attachments/assets/679aa2f2-e9fa-4662-8985-42f7229538c4" />

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->