### PR TITLE
ci: install PyYAML for slash command handler

### DIFF
--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install PyGithub
+          pip install PyGithub PyYAML
 
       - name: Handle Slash Command
         env:


### PR DESCRIPTION
## Summary
- Install PyYAML for the Slash Command Handler.
- Fix /rerun-failed-ci failing before dispatch when runner_configs imports yaml.

## Validation
- git diff --check passed.
- Reproduced from Slash Command Handler run 30601977733.