### PR TITLE
[Opt]Optimize DSV4 C128 state pool with request-scoped allocation

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
@@ -57,7 +57,7 @@ struct Prefill1Params {
   PlanW* plan_w;
   const RID_T* rid_ptr;  // [batch_size]
   const R2T_T* r2t_ptr;  // [num_reqs, stride_r2t]
-  const F2S_T* f2s_ptr;  // [num_swa_slots]
+  const F2S_T* f2s_ptr;  // full_loc -> swa_loc (C4 and legacy C128)
   int64_t stride_r2t;
   uint32_t num_c;
   uint32_t num_w;
@@ -67,19 +67,21 @@ struct Prefill1Params {
   int32_t swa_page_size;
   int32_t ring_size;
   int32_t compress_ratio;
+  bool request_scoped_c128_state;
 };
 
 struct DecodeParams {
   PlanD* plan_d;
   const RID_T* rid_ptr;  // [batch_size]
   const R2T_T* r2t_ptr;  // [num_reqs, stride_r2t]
-  const F2S_T* f2s_ptr;  // [num_swa_slots]
+  const F2S_T* f2s_ptr;  // full_loc -> swa_loc (C4 and legacy C128)
   const IDX_T* seq_ptr;  // [batch_size]
   int64_t stride_r2t;
   uint32_t batch_size;
   int32_t swa_page_size;
   int32_t ring_size;
   int32_t compress_ratio;
+  bool request_scoped_c128_state;
 };
 
 struct Prefill1ParamsLegacy {
@@ -285,6 +287,9 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
     const auto ring_offset = swa_loc % params.ring_size;
     return swa_page * params.ring_size + ring_offset;
   };
+  const auto compute_c128_loc = [&](int64_t rid, int32_t position) {
+    return static_cast<int32_t>(rid * params.ring_size + position % params.ring_size);
+  };
 
   if (!plan_c.is_invalid()) {  // 1. in bound. 2. not masked
     if (plan_c.buffer_len > 0) {
@@ -295,12 +300,17 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
       const auto position_1 = static_cast<int32_t>(plan_c.seq_len - 1);
       // only used for c4, harmless for c128
       const auto position_0 = max(position_1 - params.compress_ratio, 0);
-      const auto raw_loc_0 = mapping[position_0];
-      const auto raw_loc_1 = mapping[position_1];
-      const auto swa_loc_0 = params.f2s_ptr[raw_loc_0];
-      const auto swa_loc_1 = params.f2s_ptr[raw_loc_1];
-      plan_c.read_page_0 = compute_loc(swa_loc_0) / params.compress_ratio;
-      plan_c.read_page_1 = compute_loc(swa_loc_1) / params.compress_ratio;
+      if (params.request_scoped_c128_state && params.compress_ratio == 128) {
+        plan_c.read_page_0 = compute_c128_loc(rid, position_0) / 128;
+        plan_c.read_page_1 = compute_c128_loc(rid, position_1) / 128;
+      } else {
+        const auto raw_loc_0 = mapping[position_0];
+        const auto raw_loc_1 = mapping[position_1];
+        const auto swa_loc_0 = params.f2s_ptr[raw_loc_0];
+        const auto swa_loc_1 = params.f2s_ptr[raw_loc_1];
+        plan_c.read_page_0 = compute_loc(swa_loc_0) / params.compress_ratio;
+        plan_c.read_page_1 = compute_loc(swa_loc_1) / params.compress_ratio;
+      }
       params.plan_c[idx] = plan_c;
     }
   } else if (idx < params.num_c_padded) {
@@ -315,10 +325,14 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
     const auto mapping = params.r2t_ptr + rid * params.stride_r2t;
     // `seq_len` (`write_loc`) may not be aligned here
     const auto position = static_cast<int32_t>(plan_w.write_loc - 1);
-    const auto raw_loc = mapping[position];
-    const auto swa_loc = params.f2s_ptr[raw_loc];
     plan_w.ragged_id = ragged_id;
-    plan_w.write_loc = compute_loc(swa_loc);
+    if (params.request_scoped_c128_state && params.compress_ratio == 128) {
+      plan_w.write_loc = compute_c128_loc(rid, position);
+    } else {
+      const auto raw_loc = mapping[position];
+      const auto swa_loc = params.f2s_ptr[raw_loc];
+      plan_w.write_loc = compute_loc(swa_loc);
+    }
     params.plan_w[idx] = plan_w;
   } else if (idx < params.num_w_padded) {
     params.plan_w[idx] = PlanW::invalid();
@@ -335,16 +349,28 @@ __global__ void plan_compress_decode_kernel(const DecodeParams params) {
     const auto ring_offset = swa_loc % params.ring_size;
     return swa_page * params.ring_size + ring_offset;
   };
+  const auto compute_c128_loc = [&](int64_t rid, int32_t position) {
+    return static_cast<int32_t>(rid * params.ring_size + position % params.ring_size);
+  };
   const auto seq_len = static_cast<int32_t>(params.seq_ptr[idx]);
   const auto position_1 = static_cast<int32_t>(seq_len - 1);
   const auto position_0 = max(position_1 - params.compress_ratio, 0);
-  const auto raw_loc_0 = mapping[position_0];
-  const auto raw_loc_1 = mapping[position_1];
-  const auto swa_loc_0 = params.f2s_ptr[raw_loc_0];
-  const auto swa_loc_1 = params.f2s_ptr[raw_loc_1];
-  const auto write_loc = compute_loc(swa_loc_1);
-  const auto read_page_0 = compute_loc(swa_loc_0) / params.compress_ratio;
-  const auto read_page_1 = write_loc / params.compress_ratio;
+  int32_t write_loc;
+  int32_t read_page_0;
+  int32_t read_page_1;
+  if (params.request_scoped_c128_state && params.compress_ratio == 128) {
+    write_loc = compute_c128_loc(rid, position_1);
+    read_page_0 = compute_c128_loc(rid, position_0) / 128;
+    read_page_1 = compute_c128_loc(rid, position_1) / 128;
+  } else {
+    const auto raw_loc_0 = mapping[position_0];
+    const auto raw_loc_1 = mapping[position_1];
+    const auto swa_loc_0 = params.f2s_ptr[raw_loc_0];
+    const auto swa_loc_1 = params.f2s_ptr[raw_loc_1];
+    write_loc = compute_loc(swa_loc_1);
+    read_page_0 = compute_loc(swa_loc_0) / params.compress_ratio;
+    read_page_1 = write_loc / params.compress_ratio;
+  }
   params.plan_d[idx] = {
       .seq_len = static_cast<uint32_t>(seq_len),
       .write_loc = write_loc,
@@ -545,6 +571,7 @@ inline PrefillPlan plan_compress_prefill(
         .swa_page_size = swa_page_size,
         .ring_size = ring_size,
         .compress_ratio = compress_ratio,
+        .request_scoped_c128_state = false,
     };
     const auto block_size_1 = 256;
     const auto num_blocks_1 = div_ceil(params1.num_work, block_size_1);
@@ -628,6 +655,7 @@ inline PrefillPlan plan_compress_prefill(
       .swa_page_size = swa_page_size,
       .ring_size = ring_size,
       .compress_ratio = compress_ratio,
+      .request_scoped_c128_state = false,
   };
   const auto block_size = 256;
   const auto num_blocks = div_ceil(params.num_work, block_size);
@@ -648,7 +676,8 @@ inline PlanLens plan_compress_prefill_out(
     const int32_t compress_ratio,
     const int32_t swa_page_size,
     const int32_t ring_size,
-    const bool use_cuda_graph) {
+    const bool use_cuda_graph,
+    const bool request_scoped_c128_state) {
   auto B = SymbolicSize{"batch_size"};
   auto N = SymbolicSize{"num_q_tokens"};
   auto cpu_or_gpu = SymbolicDevice{};
@@ -741,6 +770,7 @@ inline PlanLens plan_compress_prefill_out(
         .swa_page_size = swa_page_size,
         .ring_size = ring_size,
         .compress_ratio = compress_ratio,
+        .request_scoped_c128_state = request_scoped_c128_state,
     };
     const auto block_size_1 = 256;
     const auto num_blocks_1 = div_ceil(params1.num_work, block_size_1);
@@ -820,6 +850,7 @@ inline PlanLens plan_compress_prefill_out(
       .swa_page_size = swa_page_size,
       .ring_size = ring_size,
       .compress_ratio = compress_ratio,
+      .request_scoped_c128_state = request_scoped_c128_state,
   };
   const auto block_size = 256;
   const auto num_blocks = div_ceil(params.num_work, block_size);
@@ -870,6 +901,7 @@ inline tvm::ffi::Tensor plan_compress_decode(
       .swa_page_size = swa_page_size,
       .ring_size = ring_size,
       .compress_ratio = compress_ratio,
+      .request_scoped_c128_state = false,
   };
   const auto block_size = 256;
   const auto num_blocks = div_ceil(batch_size, block_size);
@@ -885,7 +917,8 @@ inline uint32_t plan_compress_decode_out(
     const tvm::ffi::TensorView plan_d_out,        // GPU
     const int32_t compress_ratio,
     const int32_t swa_page_size,
-    const int32_t ring_size) {
+    const int32_t ring_size,
+    const bool request_scoped_c128_state) {
   auto B = SymbolicSize{"batch_size"};
   auto device_ = SymbolicDevice{};
   device_.set_options<kDLCUDA>();
@@ -924,6 +957,7 @@ inline uint32_t plan_compress_decode_out(
       .swa_page_size = swa_page_size,
       .ring_size = ring_size,
       .compress_ratio = compress_ratio,
+      .request_scoped_c128_state = request_scoped_c128_state,
   };
   RuntimeCheck(compress_ratio == 4 || compress_ratio == 128);
   RuntimeCheck(swa_page_size % ring_size == 0 && ring_size % compress_ratio == 0);

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -761,6 +761,7 @@ def create_paged_compress_data_kernel(
     is_overlap: tl.constexpr,
     swa_page_size: tl.constexpr,
     ring_size: tl.constexpr,
+    request_scoped_c128_state: tl.constexpr,
     BLOCK: tl.constexpr,
 ) -> None:
     pid = tl.program_id(0)
@@ -792,18 +793,21 @@ def create_paged_compress_data_kernel(
         else:
             pos = write_overlap_pos
         pos = tl.maximum(pos, 0)
-        loc = tl.load(
-            req_to_token_ptr
-            + rid.to(tl.int64) * stride_req_to_token_0
-            + pos.to(tl.int64) * stride_req_to_token_1,
-            mask=mask,
-            other=0,
-        ).to(tl.int32)
-        swa_loc = tl.load(full_to_swa_index_mapping_ptr + loc, mask=mask, other=0).to(
-            tl.int32
-        )
-        swa_page = swa_loc // swa_page_size
-        state_loc = swa_page * ring_size + (swa_loc % ring_size)
+        if request_scoped_c128_state and compress_ratio == 128:
+            state_loc = rid * ring_size + (pos % ring_size)
+        else:
+            loc = tl.load(
+                req_to_token_ptr
+                + rid.to(tl.int64) * stride_req_to_token_0
+                + pos.to(tl.int64) * stride_req_to_token_1,
+                mask=mask,
+                other=0,
+            ).to(tl.int32)
+            swa_loc = tl.load(
+                full_to_swa_index_mapping_ptr + loc, mask=mask, other=0
+            ).to(tl.int32)
+            swa_page = swa_loc // swa_page_size
+            state_loc = swa_page * ring_size + (swa_loc % ring_size)
         state_loc = state_loc // cr
         if i == 0:
             v0 = state_loc
@@ -838,6 +842,7 @@ def triton_create_paged_compress_data(
     extend_seq_lens: torch.Tensor,
     req_to_token: torch.Tensor,
     full_to_swa_index_mapping: torch.Tensor,
+    request_scoped_c128_state: bool = False,
     block: int = 128,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     batch_size = req_pool_indices.shape[0]
@@ -863,6 +868,7 @@ def triton_create_paged_compress_data(
         is_overlap=1 if is_overlap else 0,
         swa_page_size=swa_page_size,
         ring_size=ring_size,
+        request_scoped_c128_state=request_scoped_c128_state,
         BLOCK=block,
     )
 

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -27,13 +27,12 @@ from sglang.jit_kernel.utils import (
     make_cpp_args,
 )
 from sglang.srt.environ import envs
-from sglang.srt.utils import (
-    is_hcu,
-    get_bool_env_var
-)
+from sglang.srt.utils import get_bool_env_var, is_hcu
 
 _is_hcu = is_hcu()
-_use_linear_bf16_fp32_use_blaslt = get_bool_env_var("SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT")
+_use_linear_bf16_fp32_use_blaslt = get_bool_env_var(
+    "SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT"
+)
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -1001,8 +1000,8 @@ def _jit_torch_cublas_bf16_fp32() -> Any:
     if _is_hcu and _use_linear_bf16_fp32_use_blaslt:
         source = """
         #include <torch/extension.h>
-        #include <ATen/cuda/CUDAContext.h> 
-        #include <hipblaslt/hipblaslt.h>   
+        #include <ATen/cuda/CUDAContext.h>
+        #include <hipblaslt/hipblaslt.h>
 
         torch::Tensor linear_bf16_fp32(
             torch::Tensor X,
@@ -1023,16 +1022,16 @@ def _jit_torch_cublas_bf16_fp32() -> Any:
 
             hipblasLtMatmulDesc_t matmul_desc;
             hipblasLtMatmulDescCreate(&matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F);
-            
+
             int transA = HIPBLAS_OP_T;
             int transB = HIPBLAS_OP_N;
             hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &transA, sizeof(transA));
             hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &transB, sizeof(transB));
 
             hipblasLtMatrixLayout_t layoutA, layoutB, layoutC;
-            hipblasLtMatrixLayoutCreate(&layoutA, HIP_R_16BF, in_features, out_features, in_features); 
-            hipblasLtMatrixLayoutCreate(&layoutB, HIP_R_16BF, in_features, batch, in_features);        
-            hipblasLtMatrixLayoutCreate(&layoutC, HIP_R_32F, out_features, batch, out_features);       
+            hipblasLtMatrixLayoutCreate(&layoutA, HIP_R_16BF, in_features, out_features, in_features);
+            hipblasLtMatrixLayoutCreate(&layoutB, HIP_R_16BF, in_features, batch, in_features);
+            hipblasLtMatrixLayoutCreate(&layoutC, HIP_R_32F, out_features, batch, out_features);
 
             float alpha = 1.0f;
             float beta = 0.0f;
@@ -1047,11 +1046,11 @@ def _jit_torch_cublas_bf16_fp32() -> Any:
                 X.data_ptr(), layoutB,
                 &beta,
                 Y.data_ptr(), layoutC,
-                Y.data_ptr(), layoutC, 
-                nullptr, 
-                nullptr, 
-                0,       
-                stream  
+                Y.data_ptr(), layoutC,
+                nullptr,
+                nullptr,
+                0,
+                stream
             );
 
             hipblasLtMatmulDescDestroy(matmul_desc);
@@ -1112,7 +1111,7 @@ def _jit_torch_cublas_bf16_fp32() -> Any:
     m.def("linear_bf16_fp32", &linear_bf16_fp32, "BF16xBF16 -> FP32 linear (no bias)");
     }
     """
-     
+
     module = torch.utils.cpp_extension.load_inline(
         name="linear_bf16_fp32",
         cpp_sources="",

--- a/python/sglang/jit_kernel/dsv4/c128_cleanup.py
+++ b/python/sglang/jit_kernel/dsv4/c128_cleanup.py
@@ -1,0 +1,58 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _clear_unaccepted_c128_draft_states_kernel(
+    state,
+    req_pool_indices,
+    seq_lens,
+    accept_lens,
+    ring_size: tl.constexpr,
+    half: tl.constexpr,
+    num_draft_tokens: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    bid = tl.program_id(0)
+    draft_offset = tl.program_id(1)
+    block_id = tl.program_id(2)
+
+    accept_len = tl.load(accept_lens + bid)
+    if draft_offset < accept_len:
+        return
+
+    req_pool_idx = tl.load(req_pool_indices + bid).to(tl.int64)
+    seq_len = tl.load(seq_lens + bid).to(tl.int64)
+    slot = (seq_len + draft_offset) % ring_size
+    row = req_pool_idx * ring_size + slot
+
+    offsets = block_id * BLOCK_D + tl.arange(0, BLOCK_D)
+    mask = offsets < half
+    row_base = row * (half * 2)
+    tl.store(state + row_base + offsets, 0.0, mask=mask)
+    tl.store(state + row_base + half + offsets, float("-inf"), mask=mask)
+
+
+def clear_unaccepted_c128_draft_states(
+    state: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    accept_lens: torch.Tensor,
+    *,
+    ring_size: int,
+    num_draft_tokens: int,
+) -> None:
+    half = state.shape[-1] // 2
+    _clear_unaccepted_c128_draft_states_kernel[
+        (req_pool_indices.numel(), num_draft_tokens, triton.cdiv(half, 256))
+    ](
+        state,
+        req_pool_indices,
+        seq_lens,
+        accept_lens,
+        ring_size,
+        half,
+        num_draft_tokens,
+        BLOCK_D=256,
+    )

--- a/python/sglang/jit_kernel/dsv4/compress.py
+++ b/python/sglang/jit_kernel/dsv4/compress.py
@@ -132,7 +132,8 @@ class CompressorDecodePlan(NamedTuple):
         seq_lens: torch.Tensor,
         swa_page_size: int,
         ring_size: int,
-        ) -> CompressorDecodePlan:
+        request_scoped_c128_state: bool = False,
+    ) -> CompressorDecodePlan:
         module = _jit_compress_plan_module()
         plan_d = torch.empty(
             (req_pool_indices.shape[0], 16),
@@ -148,6 +149,7 @@ class CompressorDecodePlan(NamedTuple):
             int(compress_ratio),
             int(swa_page_size),
             int(ring_size),
+            bool(request_scoped_c128_state),
         )
         return CompressorDecodePlan(compress_ratio, plan_d)
 
@@ -210,6 +212,7 @@ class CompressorPrefillPlan(NamedTuple):
         ring_size: int,
         num_q_tokens: int,
         use_cuda_graph: bool = False,
+        request_scoped_c128_state: bool = False,
     ) -> CompressorPrefillPlan:
         is_gpu_input = seq_lens.device.type == "cuda"
         pin_buffer = torch.empty(
@@ -235,6 +238,7 @@ class CompressorPrefillPlan(NamedTuple):
             int(swa_page_size),
             int(ring_size),
             bool(use_cuda_graph),
+            bool(request_scoped_c128_state),
         )
         return CompressorPrefillPlan(
             compress_ratio,

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -22,6 +22,8 @@ class StateType(str, enum.Enum):
     MAMBA = "mamba"
     SWA = "swa"
     NSA = "nsa"
+    # DeepSeek-V4 C128 request-scoped compression state.
+    C128_STATE = "c128_state"
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -741,7 +741,10 @@ class CommonKVManager(BaseKVManager):
         return src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage
 
     def get_mla_kv_ptrs_with_pp(
-        self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
+        self,
+        src_kv_ptrs: List[int],
+        dst_kv_ptrs: List[int],
+        state_type: Optional[StateType] = None,
     ) -> Tuple[List[int], List[int], int]:
         # Fast path: both sides use exactly the same PP layout
         if len(src_kv_ptrs) == len(dst_kv_ptrs):
@@ -754,7 +757,7 @@ class CommonKVManager(BaseKVManager):
             # layer, so we locate the sub-range for this PP stage inside each
             # section of the dst flat list.
             sliced_src_kv_ptrs, sliced_dst_kv_ptrs = self._mla_slice_ptrs_for_pp(
-                src_kv_ptrs, dst_kv_ptrs, mla_ratios
+                src_kv_ptrs, dst_kv_ptrs, mla_ratios, state_type
             )
             return (
                 sliced_src_kv_ptrs,
@@ -774,6 +777,7 @@ class CommonKVManager(BaseKVManager):
         src_kv_ptrs: List[int],
         dst_kv_ptrs: List[int],
         mla_ratios: List[int],
+        state_type: Optional[StateType] = None,
     ) -> Tuple[List[int], List[int]]:
         """Produce aligned (src, dst) pointer lists for compressed-MLA
         pools (e.g. DeepSeek V4) under PP.
@@ -819,7 +823,70 @@ class CommonKVManager(BaseKVManager):
         c128_off_s = sum(1 for r in mla_ratios[:start_layer] if r == 128)
         c128_off_e = sum(1 for r in mla_ratios[:end_layer] if r == 128)
 
-        if len(dst_kv_ptrs) == kv_layout_len:
+        if not envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get():
+            if len(dst_kv_ptrs) == kv_layout_len:
+                sliced_dst = (
+                    list(dst_kv_ptrs[c4_off_s:c4_off_e])
+                    + list(
+                        dst_kv_ptrs[
+                            c4_full + c4_off_s : c4_full + c4_off_e
+                        ]
+                    )
+                    + list(
+                        dst_kv_ptrs[
+                            2 * c4_full
+                            + c128_off_s : 2 * c4_full
+                            + c128_off_e
+                        ]
+                    )
+                )
+                return src_kv_ptrs, sliced_dst
+
+            swa_L = len(dst_kv_ptrs) - 2 * c4_full - c128_full
+            if swa_L < 0 or swa_L > len(mla_ratios):
+                raise ValueError(
+                    f"Unexpected compressed-MLA dst_kv_ptrs length "
+                    f"{len(dst_kv_ptrs)}; expected either {kv_layout_len} "
+                    f"(kv_data) or swa_L + {2 * c4_full + c128_full} "
+                    f"(state_data) given compression_ratios "
+                    f"(c4={c4_full}, c128={c128_full}, "
+                    f"total={len(mla_ratios)})."
+                )
+            assert end_layer <= swa_L, (
+                f"prefill_end_layer ({end_layer}) exceeds dst SWA pool "
+                f"buffer count ({swa_L}); compression_ratios may include "
+                f"layers (e.g. nextn) that the SWA pool does not cover."
+            )
+
+            c_non_zero_s = sum(
+                1 for r in mla_ratios[:start_layer] if r != 0
+            )
+            c_non_zero_e = sum(1 for r in mla_ratios[:end_layer] if r != 0)
+            compress_section_start = swa_L
+            indexer_section_start = swa_L + c4_full + c128_full
+            sliced_dst = (
+                list(dst_kv_ptrs[start_layer:end_layer])
+                + list(
+                    dst_kv_ptrs[
+                        compress_section_start
+                        + c_non_zero_s : compress_section_start
+                        + c_non_zero_e
+                    ]
+                )
+                + list(
+                    dst_kv_ptrs[
+                        indexer_section_start
+                        + c4_off_s : indexer_section_start
+                        + c4_off_e
+                    ]
+                )
+            )
+            return src_kv_ptrs, sliced_dst
+
+        if state_type == StateType.C128_STATE:
+            return src_kv_ptrs, list(dst_kv_ptrs[c128_off_s:c128_off_e])
+
+        if state_type != StateType.SWA and len(dst_kv_ptrs) == kv_layout_len:
             sliced_dst = (
                 list(dst_kv_ptrs[c4_off_s:c4_off_e])
                 + list(dst_kv_ptrs[c4_full + c4_off_s : c4_full + c4_off_e])
@@ -827,39 +894,31 @@ class CommonKVManager(BaseKVManager):
             )
             return src_kv_ptrs, sliced_dst
 
-        # State-data layout. ``swa_L`` is derived from the actual dst
+        # SWA state-data layout. ``swa_L`` is derived from the actual dst
         # length so we tolerate cases where the SWA pool has fewer
-        # buffers than ``len(mla_ratios)`` (e.g. nextn padding).
-        swa_L = len(dst_kv_ptrs) - 2 * c4_full - c128_full
+        # buffers than ``len(mla_ratios)`` (e.g. nextn padding). C128
+        # state is transferred as its own StateType.C128_STATE component.
+        swa_L = len(dst_kv_ptrs) - 2 * c4_full
         if swa_L < 0 or swa_L > len(mla_ratios):
             raise ValueError(
                 f"Unexpected compressed-MLA dst_kv_ptrs length "
                 f"{len(dst_kv_ptrs)}; expected either {kv_layout_len} "
-                f"(kv_data) or swa_L + {2 * c4_full + c128_full} "
+                f"(kv_data) or swa_L + {2 * c4_full} "
                 f"(state_data) given compression_ratios "
                 f"(c4={c4_full}, c128={c128_full}, "
                 f"total={len(mla_ratios)})."
             )
-        # Guard against asking the prefill side to read past the SWA
-        # pool boundary.
-        assert end_layer <= swa_L, (
-            f"prefill_end_layer ({end_layer}) exceeds dst SWA pool "
-            f"buffer count ({swa_L}); compression_ratios may include "
-            f"layers (e.g. nextn) that the SWA pool does not cover."
-        )
-
-        # compress_state non-None count up to L = count(r != 0).
-        c_non_zero_s = sum(1 for r in mla_ratios[:start_layer] if r != 0)
-        c_non_zero_e = sum(1 for r in mla_ratios[:end_layer] if r != 0)
+        swa_s = min(start_layer, swa_L)
+        swa_e = min(end_layer, swa_L)
         compress_section_start = swa_L
-        indexer_section_start = swa_L + (c4_full + c128_full)
+        indexer_section_start = swa_L + c4_full
         sliced_dst = (
-            list(dst_kv_ptrs[start_layer:end_layer])
+            list(dst_kv_ptrs[swa_s:swa_e])
             + list(
                 dst_kv_ptrs[
                     compress_section_start
-                    + c_non_zero_s : compress_section_start
-                    + c_non_zero_e
+                    + c4_off_s : compress_section_start
+                    + c4_off_e
                 ]
             )
             + list(

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -39,6 +39,7 @@ from sglang.srt.disaggregation.base.conn import (
     KVArgs,
     KVPoll,
     KVTransferMetric,
+    StateType,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.distributed import get_pp_group, get_world_group
@@ -827,17 +828,9 @@ class CommonKVManager(BaseKVManager):
             if len(dst_kv_ptrs) == kv_layout_len:
                 sliced_dst = (
                     list(dst_kv_ptrs[c4_off_s:c4_off_e])
+                    + list(dst_kv_ptrs[c4_full + c4_off_s : c4_full + c4_off_e])
                     + list(
-                        dst_kv_ptrs[
-                            c4_full + c4_off_s : c4_full + c4_off_e
-                        ]
-                    )
-                    + list(
-                        dst_kv_ptrs[
-                            2 * c4_full
-                            + c128_off_s : 2 * c4_full
-                            + c128_off_e
-                        ]
+                        dst_kv_ptrs[2 * c4_full + c128_off_s : 2 * c4_full + c128_off_e]
                     )
                 )
                 return src_kv_ptrs, sliced_dst
@@ -858,9 +851,7 @@ class CommonKVManager(BaseKVManager):
                 f"layers (e.g. nextn) that the SWA pool does not cover."
             )
 
-            c_non_zero_s = sum(
-                1 for r in mla_ratios[:start_layer] if r != 0
-            )
+            c_non_zero_s = sum(1 for r in mla_ratios[:start_layer] if r != 0)
             c_non_zero_e = sum(1 for r in mla_ratios[:end_layer] if r != 0)
             compress_section_start = swa_L
             indexer_section_start = swa_L + c4_full + c128_full
@@ -1533,9 +1524,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         bootstrap_rooms = data["bootstrap_rooms"]
         async with self.lock:
             aborted_rooms = [
-                int(room)
-                for room in bootstrap_rooms
-                if int(room) in self.aborted_rooms
+                int(room) for room in bootstrap_rooms if int(room) in self.aborted_rooms
             ]
         return web.json_response({"aborted_rooms": aborted_rooms}, status=200)
 

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -48,7 +48,9 @@ from sglang.srt.disaggregation.utils import (
     ReqToMetadataIdxAllocator,
     TransferBackend,
     all_reduce_status_by_rid,
+    get_dsv4_c128_state_indices,
     get_kv_class,
+    is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce,
     poll_and_all_reduce_by_rid,
@@ -1025,8 +1027,24 @@ class DecodePreallocQueue:
                     kv_indices_full.cpu().numpy(), device_page_size
                 )
 
+            def _c128_state_payload():
+                online = is_dsv4_c128_online_enabled()
+                ring_size = 1 if online else self.token_to_kv_pool.get_ring_size(128)
+                return get_dsv4_c128_state_indices(
+                    int(decode_req.req.req_pool_idx),
+                    seq_len,
+                    online=online,
+                    ring_size=ring_size,
+                )
+
             state_types = self.kv_manager.kv_args.state_types
             state_indices: Optional[List] = []
+            if StateType.C128_STATE in state_types:
+                clear_c128_state = getattr(
+                    self.token_to_kv_pool, "clear_c128_req_state", None
+                )
+                if clear_c128_state is not None:
+                    clear_c128_state(int(decode_req.req.req_pool_idx))
             for st in state_types:
                 if st == StateType.MAMBA:
                     state_indices.append(_mamba_payload())
@@ -1034,6 +1052,8 @@ class DecodePreallocQueue:
                     state_indices.append(_swa_payload())
                 elif st == StateType.NSA:
                     state_indices.append(_nsa_payload())
+                elif st == StateType.C128_STATE:
+                    state_indices.append(_c128_state_payload())
                 else:
                     state_indices.append(None)
 

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -52,7 +52,6 @@ from sglang.srt.disaggregation.utils import (
     get_kv_class,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
-    poll_and_all_reduce,
     poll_and_all_reduce_by_rid,
     poll_and_all_reduce_with_staging,
     poll_and_all_reduce_with_staging_by_rid,
@@ -669,9 +668,7 @@ class DecodePreallocQueue:
                 continue
             # Keep polling after the initial handshake. An asynchronous failure
             # must override the cached waiting_for_input state.
-            local_status_by_rid[decode_req.req.rid] = int(
-                decode_req.kv_receiver.poll()
-            )
+            local_status_by_rid[decode_req.req.rid] = int(decode_req.kv_receiver.poll())
         if rids_to_check is None:
             status_by_rid = all_reduce_status_by_rid(
                 local_status_by_rid, self.gloo_group

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -605,6 +605,7 @@ class MooncakeKVManager(CommonKVManager):
         prefill_data_indices: npt.NDArray[np.int32],
         dst_data_indices: npt.NDArray[np.int32],
         executor: concurrent.futures.ThreadPoolExecutor,
+        state_type: Optional[StateType] = None,
     ) -> int:
         """
         Generic KV cache transfer supporting both MHA and MLA architectures.
@@ -620,7 +621,9 @@ class MooncakeKVManager(CommonKVManager):
         # Decode pp size should be equal to prefill pp size or 1
         if self.is_mla_backend:
             src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
-                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
+                self.get_mla_kv_ptrs_with_pp(
+                    src_data_ptrs, dst_data_ptrs, state_type
+                )
             )
             layers_params = [
                 (
@@ -1637,7 +1640,7 @@ class MooncakeKVManager(CommonKVManager):
                         )
                         or rc
                     )
-            elif st in (StateType.SWA, StateType.NSA):
+            elif st in (StateType.SWA, StateType.NSA, StateType.C128_STATE):
                 if (
                     target_rank_registration_info is not None
                     and not self.is_mla_backend
@@ -1663,6 +1666,21 @@ class MooncakeKVManager(CommonKVManager):
                 else:
                     src_indices = list(indices)
                     dst_indices_local = list(dst_indices)
+                    if (
+                        st == StateType.C128_STATE
+                        and len(src_indices) == 0
+                        and len(dst_indices_local) == 0
+                    ):
+                        continue
+                    if (
+                        st == StateType.C128_STATE
+                        and len(src_indices) != len(dst_indices_local)
+                    ):
+                        raise RuntimeError(
+                            "C128_STATE state index length mismatch: "
+                            f"prefill={len(src_indices)}, "
+                            f"dst={len(dst_indices_local)}"
+                        )
                     if len(src_indices) > len(dst_indices_local):
                         logger.warning(
                             f"len(prefill_state_indices) = {len(src_indices)}, len(dst_state_indices) = {len(dst_indices_local)}"
@@ -1684,6 +1702,7 @@ class MooncakeKVManager(CommonKVManager):
                                 dst_indices_local, dtype=np.int32
                             ),
                             executor=executor,
+                            state_type=st,
                         )
                         or rc
                     )

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -621,9 +621,7 @@ class MooncakeKVManager(CommonKVManager):
         # Decode pp size should be equal to prefill pp size or 1
         if self.is_mla_backend:
             src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
-                self.get_mla_kv_ptrs_with_pp(
-                    src_data_ptrs, dst_data_ptrs, state_type
-                )
+                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs, state_type)
             )
             layers_params = [
                 (
@@ -1672,9 +1670,8 @@ class MooncakeKVManager(CommonKVManager):
                         and len(dst_indices_local) == 0
                     ):
                         continue
-                    if (
-                        st == StateType.C128_STATE
-                        and len(src_indices) != len(dst_indices_local)
+                    if st == StateType.C128_STATE and len(src_indices) != len(
+                        dst_indices_local
                     ):
                         raise RuntimeError(
                             "C128_STATE state index length mismatch: "
@@ -2222,11 +2219,7 @@ class MooncakeKVManager(CommonKVManager):
             self.update_status(bootstrap_room, KVPoll.Failed)
             detected_rooms.append(bootstrap_room)
 
-        if (
-            detected_rooms
-            and self.attn_tp_rank == 0
-            and self.attn_cp_rank == 0
-        ):
+        if detected_rooms and self.attn_tp_rank == 0 and self.attn_cp_rank == 0:
             logger.info(
                 "Marked decode prealloc rooms as failed after prefill abort: %s",
                 detected_rooms,

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -821,6 +821,7 @@ class NixlKVManager(CommonKVManager):
         dst_data_indices: npt.NDArray[np.int32],
         dst_gpu_id: int,
         notif: str,
+        state_type: Optional[StateType] = None,
     ):
         """Generic KV cache transfer supporting both MHA and MLA architectures.
         Used by both send_kvcache and maybe_send_extra."""
@@ -841,7 +842,9 @@ class NixlKVManager(CommonKVManager):
         # Make descs
         if self.is_mla_backend:
             src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
-                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
+                self.get_mla_kv_ptrs_with_pp(
+                    src_data_ptrs, dst_data_ptrs, state_type=state_type
+                )
             )
             layers_params = [
                 (
@@ -1495,7 +1498,7 @@ class NixlKVManager(CommonKVManager):
             src_indices = (
                 prefill_state_indices[i] if i < len(prefill_state_indices) else None
             )
-            if src_indices is None or len(src_indices) == 0:
+            if src_indices is None:
                 continue
             src_ptrs = src_state_data_ptrs[i] if i < len(src_state_data_ptrs) else []
             src_lens = src_state_item_lens[i] if i < len(src_state_item_lens) else []
@@ -1509,6 +1512,17 @@ class NixlKVManager(CommonKVManager):
                 dst_state_dim_per_tensor[i] if i < len(dst_state_dim_per_tensor) else []
             )
             comp_notif = f"{notif}_{i}"
+
+            if st == StateType.C128_STATE:
+                if len(src_indices) == 0 and len(dst_indices) == 0:
+                    continue
+                if len(src_indices) != len(dst_indices):
+                    raise RuntimeError(
+                        f"C128 state index length mismatch at component {i}: "
+                        f"prefill={len(src_indices)}, dst={len(dst_indices)}"
+                    )
+            elif len(src_indices) == 0:
+                continue
 
             if st == StateType.MAMBA:
                 if self.attn_tp_size != decode_tp_size:
@@ -1538,7 +1552,7 @@ class NixlKVManager(CommonKVManager):
                         dst_gpu_id,
                         comp_notif,
                     )
-            elif st in (StateType.SWA, StateType.NSA):
+            elif st in (StateType.SWA, StateType.NSA, StateType.C128_STATE):
                 if not self.is_mla_backend and self.attn_tp_size != decode_tp_size:
                     raise RuntimeError(
                         f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
@@ -1557,6 +1571,7 @@ class NixlKVManager(CommonKVManager):
                     dst_data_indices=np.array(dst_indices, dtype=np.int32),
                     dst_gpu_id=dst_gpu_id,
                     notif=comp_notif,
+                    state_type=st,
                 )
             else:
                 raise RuntimeError(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -40,7 +40,10 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    get_dsv4_c128_state_indices,
     get_kv_class,
+    is_dsv4_c128_online_enabled,
+    is_dsv4_request_scoped_c128_state_enabled,
     is_mla_backend,
     poll_and_all_reduce_by_rid_attn_cp_tp_group,
     prepare_abort,
@@ -1041,10 +1044,11 @@ class SchedulerDisaggregationPrefillMixin:
         """
         page_size = self.token_to_kv_pool_allocator.page_size
         start_idx = req.start_send_idx
+        transfer_input_len = len(req.origin_input_ids)
         end_idx = (
             end_idx
             if end_idx is not None
-            else min(len(req.fill_ids), len(req.origin_input_ids))
+            else min(len(req.fill_ids), transfer_input_len)
         )
 
         if not last_chunk:
@@ -1069,7 +1073,12 @@ class SchedulerDisaggregationPrefillMixin:
         if last_chunk:
             self.disagg_metadata_buffers.set_buf(req)
 
-            seq_len = len(req.fill_ids)
+            seq_len = (
+                min(len(req.fill_ids), transfer_input_len)
+                if is_dsv4_request_scoped_c128_state_enabled()
+                else len(req.fill_ids)
+            )
+            c128_seq_len = transfer_input_len
 
             def _mamba_payload():
                 return [
@@ -1102,6 +1111,22 @@ class SchedulerDisaggregationPrefillMixin:
                 ]
                 return kv_to_page_indices(kv_indices_full.cpu().numpy(), page_size)
 
+            def _c128_state_payload():
+                online = is_dsv4_c128_online_enabled()
+                ring_size = (
+                    1
+                    if online
+                    else self.token_to_kv_pool_allocator.get_kvcache().get_ring_size(
+                        128
+                    )
+                )
+                return get_dsv4_c128_state_indices(
+                    int(req.req_pool_idx),
+                    c128_seq_len,
+                    online=online,
+                    ring_size=ring_size,
+                )
+
             state_types = (
                 self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
             )
@@ -1113,6 +1138,8 @@ class SchedulerDisaggregationPrefillMixin:
                     state_indices.append(_swa_payload())
                 elif st == StateType.NSA:
                     state_indices.append(_nsa_payload())
+                elif st == StateType.C128_STATE:
+                    state_indices.append(_c128_state_payload())
                 else:
                     state_indices.append(None)
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -982,9 +982,7 @@ class SchedulerDisaggregationPrefillMixin:
                 # The matching batch result owns final resource cleanup.
                 self.chunked_req = None
             else:
-                maybe_cache_unfinished_req(
-                    chunked_req, self.tree_cache, chunked=True
-                )
+                maybe_cache_unfinished_req(chunked_req, self.tree_cache, chunked=True)
 
             if abort_pending or chunked_req.req_pool_idx is None:
                 self.running_batch.batch_is_full = False
@@ -1026,9 +1024,7 @@ class SchedulerDisaggregationPrefillMixin:
             req.disagg_kv_sender.abort()
         if req.req_pool_idx is not None:
             release_kv_cache(req, self.tree_cache)
-        release_req_to_metadata_buffer(
-            req, self.req_to_metadata_buffer_idx_allocator
-        )
+        release_req_to_metadata_buffer(req, self.req_to_metadata_buffer_idx_allocator)
         req._prefill_abort_cleanup_done = True
         self.stream_output([req], req.return_logprob, None)
         return True

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -130,9 +130,7 @@ def all_reduce_status_by_rid(
     dist.all_reduce(status_tensor, op=dist.ReduceOp.MIN, group=gloo_group)
 
     reduced_statuses = status_tensor.tolist()
-    return {
-        rid: reduced_statuses[index] for index, rid in enumerate(canonical_rids)
-    }
+    return {rid: reduced_statuses[index] for index, rid in enumerate(canonical_rids)}
 
 
 def poll_and_all_reduce_by_rid(
@@ -743,9 +741,8 @@ def setup_state_kv_args(
             append_state_component(
                 kv_args, StateType.SWA, data_ptrs, data_lens, item_lens
             )
-            if (
-                is_dsv4_request_scoped_c128_state_enabled()
-                and hasattr(token_to_kv_pool, "get_c128_state_buf_infos")
+            if is_dsv4_request_scoped_c128_state_enabled() and hasattr(
+                token_to_kv_pool, "get_c128_state_buf_infos"
             ):
                 c128_ptrs, c128_lens, c128_item_lens = (
                     token_to_kv_pool.get_c128_state_buf_infos()

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -30,6 +30,35 @@ if TYPE_CHECKING:
 FAKE_BOOTSTRAP_HOST = "2.2.2.2"
 
 
+def is_dsv4_c128_online_enabled() -> bool:
+    """Return whether C128 uses the online compression algorithm."""
+    return envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
+
+
+def is_dsv4_request_scoped_c128_state_enabled() -> bool:
+    """Return whether PR #28612 request-scoped C128 state is enabled."""
+    return envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
+
+
+def get_dsv4_c128_state_indices(
+    req_pool_idx: int,
+    seq_len: int,
+    *,
+    online: bool,
+    ring_size: int,
+) -> np.ndarray:
+    """Return the PD transfer row/page indices for DSV4 C128 state."""
+    if seq_len == 0 or seq_len % 128 == 0:
+        return np.empty((0,), dtype=np.int32)
+    if online:
+        return np.array([int(req_pool_idx)], dtype=np.int32)
+
+    assert ring_size % 128 == 0, f"C128 ring_size must be 128-aligned, got {ring_size}"
+    pages_per_req = ring_size // 128
+    page = int(req_pool_idx) * pages_per_req + ((seq_len - 1) % ring_size) // 128
+    return np.array([page], dtype=np.int32)
+
+
 class DisaggregationMode(Enum):
     NULL = "null"
     PREFILL = "prefill"
@@ -714,6 +743,21 @@ def setup_state_kv_args(
             append_state_component(
                 kv_args, StateType.SWA, data_ptrs, data_lens, item_lens
             )
+            if (
+                is_dsv4_request_scoped_c128_state_enabled()
+                and hasattr(token_to_kv_pool, "get_c128_state_buf_infos")
+            ):
+                c128_ptrs, c128_lens, c128_item_lens = (
+                    token_to_kv_pool.get_c128_state_buf_infos()
+                )
+                if c128_ptrs:
+                    append_state_component(
+                        kv_args,
+                        StateType.C128_STATE,
+                        c128_ptrs,
+                        c128_lens,
+                        c128_item_lens,
+                    )
         elif isinstance(token_to_kv_pool, HybridLinearKVPool):
             dim = (
                 token_to_kv_pool.get_state_dim_per_tensor()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -635,6 +635,9 @@ class Envs:
     SGLANG_OPT_USE_TILELANG_INDEXER = EnvBool(False)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
+    # Use request-indexed C128 state introduced by PR #28612. Keep disabled
+    # by default so existing deployments retain the legacy SWA-indexed layout.
+    SGLANG_DSV4_REQUEST_SCOPED_C128_STATE = EnvBool(False)
     SGLANG_OPT_USE_COMPRESSOR_V2 = EnvBool(True)
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -258,6 +258,10 @@ def create_paged_compressor_data(
 ) -> FusedCompressMetadata:
     swa_page_size = token_to_kv_pool.swa_page_size
     ring_size = token_to_kv_pool.get_ring_size(compress_ratio=compress_ratio)
+    request_scoped_c128_state = (
+        compress_ratio == 128
+        and envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
+    )
     # assert ring_size % compress_ratio == 0
 
     def clip_down(positions: torch.Tensor) -> torch.Tensor:
@@ -265,10 +269,13 @@ def create_paged_compressor_data(
 
     def get_raw_loc(positions: torch.Tensor) -> torch.Tensor:
         positions = positions.masked_fill(positions < 0, 0)
-        loc = req_to_token[req_pool_indices, positions]
-        swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(loc)
-        swa_pages = swa_loc // swa_page_size
-        state_loc = swa_pages * ring_size + swa_loc % ring_size
+        if request_scoped_c128_state:
+            state_loc = req_pool_indices * ring_size + positions % ring_size
+        else:
+            loc = req_to_token[req_pool_indices, positions]
+            swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(loc)
+            swa_pages = swa_loc // swa_page_size
+            state_loc = swa_pages * ring_size + swa_loc % ring_size
         return (state_loc // compress_ratio).to(torch.int32)
 
     is_overlap = is_overlap_compress(compress_ratio)
@@ -285,6 +292,7 @@ def create_paged_compressor_data(
             extend_seq_lens=extend_lens,
             req_to_token=req_to_token,
             full_to_swa_index_mapping=token_to_kv_pool.full_to_swa_index_mapping,
+            request_scoped_c128_state=request_scoped_c128_state,
         )
 
         plan_kwargs: dict

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -30,7 +30,8 @@ from sglang.jit_kernel.deepseek_v4 import (
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsv4.quant_k_cache import (
-    quant_to_nope_fp8_rope_bf16_pack_triton, quant_to_nope_fp8_rope_bf16_pack_lightop
+    quant_to_nope_fp8_rope_bf16_pack_lightop,
+    quant_to_nope_fp8_rope_bf16_pack_triton,
 )
 from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
 from sglang.srt.layers.attention.nsa.utils import nsa_use_prefill_cp
@@ -40,10 +41,12 @@ from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_output
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
-from sglang.srt.utils import add_prefix
-from sglang.srt.utils import get_bool_env_var, is_hcu
+from sglang.srt.utils import add_prefix, get_bool_env_var, is_hcu
+
 _is_hcu = is_hcu()
-_use_dpskv4_lightop_quant_k_cache = get_bool_env_var("SGLANG_USE_DPSKV4_LIGHTOP_QUANT_K_CACHE")
+_use_dpskv4_lightop_quant_k_cache = get_bool_env_var(
+    "SGLANG_USE_DPSKV4_LIGHTOP_QUANT_K_CACHE"
+)
 if _is_hcu:
     from lightop import kvcache as op
 
@@ -175,9 +178,13 @@ class CompressorBackendMixin:
                 )
                 return
             if _is_hcu and _use_dpskv4_lightop_quant_k_cache:
-                pack = quant_to_nope_fp8_rope_bf16_pack_lightop(new_compressed_kv.bfloat16(), 1e-8)
+                pack = quant_to_nope_fp8_rope_bf16_pack_lightop(
+                    new_compressed_kv.bfloat16(), 1e-8
+                )
             else:
-                pack = quant_to_nope_fp8_rope_bf16_pack_triton(new_compressed_kv.bfloat16())
+                pack = quant_to_nope_fp8_rope_bf16_pack_triton(
+                    new_compressed_kv.bfloat16()
+                )
             token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc, pack)
 
     def forward_indexer_compressor(
@@ -259,8 +266,7 @@ def create_paged_compressor_data(
     swa_page_size = token_to_kv_pool.swa_page_size
     ring_size = token_to_kv_pool.get_ring_size(compress_ratio=compress_ratio)
     request_scoped_c128_state = (
-        compress_ratio == 128
-        and envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
+        compress_ratio == 128 and envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
     )
     # assert ring_size % compress_ratio == 0
 

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -272,6 +272,10 @@ def create_paged_compressor_data(
 
     swa_page_size = token_to_kv_pool.swa_page_size
     ring_size = token_to_kv_pool.get_ring_size(compress_ratio=compress_ratio)
+    request_scoped_c128_state = (
+        compress_ratio == 128
+        and envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
+    )
     # NOTE: This is actually a proxy, which encounter some bug with tvm-ffi.
     # As a workaround, we use `.detach()` to get the real tensor.
     full_to_swa = token_to_kv_pool.full_to_swa_index_mapping.detach()
@@ -300,6 +304,7 @@ def create_paged_compressor_data(
             ring_size=ring_size,
             num_q_tokens=num_q_tokens,
             use_cuda_graph=use_prefill_cuda_graph,
+            request_scoped_c128_state=request_scoped_c128_state,
         )
     else:
         return CompressorDecodePlan.generate(
@@ -310,6 +315,7 @@ def create_paged_compressor_data(
             seq_lens=seq_lens.to(torch.int64),
             swa_page_size=swa_page_size,
             ring_size=ring_size,
+            request_scoped_c128_state=request_scoped_c128_state,
         )
 
 

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -18,15 +18,15 @@ from typing import TYPE_CHECKING, List, Literal, Optional, TypeAlias, Union, cas
 
 import torch
 
+from sglang.jit_kernel.deepseek_v4 import (
+    compress_fused_norm_rope_inplace,
+    fused_rope,
+)
 from sglang.jit_kernel.dsv4 import (
     CompressorDecodePlan,
     CompressorPrefillPlan,
     compress_forward,
     compress_norm_rope_store,
-)
-from sglang.jit_kernel.deepseek_v4 import (
-    compress_fused_norm_rope_inplace,
-    fused_rope,
 )
 from sglang.srt.environ import envs
 
@@ -147,10 +147,7 @@ class CompressorBackendMixin:
         token_to_kv_pool = cast("DeepSeekV4TokenToKVPool", token_to_kv_pool)
         kv_score_input = compressor.compute_kv_score(x, forward_batch)
         state_pool = compressor.get_state_pool(forward_batch)
-        if (
-            token_to_kv_pool.is_bf16_attention_kv_cache
-            and not compressor.is_in_indexer
-        ):
+        if token_to_kv_pool.is_bf16_attention_kv_cache and not compressor.is_in_indexer:
             plan = self._get_paged_compress_metadata(compressor.ratio)
             is_online = _use_online_compress(compressor.ratio)
             kv_score_buffer = state_pool.kv_score_buffer.kv_score
@@ -160,9 +157,7 @@ class CompressorBackendMixin:
                 coff = 2 if is_overlap_compress(compressor.ratio) else 1
                 last_dim = 2 * compressor.head_dim * coff
                 assert kv_score_buffer.shape[-1] == last_dim
-                kv_score_buffer = kv_score_buffer.view(
-                    -1, compressor.ratio, last_dim
-                )
+                kv_score_buffer = kv_score_buffer.view(-1, compressor.ratio, last_dim)
             kv_compressed = compress_forward(
                 kv_score_buffer=kv_score_buffer,
                 kv_score_input=kv_score_input,
@@ -273,8 +268,7 @@ def create_paged_compressor_data(
     swa_page_size = token_to_kv_pool.swa_page_size
     ring_size = token_to_kv_pool.get_ring_size(compress_ratio=compress_ratio)
     request_scoped_c128_state = (
-        compress_ratio == 128
-        and envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
+        compress_ratio == 128 and envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
     )
     # NOTE: This is actually a proxy, which encounter some bug with tvm-ffi.
     # As a workaround, we use `.detach()` to get the real tensor.

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -239,7 +239,12 @@ class SchedulePolicy:
         for r in waiting_queue:
             prefix_ids = r.origin_input_ids + r.output_ids
             extra_key = r.extra_key
-            match_result = match_prefix_for_req(self.tree_cache, r, prefix_ids)
+            match_result = match_prefix_for_req(
+                self.tree_cache,
+                r,
+                prefix_ids,
+                include_req=envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get(),
+            )
 
             # NOTE(sang): This logic is for in-batch prefix caching;
             # If there are more than 1 request that have small matching prefix from

--- a/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
@@ -47,6 +47,8 @@ class CompressStatePool:
         online: bool = False,
     ):
         self.ring_size = ring_size
+        self.ratio = ratio
+        self.online = online
 
         if online:
             assert ring_size == 1, "online compress requires ring_size=1"
@@ -79,3 +81,10 @@ class CompressStatePool:
                 )
                 if not online:
                     self.kv_score_buffer[-1].clear()
+
+    def translate_from_req_position_to_state_loc(
+        self, req_pool_indices: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        """Map request-local positions into the request-scoped state ring."""
+        state_loc = req_pool_indices * self.ring_size + positions % self.ring_size
+        return torch.where(positions < 0, -1, state_loc)

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -216,14 +216,14 @@ class DeepSeekV4SingleKVPool(KVCache):
         valid_mask: Optional[torch.Tensor] = None,
     ) -> None:
         assert self.is_bf16_attention_kv_cache
-        assert cache_k.shape[-1] == self.logical_kv_dim, (
-            f"expected cache_k last dim {self.logical_kv_dim}, got {cache_k.shape}"
-        )
+        assert (
+            cache_k.shape[-1] == self.logical_kv_dim
+        ), f"expected cache_k last dim {self.logical_kv_dim}, got {cache_k.shape}"
         values = cache_k.to(torch.bfloat16).contiguous().view(-1, self.logical_kv_dim)
         n_values = values.shape[0]
-        assert loc.numel() == n_values, (
-            f"expected loc to match cache_k rows, got {loc.numel()=} {n_values=}"
-        )
+        assert (
+            loc.numel() == n_values
+        ), f"expected loc to match cache_k rows, got {loc.numel()=} {n_values=}"
         if n_values == 0:
             return
         kv_buffer = self.kv_buffer[layer_id].view(-1, self.logical_kv_dim)
@@ -685,9 +685,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             assert state.ndim == 2, f"expected 2D buffer, got {state.ndim}D"
             data_ptrs.append(state.data_ptr())
             data_lens.append(state.nbytes)
-            item_lens.append(
-                state[0].nbytes if ONLINE_C128 else state[0].nbytes * 128
-            )
+            item_lens.append(state[0].nbytes if ONLINE_C128 else state[0].nbytes * 128)
         return data_ptrs, data_lens, item_lens
 
     def _init_paged_compress_states(self, enable_memory_saver: bool):

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -452,6 +452,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def __init__(
         self,
         max_num_reqs: int,
+        num_req_slots: Optional[int],
         swa_size: int,
         c4_size: int,
         c128_size: int,
@@ -484,21 +485,35 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         )
         c4_logical_size = c128_size * 32
 
-        logger.info(
-            "Initialize DeepSeekV4TokenToKVPool with "
-            f"{max_num_reqs=} {swa_size=} {c4_size=} "
-            f"{c4_logical_size=} {c128_size=} "
-            f"{c4_state_pool_size=} {c128_state_pool_size=}"
-        )
-
         self.max_num_reqs = max_num_reqs
+        # Decode PD adds pre-transfer request rows beyond max_num_reqs. C128
+        # state is indexed by req_pool_idx, so it must cover every addressable
+        # req_to_token row, including the padding row.
+        self.num_req_slots = (
+            num_req_slots if num_req_slots is not None else max_num_reqs + 1
+        )
         self.c4_size = c4_size
         self.c4_logical_size = c4_logical_size
         self.c128_size = c128_size
         self.c4_state_pool_size = c4_state_pool_size
+        c128_ring_size = self.get_ring_size(128)
+        if envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get():
+            if ONLINE_C128:
+                c128_state_pool_size = max(c128_state_pool_size, self.num_req_slots)
+            else:
+                c128_state_pool_size = max(
+                    c128_state_pool_size, self.num_req_slots * c128_ring_size
+                )
         self.c128_state_pool_size = c128_state_pool_size
         self.state_dtype = state_dtype
         self.compression_ratios = compression_ratios
+
+        logger.info(
+            "Initialize DeepSeekV4TokenToKVPool with "
+            f"{max_num_reqs=} {self.num_req_slots=} {swa_size=} {c4_size=} "
+            f"{c4_logical_size=} {c128_size=} "
+            f"{c4_state_pool_size=} {c128_state_pool_size=}"
+        )
 
         # Determine this PP stage's absolute layer range
         if (
@@ -641,12 +656,38 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             for pool in pools:
                 if pool is None:
                     continue
+                if (
+                    envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
+                    and pool.ratio == 128
+                ):
+                    continue
                 t = pool.kv_score_buffer.kv_score
                 assert t.ndim == 2, f"expected 2D buffer, got {t.ndim}D"
                 data_ptrs.append(t.data_ptr())
                 data_lens.append(t.nbytes)
                 item_lens.append(t[0].nbytes * pool.ring_size)
 
+        return data_ptrs, data_lens, item_lens
+
+    def get_c128_state_buf_infos(
+        self,
+    ) -> Tuple[List[int], List[int], List[int]]:
+        """Expose C128 state as a separate request-scoped PD component."""
+        if not envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get():
+            return [], [], []
+        data_ptrs: List[int] = []
+        data_lens: List[int] = []
+        item_lens: List[int] = []
+        for pool in self.compress_state_pools:
+            if pool is None or pool.ratio != 128:
+                continue
+            state = pool.kv_score_buffer.kv_score
+            assert state.ndim == 2, f"expected 2D buffer, got {state.ndim}D"
+            data_ptrs.append(state.data_ptr())
+            data_lens.append(state.nbytes)
+            item_lens.append(
+                state[0].nbytes if ONLINE_C128 else state[0].nbytes * 128
+            )
         return data_ptrs, data_lens, item_lens
 
     def _init_paged_compress_states(self, enable_memory_saver: bool):
@@ -731,6 +772,59 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             compress_state_pool is not None
         ), "Only c4/c128 layers have attention states."
         return compress_state_pool
+
+    def clear_c128_req_state(self, req_pool_idx: int) -> None:
+        """Reset request-scoped C128 state before a PD transfer reuses the slot."""
+        if not envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get():
+            return
+        for pool in self.compress_state_pools:
+            if pool is None or pool.ratio != 128:
+                continue
+
+            state = pool.kv_score_buffer.kv_score
+            if ONLINE_C128:
+                row = state[req_pool_idx]
+                head_dim = row.shape[-1] // 3
+                row[:head_dim].fill_(float("-inf"))
+                row[head_dim:].zero_()
+            else:
+                start = req_pool_idx * pool.ring_size
+                rows = state[start : start + pool.ring_size]
+                half = rows.shape[-1] // 2
+                rows[:, :half].zero_()
+                rows[:, half:].fill_(float("-inf"))
+
+    def clear_unaccepted_c128_draft_states(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        accept_lens: torch.Tensor,
+        num_draft_tokens: int,
+    ) -> None:
+        """Clear offline C128 rows written by rejected speculative tokens."""
+        if (
+            not envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
+            or ONLINE_C128
+            or num_draft_tokens <= 1
+            or req_pool_indices.numel() == 0
+        ):
+            return
+
+        from sglang.jit_kernel.dsv4.c128_cleanup import (
+            clear_unaccepted_c128_draft_states,
+        )
+
+        for pool in self.compress_state_pools:
+            if pool is None or pool.ratio != 128:
+                continue
+            clear_unaccepted_c128_draft_states(
+                pool.kv_score_buffer.kv_score,
+                req_pool_indices,
+                seq_lens,
+                accept_lens,
+                ring_size=pool.ring_size,
+                num_draft_tokens=num_draft_tokens,
+            )
 
     def get_indexer_compress_states(self, layer_id: int) -> CompressStatePool:
         self.wait_layer_transfer(layer_id)

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -52,9 +52,9 @@ from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool, SWATokenToKVPoolAllo
 from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_float4_e2m1fn_x2,
-    is_hip,
     is_hcu,
     is_hcu_native_fp8_supported,
+    is_hip,
     is_npu,
 )
 
@@ -103,8 +103,7 @@ class ModelRunnerKVCacheMixin:
             if is_deepseek_nsa(self.model_config.hf_config):
                 index_head_dim = get_nsa_index_head_dim(self.model_config.hf_config)
                 use_bf16_index_cache = _is_hcu and (
-                    self.kv_cache_dtype
-                    not in (torch.float8_e4m3fn, torch.float8_e5m2)
+                    self.kv_cache_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2)
                     or not is_hcu_native_fp8_supported()
                 )
                 if use_bf16_index_cache:

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -446,6 +446,7 @@ class ModelRunnerKVCacheMixin:
                 compression_ratios = self.model_config.compress_ratios
             self.token_to_kv_pool = DeepSeekV4TokenToKVPool(
                 max_num_reqs=self.max_running_requests,
+                num_req_slots=self.req_to_token_pool.req_to_token.shape[0],
                 swa_size=self.swa_max_total_num_tokens,
                 c4_size=self.c4_max_total_num_tokens,
                 c128_size=self.c128_max_total_num_tokens,
@@ -985,6 +986,7 @@ class ModelRunnerKVCacheMixin:
         config.max_running_requests = self._resolve_max_num_reqs(
             config.max_total_num_tokens
         )
+        config = configurator.finalize_with_max_running_requests(config)
         config.mem_fraction_static = self.server_args.mem_fraction_static
         return config
 

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -478,9 +478,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
     def _get_decode_pre_alloc_size(max_running_requests: int) -> int:
         pre_alloc_size = envs.SGLANG_DISAGGREGATION_NUM_PRE_ALLOCATE_REQS.get()
         return (
-            max_running_requests * 2
-            if max_running_requests <= 32
-            else pre_alloc_size
+            max_running_requests * 2 if max_running_requests <= 32 else pre_alloc_size
         )
 
     def _get_num_req_slots(self, max_running_requests: int) -> int:

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -42,7 +42,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring_size
 from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
-from sglang.srt.utils.common import is_float4_e2m1fn_x2
+from sglang.srt.utils.common import ceil_div, is_float4_e2m1fn_x2
 
 
 @dataclass
@@ -95,6 +95,12 @@ class MemoryPoolConfigurator:
     ) -> MemoryPoolConfig:
         """Constraint path: recalculate pool sizes from a constrained max_tokens."""
         raise NotImplementedError
+
+    def finalize_with_max_running_requests(
+        self, config: MemoryPoolConfig
+    ) -> MemoryPoolConfig:
+        """Finalize request-scoped pool sizes after per-worker concurrency is known."""
+        return config
 
 
 class DefaultPoolConfigurator(MemoryPoolConfigurator):
@@ -324,8 +330,9 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
     """Configurator for DSV4 compressed-attention models.
 
     Splits available memory across full / swa / c4 / c128 + c4_state / c128_state
-    pools. coeff is bytes_per_full_token (inflated by (T+D)/T when speculative
-    decode reserves a draft worker, mirroring dflash's cell_size scaling); bias = 0.
+    pools. The legacy C128 state pool is token/SWA-scoped. When
+    ``SGLANG_DSV4_REQUEST_SCOPED_C128_STATE`` is enabled, it becomes
+    request-scoped and is budgeted as fixed memory.
     """
 
     def __init__(self, mr: ModelRunner):
@@ -333,11 +340,25 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.qk_nope_head_dim = cfg.qk_nope_head_dim
         self.qk_rope_head_dim = cfg.qk_rope_head_dim
         self.indexer_head_dim = cfg.index_head_dim
-        self.compression_ratios = cfg.compress_ratios
+        self.request_scoped_c128_state = (
+            envs.SGLANG_DSV4_REQUEST_SCOPED_C128_STATE.get()
+        )
+        self.context_len = cfg.context_len
+        self.compression_ratios = (
+            cfg.compress_ratios[mr.start_layer : mr.end_layer]
+            if self.request_scoped_c128_state
+            else cfg.compress_ratios
+        )
         self.kv_cache_dtype = mr.kv_cache_dtype
         self.swa_page_size = cfg.window_size
         self.swa_ratio = mr.server_args.swa_full_tokens_ratio
         self.is_speculative = mr.server_args.speculative_algorithm is not None
+        self.requested_max_running_requests_per_worker = (
+            mr.server_args.max_running_requests // mr.dp_size
+            if mr.server_args.max_running_requests is not None
+            else None
+        )
+        self.disaggregation_mode = mr.server_args.disaggregation_mode
         if mr.enable_hisparse:
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
@@ -372,10 +393,21 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         # would need rollback / replay across draft and verify, which the
         # online path doesn't support yet.
         if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+            if self.request_scoped_c128_state:
+                raise RuntimeError(
+                    "SGLANG_DSV4_REQUEST_SCOPED_C128_STATE currently supports "
+                    "offline C128 only. Unset SGLANG_OPT_USE_ONLINE_COMPRESS "
+                    "or disable the request-scoped C128 state layout."
+                )
             assert (
                 mr.spec_algorithm.is_none()
             ), "SGLANG_OPT_USE_ONLINE_COMPRESS does not support speculative decode (MTP) yet"
             logger.info("DSV4 compressed attention: online c128 enabled (ring_size=1)")
+
+        logger.info(
+            "DSV4 request-scoped C128 state layout: %s",
+            "enabled" if self.request_scoped_c128_state else "disabled",
+        )
 
     def _get_bytes_per_full_token(self) -> float:
         if self.kv_cache_dtype == torch.bfloat16:
@@ -403,7 +435,11 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         c4_indexer_state_bytes = 2 * 2 * self.indexer_head_dim * state_dtype_size
 
         c4_state_ratio = self.c4_ring_size / self.swa_page_size
-        c128_state_ratio = self.c128_ring_size / self.swa_page_size
+        c128_state_ratio = (
+            0
+            if self.request_scoped_c128_state
+            else self.c128_ring_size / self.swa_page_size
+        )
 
         c4_frac = 1 / (4 * self.c4_shrink_factor)
         return (
@@ -431,8 +467,62 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             c4_max_total_num_tokens=full_token // (4 * self.c4_shrink_factor),
             c128_max_total_num_tokens=full_token // 128,
             c4_state_pool_size=swa_tokens // self.swa_page_size * self.c4_ring_size,
-            c128_state_pool_size=swa_tokens // self.swa_page_size * self.c128_ring_size,
+            c128_state_pool_size=(
+                0
+                if self.request_scoped_c128_state
+                else swa_tokens // self.swa_page_size * self.c128_ring_size
+            ),
         )
+
+    @staticmethod
+    def _get_decode_pre_alloc_size(max_running_requests: int) -> int:
+        pre_alloc_size = envs.SGLANG_DISAGGREGATION_NUM_PRE_ALLOCATE_REQS.get()
+        return (
+            max_running_requests * 2
+            if max_running_requests <= 32
+            else pre_alloc_size
+        )
+
+    def _get_num_req_slots(self, max_running_requests: int) -> int:
+        if self.disaggregation_mode == "decode":
+            return (
+                max_running_requests
+                + self._get_decode_pre_alloc_size(max_running_requests)
+                + 1
+            )
+        return max_running_requests + 1
+
+    def _get_c128_state_fixed_bytes(self, max_running_requests: int) -> int:
+        if self.num_layers_ca128 == 0:
+            return 0
+
+        attn_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        state_dtype_size = 4
+        num_req_slots = self._get_num_req_slots(max_running_requests)
+
+        if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+            state_rows = num_req_slots + self.c128_ring_size + 1
+            state_last_dim = 3 * attn_head_dim
+        else:
+            state_pool_size = num_req_slots * self.c128_ring_size
+            state_rows = state_pool_size + self.c128_ring_size + 1
+            state_rows = ceil_div(state_rows, 128) * 128
+            state_last_dim = 2 * attn_head_dim
+
+        return state_rows * state_last_dim * state_dtype_size * self.num_layers_ca128
+
+    def _get_c128_state_fixed_bytes_for_token_capacity(
+        self, token_capacity: int
+    ) -> int:
+        if self.requested_max_running_requests_per_worker is not None:
+            return self._get_c128_state_fixed_bytes(
+                self.requested_max_running_requests_per_worker
+            )
+
+        estimated = int(token_capacity / self.context_len * 512)
+        estimated = max(min(estimated, 4096), 2048)
+        max_running_requests = min(estimated, token_capacity // 2)
+        return self._get_c128_state_fixed_bytes(max_running_requests)
 
     def _to_config(self, sizes: _DSV4PoolSizes) -> MemoryPoolConfig:
         full = sizes.full_max_total_num_tokens
@@ -454,6 +544,19 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             c128_state_pool_size=sizes.c128_state_pool_size,
         )
 
+    def finalize_with_max_running_requests(
+        self, config: MemoryPoolConfig
+    ) -> MemoryPoolConfig:
+        if not self.request_scoped_c128_state:
+            return config
+        assert config.max_running_requests is not None
+        num_req_slots = self._get_num_req_slots(config.max_running_requests)
+        if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+            config.c128_state_pool_size = num_req_slots
+        else:
+            config.c128_state_pool_size = num_req_slots * self.c128_ring_size
+        return config
+
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
@@ -461,12 +564,26 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             page_size % 128 == 0
         ), "page_size must be multiple of 128 for compressed attention"
 
-        full_token = int(available_bytes / self.bytes_per_full_token)
+        if not self.request_scoped_c128_state:
+            c128_state_fixed_bytes = 0
+        elif self.requested_max_running_requests_per_worker is not None:
+            c128_state_fixed_bytes = self._get_c128_state_fixed_bytes(
+                self.requested_max_running_requests_per_worker
+            )
+        else:
+            full_token = int(available_bytes / self.bytes_per_full_token)
+            c128_state_fixed_bytes = (
+                self._get_c128_state_fixed_bytes_for_token_capacity(full_token)
+            )
+
+        available_bytes_for_tokens = max(available_bytes - c128_state_fixed_bytes, 0)
+        full_token = int(available_bytes_for_tokens / self.bytes_per_full_token)
         sizes = self._compute_dsv4_sizes(full_token, page_size)
         logger.info(
             f"DSV4 memory calculation: "
             f"bytes_per_full_token={self.bytes_per_full_token:.2f}, "
             f"available_bytes={available_bytes / (1 << 30):.2f} GB, "
+            f"c128_state_fixed={c128_state_fixed_bytes / (1 << 30):.2f} GB, "
             f"full_token={sizes.full_max_total_num_tokens}"
         )
         return self._to_config(sizes)

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1258,6 +1258,18 @@ class EAGLEWorkerV2(BaseSpecWorker):
             accept_index,
         ) = verify_input.sample(batch, logits_output, vocab_mask)
         new_seq_lens = batch.seq_lens + accept_lens
+        clear_unaccepted_c128 = getattr(
+            self.token_to_kv_pool_allocator.get_kvcache(),
+            "clear_unaccepted_c128_draft_states",
+            None,
+        )
+        if clear_unaccepted_c128 is not None and not batch.forward_mode.is_idle():
+            clear_unaccepted_c128(
+                batch.req_pool_indices,
+                batch.seq_lens,
+                accept_lens,
+                self.speculative_num_draft_tokens,
+            )
 
         # Update mamba state for hybrid GDN models after verification
         if (


### PR DESCRIPTION
1、合入官方mr：https://github.com/sgl-project/sglang/pull/28612/changes，优化DpskV4的kv cache pool。
原实现按照 KV token pool 容量分配 C128 State，导致显存占用随 max_total_num_tokens 增长。优化后，C128 State 按活跃请求及预分配请求槽位分配，使其显存占用主要与 max_running_requests 相关，从而降低固定状态池显存、增加可用于 KV Cache Pool 的空间和 max_total_num_tokens。
2、该优化通过 SGLANG_DSV4_REQUEST_SCOPED_C128_STATE 环境变量控制，默认关闭，未开启时保持原有分配和执行路径。优化仅调整 C128 State 的分配、索引及生命周期管理，不改变模型权重、KV Cache 内容和计算结果。



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->