### PR TITLE
[perf] 优化minimax 支持rms_quant算子

### DIFF
--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -19,6 +19,9 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, cast
 
 import torch
+
+# from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8
+from lightop.quant import per_token_quant_int8
 from torch.nn.parameter import Parameter
 
 from sglang.srt.distributed import get_tensor_model_parallel_world_size
@@ -28,6 +31,7 @@ from sglang.srt.layers.amx_utils import (
 )
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
+from sglang.srt.layers.moe.utils import get_moe_runner_backend
 from sglang.srt.layers.parameter import ChannelQuantScaleParameter, ModelWeightParameter
 from sglang.srt.layers.quantization.base_config import (
     FusedMoEMethodBase,
@@ -35,11 +39,10 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
-from sglang.srt.layers.moe.utils import get_moe_runner_backend
 from sglang.srt.layers.quantization.compressed_tensors.utils import should_ignore_layer
-# from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8
-from lightop.quant import per_token_quant_int8
-from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod, UnquantizedEmbeddingMethod
+from sglang.srt.layers.quantization.unquant import (
+    UnquantizedEmbeddingMethod,
+)
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
@@ -53,6 +56,7 @@ from sglang.srt.utils.patch_torch import register_fake_if_exists
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
+
 from lightop import gemm_ops as quant_ops
 
 _is_cuda = is_cuda()
@@ -62,7 +66,6 @@ _is_cpu = is_cpu()
 _is_cpu_arm64 = is_host_cpu_arm64()
 
 if _is_cuda:
-    from sgl_kernel import int8_scaled_mm
 
     @register_fake_if_exists("sgl_kernel::int8_scaled_mm")
     def _int8_scaled_mm_abstract(
@@ -127,9 +130,10 @@ class W8A8Int8Config(QuantizationConfig):
     ) -> Optional[QuantizeMethodBase]:
         from sglang.srt.layers.linear import LinearBase
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
-        from sglang.srt.layers.radix_attention import RadixAttention
         from sglang.srt.layers.quantization.fp8 import Fp8KVCacheMethod
         from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
+        from sglang.srt.layers.radix_attention import RadixAttention
+
         if isinstance(layer, LinearBase):
             if should_ignore_layer(
                 prefix, ignore=self.ignore, fused_mapping=self.packed_modules_mapping

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -241,8 +241,13 @@ class W8A8Int8LinearMethod(LinearMethodBase):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
+        input_quant_args: Optional[List[torch.Tensor]] = None,
     ):
         if use_intel_amx_backend(layer) or _is_cpu_arm64:
+            if input_quant_args is not None:
+                raise NotImplementedError(
+                    "Pre-quantized input is not supported by the CPU W8A8 backend."
+                )
             return torch.ops.sgl_kernel.int8_scaled_mm_with_quant(
                 x,
                 layer.weight,
@@ -251,7 +256,11 @@ class W8A8Int8LinearMethod(LinearMethodBase):
                 x.dtype,
                 True,  # is_vnni
             )
-        x_q, x_scale = per_token_quant_int8(x)
+        if input_quant_args is not None:
+            assert len(input_quant_args) == 2
+            x_q, x_scale = input_quant_args
+        else:
+            x_q, x_scale = per_token_quant_int8(x)
 
         x_q_2d = x_q.view(-1, x_q.shape[-1])
         x_scale_2d = x_scale.view(-1, x_scale.shape[-1])

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -1231,7 +1231,7 @@ class MiniMaxM2DecoderLayer(nn.Module):
         if _use_fused_rms_quant:
             pre_norm = hidden_states.clone() if residual is None else residual
             hidden_states, _ = self.layer_communicator.prepare_attn(
-                hidden_states, residual, forward_batch, skip_layernorm=True
+                hidden_states, residual, forward_batch
             )
             if residual is not None:
                 assert residual.shape[0] == hidden_states.shape[0], (

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -18,8 +18,8 @@
 # Adapted from DeepSeek and Mixtral implementation
 """Inference-only MiniMax M2 model compatible with HuggingFace weights."""
 
-import os
 import logging
+import os
 from contextlib import nullcontext
 from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
@@ -40,8 +40,8 @@ from sglang.srt.batch_overlap.two_batch_overlap import model_forward_maybe_tbo
 from sglang.srt.distributed import (
     get_moe_expert_parallel_world_size,
     get_pp_group,
-    get_tp_group,
     get_tensor_model_parallel_world_size,
+    get_tp_group,
     tensor_model_parallel_all_reduce,
 )
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
@@ -126,14 +126,17 @@ if _is_npu:
 
 _FP32GEMM_GATE = None
 
+
 def _gate_fp32gemm(
-    hidden_states: torch.Tensor, weight: torch.Tensor,
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
 ) -> torch.Tensor:
     global _FP32GEMM_GATE
     if _FP32GEMM_GATE is None:
         if os.environ.get("SGLANG_USE_FP32GEMM_GATE_CUSTOM", "0") == "1":
             try:
                 import fp32gemm
+
                 _FP32GEMM_GATE = fp32gemm
             except ImportError:
                 _FP32GEMM_GATE = False
@@ -1319,13 +1322,17 @@ class MiniMaxM2DecoderLayer(nn.Module):
                 rms_weight=self.input_layernorm.weight,
                 residual=residual,
             )
-            hidden_states, residual = self.post_attention_layernorm(hidden_states, pre_norm)
+            hidden_states, residual = self.post_attention_layernorm(
+                hidden_states, pre_norm
+            )
         else:
             if residual is None:
                 residual = hidden_states
                 hidden_states = self.input_layernorm(hidden_states)
             else:
-                hidden_states, residual = self.input_layernorm(hidden_states, residual, None)
+                hidden_states, residual = self.input_layernorm(
+                    hidden_states, residual, None
+                )
 
             hidden_states = self.self_attn(
                 positions=positions,
@@ -1333,7 +1340,9 @@ class MiniMaxM2DecoderLayer(nn.Module):
                 forward_batch=forward_batch,
             )
 
-            hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+            hidden_states, residual = self.post_attention_layernorm(
+                hidden_states, residual
+            )
         hidden_states = self.block_sparse_moe(hidden_states, forward_batch)
         return hidden_states, residual
 
@@ -1412,13 +1421,13 @@ class MiniMaxM2Model(nn.Module):
         self.padding_idx = getattr(config, "pad_token_id", 0)
         self.vocab_size = config.vocab_size
         self.pp_group = get_pp_group()
-       
+
         if self.pp_group.is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size,
-            config.hidden_size,
-            use_attn_tp_group=is_dp_attention_enabled(),
-        )
+                config.vocab_size,
+                config.hidden_size,
+                use_attn_tp_group=is_dp_attention_enabled(),
+            )
 
         def layer_fn(idx, prefix: str) -> nn.Module:
             return MiniMaxM2DecoderLayer(
@@ -1508,7 +1517,7 @@ class MiniMaxM2Model(nn.Module):
                         ),
                     )
 
-        if not self.pp_group.is_last_rank:   
+        if not self.pp_group.is_last_rank:
             return PPProxyTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
@@ -1562,13 +1571,13 @@ class MiniMaxM2ForCausalLM(nn.Module):
         self.config = config
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
-        
+
         self.model = MiniMaxM2Model(
             config, quant_config, prefix=add_prefix("model", prefix)
         )
 
         if self.pp_group.is_last_rank:
-                   
+
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
                 config.hidden_size,
@@ -1578,13 +1587,14 @@ class MiniMaxM2ForCausalLM(nn.Module):
         else:
             self.lm_head = PPMissingLayer()
 
-        self.logits_processor = LogitsProcessor(config)        
+        self.logits_processor = LogitsProcessor(config)
 
         # For EAGLE3
         self.capture_aux_hidden_states = False
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
+
     @property
     def start_layer(self) -> int:
         return self.model.start_layer
@@ -1592,7 +1602,7 @@ class MiniMaxM2ForCausalLM(nn.Module):
     @property
     def end_layer(self) -> int:
         return self.model.end_layer
-    
+
     def set_eagle3_layers_to_capture(self, layer_ids: Optional[list[int]] = None):
         if not self.pp_group.is_last_rank:
             return


### PR DESCRIPTION
优化minimax模型，支持rms_quant算子
1. w8a8_int8_linear 接受融合的参数
2. 去掉不支持的skip_layernorm参数



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->