### PR TITLE
fix: enable validated HiSparse P4D4 on HCU

### DIFF
--- a/python/sglang/jit_kernel/csrc/hisparse.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse.cuh
@@ -8,14 +8,21 @@
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
 
-#include <cuda_runtime.h>
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
 
 namespace {
 
+#ifdef USE_ROCM
+constexpr int WARP_SIZE = 64;
+using BallotMask = uint64_t;
+constexpr BallotMask FULL_WARP_MASK = 0xFFFFFFFFFFFFFFFFull;
+#else
 constexpr int WARP_SIZE = 32;
+using BallotMask = unsigned int;
+constexpr BallotMask FULL_WARP_MASK = 0xFFFFFFFFu;
+#endif
 constexpr int32_t TOKEN_HIT = 0xFFFFFFFF;
 constexpr int32_t HASH_EMPTY = -1;
 
@@ -24,6 +31,25 @@ __device__ __forceinline__ int hash_slot(int32_t key, int hash_size) {
   return ((uint32_t)key * 2654435761u) % (uint32_t)hash_size;
 }
 
+#ifdef USE_ROCM
+__device__ __forceinline__ void transfer_item_warp(
+    int32_t lane_id, const void* __restrict__ src_addr, void* __restrict__ dst_addr, int64_t item_size_bytes) {
+  const auto src = static_cast<const char*>(src_addr);
+  auto dst = static_cast<char*>(dst_addr);
+
+  const int64_t word_count = item_size_bytes / static_cast<int64_t>(sizeof(uint64_t));
+  const auto src_words = reinterpret_cast<const uint64_t*>(src);
+  auto dst_words = reinterpret_cast<uint64_t*>(dst);
+  for (int64_t i = lane_id; i < word_count; i += WARP_SIZE) {
+    dst_words[i] = src_words[i];
+  }
+
+  const int64_t tail_start = word_count * static_cast<int64_t>(sizeof(uint64_t));
+  for (int64_t i = tail_start + lane_id; i < item_size_bytes; i += WARP_SIZE) {
+    dst[i] = src[i];
+  }
+}
+#else
 __device__ __forceinline__ void
 transfer_item_warp(int32_t lane_id, const void* src_addr, void* dst_addr, int64_t item_size_bytes) {
   // 128-bit bulk transfer via paired 64-bit loads (avoids alignment issues with uint4)
@@ -51,21 +77,38 @@ transfer_item_warp(int32_t lane_id, const void* src_addr, void* dst_addr, int64_
     asm volatile("st.global.cg.b64 [%0],%1;" ::"l"(dst8 + lane_id), "l"(tmp) : "memory");
   }
 }
+#endif
+
+__device__ __forceinline__ int popc_mask(BallotMask mask) {
+#ifdef USE_ROCM
+  return __popcll(mask);
+#else
+  return __popc(mask);
+#endif
+}
+
+__device__ __forceinline__ BallotMask ballot_mask(bool predicate) {
+#ifdef USE_ROCM
+  return __ballot(predicate);
+#else
+  return __ballot_sync(FULL_WARP_MASK, predicate);
+#endif
+}
 
 __device__ __forceinline__ int warp_inclusive_scan(int* s_data, int lane_id, int offset, int count, int accumulator) {
   int idx = lane_id + offset;
   int val = (idx < count) ? s_data[idx] : 0;
 
 #pragma unroll
-  for (int i = 1; i < 32; i *= 2) {
-    int n = __shfl_up_sync(0xffffffff, val, i);
+  for (int i = 1; i < WARP_SIZE; i *= 2) {
+    int n = __shfl_up_sync(FULL_WARP_MASK, val, i);
     if (lane_id >= i) val += n;
   }
   val += accumulator;
   if (idx < count) {
     s_data[idx] = val;
   }
-  accumulator = __shfl_sync(0xffffffff, val, 31);
+  accumulator = __shfl_sync(FULL_WARP_MASK, val, WARP_SIZE - 1);
   return accumulator;
 }
 
@@ -132,7 +175,7 @@ __global__ void load_cache_to_device_buffer_kernel(
   const int tid = threadIdx.x;
   const int warp_id = tid / WARP_SIZE;
   const int lane_id = tid % WARP_SIZE;
-  const unsigned int lanes_before = ((unsigned int)1 << lane_id) - 1;
+  const BallotMask lanes_before = (BallotMask(1) << lane_id) - BallotMask(1);
 
   const int64_t rid = req_pool_indices[bid];
   const int64_t seq_len = seq_lens[bid];
@@ -260,22 +303,30 @@ __global__ void load_cache_to_device_buffer_kernel(
     int local_hit_offset = 0;
     int local_evict_offset = 0;
     if (has_valid_chunk) {
-      const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
-      const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
-      local_hit_offset = __popc(hit_mask & lanes_before);
-      local_evict_offset = __popc(evict_mask & lanes_before);
+      const BallotMask hit_mask = ballot_mask(is_hit);
+      const BallotMask evict_mask = ballot_mask(is_evictable);
+      local_hit_offset = popc_mask(hit_mask & lanes_before);
+      local_evict_offset = popc_mask(evict_mask & lanes_before);
       if (lane_id == 0) {
-        s_chunk_offset[chunk_idx + 1] = __popc(hit_mask);
-        s_evict_chunk_offset[chunk_idx + 1] = __popc(evict_mask);
+        s_chunk_offset[chunk_idx + 1] = popc_mask(hit_mask);
+        s_evict_chunk_offset[chunk_idx + 1] = popc_mask(evict_mask);
       }
     }
     __syncthreads();
 
     if (warp_id == 0) {
+#ifdef USE_ROCM
+      const int scan_offset = iter * NUM_WARPS + 1;
+      const int scan_count = min(scan_offset + NUM_WARPS, NUM_BUFFER_CHUNKS + 1);
+      total_hit_count = warp_inclusive_scan(s_chunk_offset, lane_id, scan_offset, scan_count, total_hit_count);
+      total_evict_count =
+          warp_inclusive_scan(s_evict_chunk_offset, lane_id, scan_offset, scan_count, total_evict_count);
+#else
       total_hit_count =
           warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
       total_evict_count =
           warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
+#endif
       if (tid == 0) {
         s_total_hits = total_hit_count;
       }
@@ -324,9 +375,9 @@ __global__ void load_cache_to_device_buffer_kernel(
     }
 
     if (has_valid_chunk) {
-      const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
-      local_miss_offset = __popc(miss_mask & lanes_before);
-      const int warp_miss_count = __popc(miss_mask);
+      const BallotMask miss_mask = ballot_mask(is_miss);
+      local_miss_offset = popc_mask(miss_mask & lanes_before);
+      const int warp_miss_count = popc_mask(miss_mask);
       if (lane_id == 0) {
         s_chunk_offset[chunk_idx + 1] = warp_miss_count;
       }
@@ -334,7 +385,13 @@ __global__ void load_cache_to_device_buffer_kernel(
     __syncthreads();
 
     if (warp_id == 0) {
+#ifdef USE_ROCM
+      const int scan_offset = iter * NUM_WARPS + 1;
+      const int scan_count = min(scan_offset + NUM_WARPS, NUM_TOKEN_CHUNKS + 1);
+      total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, scan_offset, scan_count, total_misses);
+#else
       total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
+#endif
     }
     __syncthreads();
 
@@ -354,6 +411,20 @@ __global__ void load_cache_to_device_buffer_kernel(
   // Write back LRU order: evictables at front (LRU), hits at back (MRU).
   {
     const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
+#ifdef USE_ROCM
+    constexpr int LRU_WRITEBACK_THREADS = (BLOCK_SIZE > 512) ? 512 : BLOCK_SIZE;
+    if (tid < LRU_WRITEBACK_THREADS) {
+      for (int i = tid; i < HOT_BUFFER_SIZE; i += LRU_WRITEBACK_THREADS) {
+        if (i < total_misses) {
+          req_lru_slots[total_evictable - total_misses + i] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+        } else if (i < total_evictable) {
+          req_lru_slots[i - total_misses] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+        } else {
+          req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
+        }
+      }
+    }
+#else
     for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
       if (i < total_misses) {
         // Misses: just loaded from host, place right before hits
@@ -366,6 +437,7 @@ __global__ void load_cache_to_device_buffer_kernel(
         req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
       }
     }
+#endif
   }
 
   // each warp copies one miss directly, can be separated into a new kernel if parallelism is a concern
@@ -426,21 +498,49 @@ void load_cache_to_device_buffer(
   const int64_t top_k_device_locs_stride = top_k_device_locs.strides()[0];
   const auto device = LaunchKernel::resolve_device(top_k_tokens.device());
 
+#ifdef USE_ROCM
+  // HCU exposes cudaHostRegister allocations through a device-side alias that
+  // can differ from the CPU virtual address.  PyTorch pin_memory allocations
+  // commonly use an already-accessible address, which hid this distinction in
+  // the kernel tests, while the production HiSparse host pool uses
+  // cudaHostRegister.  Resolve the alias before launching a kernel that reads
+  // the host cache directly.
+  auto get_kernel_accessible_ptr = [](tvm::ffi::TensorView tensor) -> const void* {
+    void* ptr = tensor.data_ptr();
+    const auto device_type = tensor.device().device_type;
+    if (ptr == nullptr || (device_type != kDLCPU && device_type != kDLCUDAHost)) {
+      return ptr;
+    }
+
+    void* device_ptr = nullptr;
+    RuntimeDeviceCheck(hipHostGetDevicePointer(&device_ptr, ptr, 0));
+    return device_ptr;
+  };
+  const void* host_cache_k_ptr = get_kernel_accessible_ptr(host_cache_k);
+  const void* host_cache_v_ptr =
+      (IsMLA || host_cache_v.ndim() == 0) ? nullptr : get_kernel_accessible_ptr(host_cache_v);
+#else
+  const void* host_cache_k_ptr = host_cache_k.data_ptr();
+  const void* host_cache_v_ptr = (IsMLA || host_cache_v.ndim() == 0) ? nullptr : host_cache_v.data_ptr();
+#endif
+
   // Generic lambda: int32/int64 kernel variants are compiled for both
   // seq_lens and req_pool_indices; the correct combo is selected at runtime.
   auto launch = [&](auto kernel_fn, const auto* seq_lens_ptr, const auto* req_pool_indices_ptr) {
     constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>::BYTES;
+#ifndef USE_ROCM
     if constexpr (smem_bytes > 48u * 1024u) {
       cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
     }
+#endif
     LaunchKernel(bs, BLOCK_SIZE, device, smem_bytes)(
         kernel_fn,
         static_cast<const int32_t*>(top_k_tokens.data_ptr()),
         static_cast<int32_t*>(device_buffer_tokens.data_ptr()),
         static_cast<const int64_t*>(host_cache_locs.data_ptr()),
         static_cast<const int32_t*>(device_buffer_locs.data_ptr()),
-        host_cache_k.data_ptr(),
-        (IsMLA || host_cache_v.ndim() == 0) ? (const void*)nullptr : host_cache_v.data_ptr(),
+        host_cache_k_ptr,
+        host_cache_v_ptr,
         device_buffer_k.data_ptr(),
         (IsMLA || device_buffer_v.ndim() == 0) ? (void*)nullptr : device_buffer_v.data_ptr(),
         static_cast<int32_t*>(top_k_device_locs.data_ptr()),

--- a/python/sglang/jit_kernel/tests/test_hisparse.py
+++ b/python/sglang/jit_kernel/tests/test_hisparse.py
@@ -4,11 +4,17 @@ import pytest
 import torch
 
 from sglang.jit_kernel.hisparse import load_cache_to_device_buffer_mla
-from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.srt.utils import is_cuda, is_hcu, is_hip, is_npu, is_xpu
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cuda_ci,
+    register_hcu_ci,
+)
 
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
 register_cuda_ci(est_time=10, suite="stage-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_hcu_ci(est_time=30, suite="stage-b-test-1-hcu")
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available()
@@ -239,6 +245,40 @@ def test_load_cache_to_device_buffer_miss_uses_updated_lru_slot() -> None:
     assert torch.equal(state["device_buffer"][9].cpu(), state["host_cache"][6])
 
 
+@pytest.mark.skipif(
+    not is_hcu(), reason="Covers HCU cudaHostRegister device-pointer translation."
+)
+def test_load_cache_to_device_buffer_from_host_registered_memory() -> None:
+    """Read a miss from the allocation mode used by the production host pool."""
+    state = _long_case()
+    registered_host_cache = torch.empty_like(
+        state["host_cache"], device="cpu", pin_memory=False
+    )
+    registered_host_cache.copy_(state["host_cache"])
+
+    cudart = torch.cuda.cudart()
+    register_result = cudart.cudaHostRegister(
+        registered_host_cache.data_ptr(),
+        registered_host_cache.numel() * registered_host_cache.element_size(),
+        0,
+    )
+    assert int(register_result) == 0
+    state["host_cache"] = registered_host_cache
+
+    try:
+        out = _run_kernel(
+            top_k_tokens=torch.tensor([[6]], dtype=torch.int32, device=DEVICE),
+            seq_len=8,
+            **state,
+        )
+        assert torch.equal(out.cpu(), torch.tensor([[9]], dtype=torch.int32))
+        assert torch.equal(state["device_buffer"][9].cpu(), registered_host_cache[6])
+    finally:
+        torch.cuda.synchronize()
+        unregister_result = cudart.cudaHostUnregister(registered_host_cache.data_ptr())
+        assert int(unregister_result) == 0
+
+
 def test_load_cache_to_device_buffer_batched_with_padding() -> None:
     state = _make_state(
         [
@@ -293,6 +333,75 @@ def test_load_cache_to_device_buffer_batched_with_padding() -> None:
     )
     assert torch.equal(state["lru_slots"][2].cpu(), padded_lru_before.cpu())
     assert torch.equal(state["device_buffer"][9].cpu(), state["host_cache"][6])
+
+
+@pytest.mark.skipif(
+    not is_hip(), reason="Covers a ROCm wavefront64 LRU writeback regression."
+)
+def test_load_cache_to_device_buffer_rocm_benchmark_sized_lru() -> None:
+    """Exercise the 20K benchmark's 2K top-k and 12K hot-buffer shape."""
+    top_k = 2048
+    hot_buffer_size = 12288
+    seq_len = 18959
+    kv_dim = 4
+    item_size_bytes = kv_dim * torch.empty((), dtype=DTYPE).element_size()
+
+    top_k_tokens = torch.cat(
+        [
+            torch.arange(1000, 2000, dtype=torch.int32),
+            torch.arange(15000, 16048, dtype=torch.int32),
+        ]
+    ).view(1, -1)
+    device_buffer_tokens = torch.arange(hot_buffer_size, dtype=torch.int32).view(1, -1)
+    device_buffer_locs = torch.arange(hot_buffer_size + 1, dtype=torch.int32).view(
+        1, -1
+    )
+    lru_slots = torch.arange(hot_buffer_size, dtype=torch.int16).view(1, -1)
+    host_cache_locs = torch.arange(seq_len, dtype=torch.int64).view(1, -1)
+
+    top_k_tokens = top_k_tokens.to(DEVICE)
+    device_buffer_tokens = device_buffer_tokens.to(DEVICE)
+    device_buffer_locs = device_buffer_locs.to(DEVICE)
+    lru_slots = lru_slots.to(DEVICE)
+    host_cache_locs = host_cache_locs.to(DEVICE)
+
+    host_cache = torch.zeros(
+        (seq_len, 1, kv_dim), dtype=DTYPE, device="cpu", pin_memory=True
+    )
+    device_buffer = torch.empty(
+        (hot_buffer_size + 1, 1, kv_dim), dtype=DTYPE, device=DEVICE
+    )
+    out = torch.full_like(top_k_tokens, -1)
+
+    load_cache_to_device_buffer_mla(
+        top_k_tokens=top_k_tokens,
+        device_buffer_tokens=device_buffer_tokens,
+        host_cache_locs=host_cache_locs,
+        device_buffer_locs=device_buffer_locs,
+        host_cache=host_cache,
+        device_buffer=device_buffer,
+        top_k_device_locs=out,
+        req_pool_indices=torch.tensor([0], dtype=torch.int64, device=DEVICE),
+        seq_lens=torch.tensor([seq_len], dtype=torch.int32, device=DEVICE),
+        lru_slots=lru_slots,
+        item_size_bytes=item_size_bytes,
+        num_top_k=top_k,
+        hot_buffer_size=hot_buffer_size,
+        page_size=1,
+        block_size=1024,
+        num_real_reqs=torch.tensor([1], dtype=torch.int32, device=DEVICE),
+    )
+    torch.cuda.synchronize()
+
+    expected_lru = torch.cat(
+        [
+            torch.arange(2048, hot_buffer_size, dtype=torch.int16),
+            torch.arange(0, 1000, dtype=torch.int16),
+            torch.arange(2000, 2048, dtype=torch.int16),
+            torch.arange(1000, 2000, dtype=torch.int16),
+        ]
+    )
+    assert torch.equal(lru_slots.cpu().view(-1), expected_lru)
 
 
 if __name__ == "__main__":

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -252,19 +252,11 @@ class CommonKVManager(BaseKVManager):
 
         # Sanity checks
         if info.page_size is not None and info.page_size != self.kv_args.page_size:
-            if self.server_args.enable_hisparse:
-                # HiSparse: decode host pool page_size=1, prefill device pool page_size >= 1.
-                # Transfer will use send_kvcache_hisparse with per-token item_lens.
-                logger.info(
-                    f"HiSparse PD transfer mode: prefill page_size={info.page_size}, "
-                    f"decode host page_size={self.kv_args.page_size}"
-                )
-            else:
-                raise RuntimeError(
-                    f"Page size mismatch: prefill server has page_size={info.page_size}, "
-                    f"but decode server has page_size={self.kv_args.page_size}. "
-                    f"Both servers must use the same --page-size value."
-                )
+            raise RuntimeError(
+                f"Page size mismatch: prefill server has page_size={info.page_size}, "
+                f"but decode server has page_size={self.kv_args.page_size}. "
+                f"Both servers must use the same --page-size value."
+            )
 
         if (
             info.kv_cache_dtype is not None

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -458,10 +458,7 @@ class DecodePreallocQueue:
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        # HiSparse Host pool has page_size=1; use it when hisparse is enabled
-        kv_args.page_size = (
-            1 if self.scheduler.enable_hisparse else self.token_to_kv_pool.page_size
-        )
+        kv_args.page_size = self.token_to_kv_pool.page_size
 
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (
             self.metadata_buffers.get_buf_infos()
@@ -967,6 +964,7 @@ class DecodePreallocQueue:
                 swa_allocatable_tokens -= swa_required
             decode_req.req.cache_protected_len = prefix_len
 
+            page_size = self.token_to_kv_pool_allocator.page_size
             if self.scheduler.enable_hisparse:
                 # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
                 kv_indices = (
@@ -975,7 +973,6 @@ class DecodePreallocQueue:
                     .numpy()
                     .astype(np.int32)
                 )
-                page_size = 1  # host pool page_size
             else:
                 # Only send delta indices (beyond prefix) to prefill.
                 kv_indices = (
@@ -985,7 +982,6 @@ class DecodePreallocQueue:
                     .cpu()
                     .numpy()
                 )
-                page_size = self.token_to_kv_pool_allocator.page_size
 
             seq_len = len(decode_req.req.origin_input_ids)
 
@@ -1342,14 +1338,13 @@ class DecodePreallocQueue:
                 extend_num_tokens=fill_len,
             )
             # Allocate host indices for the RDMA transfer target.
-            host_indices = coordinator.mem_pool_host.alloc(fill_len)
-            if host_indices is None:
-                raise RuntimeError(
-                    f"HiSparse host mem pool alloc failed for {fill_len} tokens "
-                    f"in _pre_alloc (req {req.rid})"
-                )
-            host_indices = host_indices.to(device=coordinator.device)
-            coordinator.req_to_host_pool[req.req_pool_idx, :fill_len] = host_indices
+            host_indices = coordinator.mem_pool_host.alloc_paged_token_slots(
+                coordinator.req_to_host_pool,
+                coordinator.req_to_host_pool_allocated_len,
+                req.req_pool_idx,
+                0,
+                fill_len,
+            )
         elif self.token_to_kv_pool_allocator.page_size == 1:
             kv_loc = self.token_to_kv_pool_allocator.alloc(delta_len)
         else:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -147,8 +147,6 @@ class KVArgsRegisterInfo:
     # for mamba state different tp slice transfer
     dst_state_item_lens: List[List[int]]
     dst_state_dim_per_tensor: List[List[int]]
-    # HiSparse: decode host pool stores KV at token granularity
-    enable_hisparse: bool = False
     # Note: always put the staging field at the final (since the staging field is optional and contains multiple inputs)
     staging: Optional[StagingRegisterInfo] = None
 
@@ -171,11 +169,8 @@ class KVArgsRegisterInfo:
             dst_state_dim_per_tensor=(
                 unpack_int_lists(msg[11], "I") if len(msg) > 11 else []
             ),
-            enable_hisparse=(
-                msg[12].decode("ascii") == "1" if len(msg) > 12 else False
-            ),
             # Note: always put the staging field at the final
-            staging=StagingRegisterInfo.from_zmq_fields(msg, 13),
+            staging=StagingRegisterInfo.from_zmq_fields(msg, 12),
         )
 
 
@@ -720,49 +715,6 @@ class MooncakeKVManager(CommonKVManager):
             item_lens=self.kv_args.kv_item_lens,
             prefill_data_indices=prefill_kv_indices,
             dst_data_indices=dst_kv_indices,
-            executor=executor,
-        )
-
-    def send_kvcache_hisparse(
-        self,
-        mooncake_session_id: str,
-        prefill_kv_indices: npt.NDArray[np.int32],
-        dst_kv_ptrs: list[int],
-        dst_kv_indices: npt.NDArray[np.int32],
-        page_index_slice: slice,
-        executor: concurrent.futures.ThreadPoolExecutor,
-    ):
-        """HiSparse transfer: prefill page_size > decode host page_size=1.
-
-        Receives page-level prefill_kv_indices and the full token-level
-        dst_kv_indices.  Expands both to token granularity before transfer.
-        """
-        page_size = self.kv_args.page_size
-        per_token_item_lens = [il // page_size for il in self.kv_args.kv_item_lens]
-
-        # Expand page-level src indices to token-level
-        base = np.repeat(prefill_kv_indices * page_size, page_size)
-        offsets = np.tile(np.arange(page_size, dtype=np.int32), len(prefill_kv_indices))
-        expanded_src = base + offsets
-
-        # Expand page-level index_slice to token-level for dst
-        token_start = page_index_slice.start * page_size
-        token_end = min(page_index_slice.stop * page_size, len(dst_kv_indices))
-        expanded_dst = dst_kv_indices[token_start:token_end]
-
-        # Clip src to match dst length (last page may be partial)
-        expanded_src = expanded_src[: len(expanded_dst)]
-
-        logger.debug(
-            f"Send KVCache for hisparse: {expanded_src.shape} -> {expanded_dst.shape}"
-        )
-        return self._send_kvcache_generic(
-            mooncake_session_id=mooncake_session_id,
-            src_data_ptrs=self.kv_args.kv_data_ptrs,
-            dst_data_ptrs=dst_kv_ptrs,
-            item_lens=per_token_item_lens,
-            prefill_data_indices=expanded_src,
-            dst_data_indices=expanded_dst,
             executor=executor,
         )
 
@@ -1990,23 +1942,13 @@ class MooncakeKVManager(CommonKVManager):
                             self.attn_tp_size
                             == target_rank_registration_info.dst_attn_tp_size
                         ):
-                            if target_rank_registration_info.enable_hisparse:
-                                ret = self.send_kvcache_hisparse(
-                                    req.mooncake_session_id,
-                                    kv_chunk.prefill_kv_indices,
-                                    target_rank_registration_info.dst_kv_ptrs,
-                                    req.dst_kv_indices,
-                                    kv_chunk.index_slice,
-                                    executor,
-                                )
-                            else:
-                                ret = self.send_kvcache(
-                                    req.mooncake_session_id,
-                                    kv_chunk.prefill_kv_indices,
-                                    target_rank_registration_info.dst_kv_ptrs,
-                                    chunked_dst_kv_indice,
-                                    executor,
-                                )
+                            ret = self.send_kvcache(
+                                req.mooncake_session_id,
+                                kv_chunk.prefill_kv_indices,
+                                target_rank_registration_info.dst_kv_ptrs,
+                                chunked_dst_kv_indice,
+                                executor,
+                            )
                         elif (
                             self.enable_staging
                             and staging_strategy is not None
@@ -2571,8 +2513,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
             dst_tp_rank = str(tp_rank).encode("ascii")
             dst_attn_tp_size = str(self.kv_mgr.attn_tp_size).encode("ascii")
             dst_kv_item_len = str(kv_item_len).encode("ascii")
-            enable_hisparse = b"1" if self.kv_mgr.server_args.enable_hisparse else b"0"
-
             if (
                 self.kv_mgr.enable_staging
                 and self.kv_mgr._staging_ctx.allocator is not None
@@ -2601,7 +2541,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         dst_kv_item_len,
                         packed_state_item_lens,
                         packed_state_dim_per_tensor,
-                        enable_hisparse,
                         packed_staging_base_ptr,
                         staging_total_size_str,
                     ],

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -84,11 +84,12 @@ class HiSparseCoordinator:
                 device_pool=self.mem_pool_device,
                 host_to_device_ratio=host_to_device_ratio,
                 host_size=0,
-                page_size=1,
+                page_size=self.mem_pool_device.page_size,
                 layout="layer_first",
                 override_kv_cache_dim=self.mem_pool_device.kv_cache_dim,
             )
             self.item_size_bytes = self.mem_pool_host.token_stride_size
+        self.page_size = self.mem_pool_device.page_size
 
         max_num_req_slots = req_to_token_pool.req_to_token.shape[0]
         max_context_len = req_to_token_pool.max_context_len
@@ -110,10 +111,13 @@ class HiSparseCoordinator:
             max_num_req_slots, dtype=torch.int64, device="cpu"
         )
         self.req_to_host_pool = torch.full(
-            (max_num_req_slots, max_compressed_context_len),
+            (max_num_req_slots, max_compressed_context_len + self.page_size),
             -1,
             dtype=torch.int64,
             device=device,
+        )
+        self.req_to_host_pool_allocated_len = torch.zeros(
+            max_num_req_slots, dtype=torch.int64, device="cpu"
         )
 
         self.write_staging_stream = device_module.Stream()
@@ -200,18 +204,13 @@ class HiSparseCoordinator:
         )
 
         prefill_len = len(device_indices)
-        host_indices = self.mem_pool_host.alloc(prefill_len)
-        if host_indices is None:
-            logger.error(
-                "HiSparse: host mem pool alloc failed for %d tokens (req %s)",
-                prefill_len,
-                req.rid,
-            )
-            raise RuntimeError(
-                f"HiSparse host mem pool alloc failed for {prefill_len} tokens"
-            )
-        host_indices = host_indices.to(device=self.device)
-        self.req_to_host_pool[req.req_pool_idx, :prefill_len] = host_indices
+        host_indices = self.mem_pool_host.alloc_paged_token_slots(
+            self.req_to_host_pool,
+            self.req_to_host_pool_allocated_len,
+            req.req_pool_idx,
+            0,
+            prefill_len,
+        )
 
         start_event = device_module.Event()
         finish_event = device_module.Event()
@@ -549,17 +548,19 @@ class HiSparseCoordinator:
 
         device_locs = self.req_to_device_buffer[backup_req_indices, buffer_slot]
 
-        host_locs = self.mem_pool_host.alloc(len(device_locs))
-        if host_locs is None:
-            logger.error(
-                "HiSparse: host mem pool alloc failed for %d decode backup tokens",
-                len(device_locs),
+        host_locs_list = []
+        for i in backup_indices:
+            req_idx = int(req_pool_indices_cpu[i])
+            start_pos = (int(seq_lens_cpu[i]) - 1) // self.compress_ratio - 1
+            host_locs = self.mem_pool_host.alloc_paged_token_slots(
+                self.req_to_host_pool,
+                self.req_to_host_pool_allocated_len,
+                req_idx,
+                start_pos,
+                1,
             )
-            raise RuntimeError(
-                f"HiSparse host mem pool alloc failed for {len(device_locs)} decode backup tokens"
-            )
-        host_locs = host_locs.to(device=self.device)
-        self.req_to_host_pool[backup_req_indices, actual_compressed_pos] = host_locs
+            host_locs_list.append(host_locs)
+        host_locs = torch.cat(host_locs_list)
 
         self.wait_for_pending_backup()
         schedule_stream = device_module.current_stream()
@@ -702,12 +703,15 @@ class HiSparseCoordinator:
         self.token_to_kv_pool_allocator.free_hisparse(allocated_locs)
 
         # Free host memory that was allocated during admit_request_into_staging
-        compressed_len = prefill_len // self.compress_ratio
-        host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
-        host_indices = host_indices[host_indices >= 0]
+        host_indices = self.mem_pool_host.allocated_host_indices(
+            self.req_to_host_pool,
+            req.req_pool_idx,
+            self.req_to_host_pool_allocated_len[req.req_pool_idx],
+        )
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
         self.req_to_host_pool[req.req_pool_idx, :] = -1
+        self.req_to_host_pool_allocated_len[req.req_pool_idx] = 0
         self._skip_first_backup[req.req_pool_idx] = False
         req.hisparse_staging = False
 
@@ -730,8 +734,6 @@ class HiSparseCoordinator:
         # subsequent release_kv_cache -> allocator.free -> free_hisparse path
         # re-frees them (double-free into the page allocator's free list).
         allocated_len = req.kv_allocated_len
-        compressed_len = allocated_len // self.compress_ratio
-
         # release memory -- only free actually-allocated buffer indices
         current_cap = int(self.req_device_buffer_size[req.req_pool_idx])
         if current_cap > 0:
@@ -748,8 +750,11 @@ class HiSparseCoordinator:
         )
         self.mem_pool_device.full_to_hisparse_device_index_mapping[compressed_locs] = 0
 
-        host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
-        host_indices = host_indices[host_indices >= 0]
+        host_indices = self.mem_pool_host.allocated_host_indices(
+            self.req_to_host_pool,
+            req.req_pool_idx,
+            self.req_to_host_pool_allocated_len[req.req_pool_idx],
+        )
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
 
@@ -759,6 +764,7 @@ class HiSparseCoordinator:
         self.req_to_device_buffer[req.req_pool_idx, :] = 0
         self.req_device_buffer_size[req.req_pool_idx] = 0
         self.req_to_host_pool[req.req_pool_idx, :] = -1
+        self.req_to_host_pool_allocated_len[req.req_pool_idx] = 0
         self.lru_slots[:, req.req_pool_idx, :].copy_(self._lru_init)
         self._skip_first_backup[req.req_pool_idx] = False
 

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -218,14 +218,28 @@ class SchedulerOutputProcessorMixin:
                     logits_output.input_token_logprobs = tuple(
                         logits_output.input_token_logprobs.tolist()
                     )
-                if logits_output.next_token_top_logprobs_val:
+                if logits_output.input_top_logprobs_val is not None:
+                    logits_output.input_top_logprobs_val = [
+                        v.tolist() if isinstance(v, torch.Tensor) else v
+                        for v in logits_output.input_top_logprobs_val
+                    ]
+                    logits_output.input_top_logprobs_idx = [
+                        x.tolist() if isinstance(x, torch.Tensor) else x
+                        for x in logits_output.input_top_logprobs_idx
+                    ]
+                if logits_output.input_token_ids_logprobs_val is not None:
+                    logits_output.input_token_ids_logprobs_val = [
+                        v.tolist() if isinstance(v, torch.Tensor) else v
+                        for v in logits_output.input_token_ids_logprobs_val
+                    ]
+                if logits_output.next_token_top_logprobs_val is not None:
                     logits_output.next_token_top_logprobs_val = [
                         v.tolist() for v in logits_output.next_token_top_logprobs_val
                     ]
                     logits_output.next_token_top_logprobs_idx = [
                         x.tolist() for x in logits_output.next_token_top_logprobs_idx
                     ]
-                if logits_output.next_token_token_ids_logprobs_val:
+                if logits_output.next_token_token_ids_logprobs_val is not None:
                     logits_output.next_token_token_ids_logprobs_val = [
                         v.tolist()
                         for v in logits_output.next_token_token_ids_logprobs_val
@@ -495,7 +509,7 @@ class SchedulerOutputProcessorMixin:
 
             if batch.return_logprob:
                 next_token_logprobs = logits_output.next_token_logprobs.tolist()
-                if logits_output.next_token_top_logprobs_val:
+                if logits_output.next_token_top_logprobs_val is not None:
                     logits_output.next_token_top_logprobs_val = [
                         v.tolist() for v in logits_output.next_token_top_logprobs_val
                     ]
@@ -503,7 +517,7 @@ class SchedulerOutputProcessorMixin:
                         x.tolist() for x in logits_output.next_token_top_logprobs_idx
                     ]
 
-                if logits_output.next_token_token_ids_logprobs_val:
+                if logits_output.next_token_token_ids_logprobs_val is not None:
                     logits_output.next_token_token_ids_logprobs_val = [
                         v.tolist()
                         for v in logits_output.next_token_token_ids_logprobs_val

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2091,11 +2091,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # We should batch all top-k tokens in all positions.
         ret = []
         for i in range(len(token_logprobs_val)):
-            if token_logprobs_val[i]:
+            values = token_logprobs_val[i]
+            indices = token_logprobs_idx[i]
+            if isinstance(values, torch.Tensor):
+                values = values.tolist()
+            if isinstance(indices, torch.Tensor):
+                indices = indices.tolist()
+            if values:
                 ret.append(
-                    self.detokenize_logprob_tokens(
-                        token_logprobs_val[i], token_logprobs_idx[i], decode_to_text
-                    )
+                    self.detokenize_logprob_tokens(values, indices, decode_to_text)
                 )
             else:
                 ret.append(None)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -63,6 +63,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _get_effective_token_capacity(
+    model_runner: "ModelRunner", enable_hisparse: bool
+) -> int:
+    if enable_hisparse:
+        return model_runner.token_to_kv_pool_allocator.size
+    return model_runner.max_total_num_tokens
+
+
 class BaseTpWorker(ABC):
     @abstractmethod
     def forward_batch_generation(self, forward_batch: ForwardBatch):
@@ -296,7 +304,9 @@ class TpModelWorker(BaseTpWorker):
         self.world_group = get_world_group()
 
         # Profile number of tokens
-        self.max_total_num_tokens = self.model_runner.max_total_num_tokens
+        self.max_total_num_tokens = _get_effective_token_capacity(
+            self.model_runner, server_args.enable_hisparse
+        )
         self.max_prefill_tokens = server_args.max_prefill_tokens
         self.max_running_requests = self.model_runner.max_running_requests
         assert self.max_running_requests > 0, "max_running_request is zero"
@@ -306,7 +316,7 @@ class TpModelWorker(BaseTpWorker):
         ), "If configured, max_queued_requests must be at least 1 for any work to be scheduled."
         self.max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.max_token_pool_size - 1,
+            self.max_total_num_tokens - 1,
         )
         self.max_req_input_len = self.max_req_len - 5
         assert (

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -106,7 +106,7 @@ class HiSparseNSATokenToKVPool(NSATokenToKVPool):
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ):
-        loc = self.translate_loc_to_hisparse_device(loc)
+        loc = self._translate_loc_to_hisparse_device(loc)
         super().set_mla_kv_buffer(layer, loc, cache_k_nope, cache_k_rope)
 
     def get_mla_kv_buffer(

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -51,14 +51,18 @@ from sglang.srt.mem_cache.memory_pool import (
     MLATokenToKVPool,
     NSATokenToKVPool,
 )
-from sglang.srt.utils import is_cuda, is_mps, is_npu, is_xpu
+from sglang.srt.utils import is_cuda, is_hcu, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 _is_mps = is_mps()
 if not (_is_npu or _is_xpu or _is_mps):
     from sgl_kernel.kvcacheio import (
+        transfer_kv_all_direct_lf_pf_D2H_hcu,
+        transfer_kv_all_direct_pf_lf_H2D_hcu,
+        transfer_kv_all_kernel_lf_pf_D2H_hcu,
         transfer_kv_all_layer,
         transfer_kv_all_layer_direct_lf_pf,
         transfer_kv_all_layer_lf_pf,
@@ -68,14 +72,11 @@ if not (_is_npu or _is_xpu or _is_mps):
         transfer_kv_direct,
         transfer_kv_per_layer,
         transfer_kv_per_layer_direct_pf_lf,
+        transfer_kv_per_layer_kernel_pf_lf_H2D_hcu,
         transfer_kv_per_layer_mla,
         transfer_kv_per_layer_mla_pf_lf,
         transfer_kv_per_layer_pf_lf,
         transfer_kv_per_layer_ph_lf,
-        transfer_kv_all_direct_lf_pf_D2H_hcu,
-        transfer_kv_all_direct_pf_lf_H2D_hcu,
-        transfer_kv_all_kernel_lf_pf_D2H_hcu,
-        transfer_kv_per_layer_kernel_pf_lf_H2D_hcu,
     )
 if _is_npu:
     from sgl_kernel_npu.kvcacheio import TransferDirection, transfer_kv_dim_exchange
@@ -107,6 +108,69 @@ class HostTensorAllocator(abc.ABC):
         self.dims = dims
         tensor = torch.empty(dims, dtype=dtype, device=device)
         return tensor
+
+
+class HiSparseHostPoolMixin:
+    def _round_up_to_page_size(self, size: int) -> int:
+        return (size + self.page_size - 1) // self.page_size * self.page_size
+
+    def alloc_page(self, num_pages: int) -> Optional[torch.Tensor]:
+        return self.alloc(num_pages * self.page_size)
+
+    def alloc_paged_token_slots(
+        self,
+        req_to_host_pool: torch.Tensor,
+        req_to_host_pool_allocated_len: torch.Tensor,
+        req_pool_idx: int,
+        start_pos: int,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        """Allocate request host slots by page and return token-granular slots."""
+        device = req_to_host_pool.device
+        if num_tokens <= 0:
+            return torch.empty((0,), dtype=torch.int64, device=device)
+
+        allocated_len = int(req_to_host_pool_allocated_len[req_pool_idx])
+        end_pos = start_pos + num_tokens
+        page_end = self._round_up_to_page_size(end_pos)
+        assert start_pos <= allocated_len
+
+        if page_end > allocated_len:
+            num_new_pages = (page_end - allocated_len) // self.page_size
+            host_locs = self.alloc_page(num_new_pages)
+            if host_locs is None:
+                logger.error(
+                    "HiSparse: host mem pool alloc failed for %d host pages "
+                    "(req_pool_idx=%d, start_pos=%d, num_tokens=%d)",
+                    num_new_pages,
+                    req_pool_idx,
+                    start_pos,
+                    num_tokens,
+                )
+                raise RuntimeError(
+                    f"HiSparse host mem pool alloc failed for {num_new_pages} pages"
+                )
+
+            req_to_host_pool[req_pool_idx, allocated_len:page_end] = host_locs.to(
+                device=device, non_blocking=True
+            )
+            req_to_host_pool_allocated_len[req_pool_idx] = page_end
+
+        return req_to_host_pool[req_pool_idx, start_pos:end_pos]
+
+    def allocated_host_indices(
+        self,
+        req_to_host_pool: torch.Tensor,
+        req_pool_idx: int,
+        allocated_len: int,
+    ) -> torch.Tensor:
+        allocated_len = int(allocated_len)
+        host_len = min(
+            self._round_up_to_page_size(allocated_len),
+            req_to_host_pool.shape[1],
+        )
+        host_indices = req_to_host_pool[req_pool_idx, :host_len]
+        return host_indices[host_indices >= 0]
 
 
 def get_allocator_from_storage(allocator_type):
@@ -802,6 +866,7 @@ class MHATokenToKVPoolHost(HostKVCache):
             raise ValueError(f"Unsupported layout: {self.layout}")
         return ptr_list, element_size_list
 
+
 class MHATokenToKVPoolHostHCU(HostKVCache):
     device_pool: MHATokenToKVPool
 
@@ -859,13 +924,27 @@ class MHATokenToKVPoolHostHCU(HostKVCache):
             # dim_k = (self.layer_num,self.page_num, self.head_num, self.page_size, self.head_dim)
             # dim_v = (self.layer_num,self.page_num, self.head_num, self.head_dim, self.page_size)
             # logger.info(f"self.head_dim:{self.head_dim},self.device_pool.v:{self.device_pool.v_head_dim}")
-            dim_k = (self.page_num,self.layer_num,self.head_num, self.page_size, self.head_dim)
-            dim_v = (self.page_num,self.layer_num,self.head_num, self.head_dim,self.page_size)
+            dim_k = (
+                self.page_num,
+                self.layer_num,
+                self.head_num,
+                self.page_size,
+                self.head_dim,
+            )
+            dim_v = (
+                self.page_num,
+                self.layer_num,
+                self.head_num,
+                self.head_dim,
+                self.page_size,
+            )
         else:
             raise ValueError(f"HCU HiCache Unsupported layout: {self.layout}")
         # self.token_stride_size = self.head_num * self.head_dim * self.dtype.itemsize
         # self.layout_dim = self.token_stride_size * self.layer_num
-        self.token_stride_size = self.page_size * self.head_num * self.head_dim * self.dtype.itemsize
+        self.token_stride_size = (
+            self.page_size * self.head_num * self.head_dim * self.dtype.itemsize
+        )
 
         alloc_func = ALLOC_MEMORY_FUNCS[self.device_pool.device]
         buffer_k = alloc_func(
@@ -882,7 +961,7 @@ class MHATokenToKVPoolHostHCU(HostKVCache):
             pin_memory=self.pin_memory,
             allocator=self.allocator,
         )
-        return (buffer_k,buffer_v)
+        return (buffer_k, buffer_v)
 
     @property
     def k_buffer(self):
@@ -918,7 +997,7 @@ class MHATokenToKVPoolHostHCU(HostKVCache):
                 raise ValueError(f"Unsupported layout: {self.layout}")
         elif io_backend == "direct":
             if self.layout == "layout_hcu":
-               transfer_kv_all_direct_pf_lf_H2D_hcu(
+                transfer_kv_all_direct_pf_lf_H2D_hcu(
                     src_ptrs_k=self.k_buffer,
                     src_ptrs_v=self.v_buffer,
                     dst_ptrs_k=device_pool.k_buffer,
@@ -927,8 +1006,8 @@ class MHATokenToKVPoolHostHCU(HostKVCache):
                     dst_indices=device_indices,
                     start_layer_id=layer_id,
                     page_size=self.page_size,
-               )
-               logger.info("load_to_device_per_layer direct....")
+                )
+                logger.info("load_to_device_per_layer direct....")
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
         else:
@@ -976,34 +1055,50 @@ class MHATokenToKVPoolHostHCU(HostKVCache):
     def get_data_page(self, index, flat: bool = True) -> torch.Tensor:
         if self.layout == "layout_hcu":
             real_index = index // self.page_size
-            data_page_k = self.kv_buffer[0][real_index : real_index + 1,:, :, :, :]
-            data_page_v = self.kv_buffer[1][real_index : real_index + 1,:, :, :, :]
+            data_page_k = self.kv_buffer[0][real_index : real_index + 1, :, :, :, :]
+            data_page_v = self.kv_buffer[1][real_index : real_index + 1, :, :, :, :]
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")
         if flat:
             data_page_k = data_page_k.flatten()
             data_page_v = data_page_v.flatten()
-        return (data_page_k,data_page_v)
+        return (data_page_k, data_page_v)
 
     def get_dummy_flat_data_page(self) -> torch.Tensor:
         return torch.zeros(
-            (self.page_num,self.layer_num, self.head_num, self.page_size,self.head_dim),
+            (
+                self.page_num,
+                self.layer_num,
+                self.head_num,
+                self.page_size,
+                self.head_dim,
+            ),
             dtype=self.dtype,
             device=self.device,
             pin_memory=self.pin_memory,
         ).flatten()
 
-    def set_from_flat_data_page(self, index: int, data_page_k: torch.Tensor,data_page_v: torch.Tensor) -> None:
+    def set_from_flat_data_page(
+        self, index: int, data_page_k: torch.Tensor, data_page_v: torch.Tensor
+    ) -> None:
         if self.layout == "layout_hcu":
             real_index = index // self.page_size
-            self.kv_buffer[0][real_index:real_index + 1,:, :, :, :] = (
+            self.kv_buffer[0][real_index : real_index + 1, :, :, :, :] = (
                 data_page_k.reshape(
-                    self.page_num, self.layer_num,self.head_num,self.page_size, self.head_dim
+                    self.page_num,
+                    self.layer_num,
+                    self.head_num,
+                    self.page_size,
+                    self.head_dim,
                 )
             )
-            self.kv_buffer[1][real_index:real_index + 1,:, :, :, :] = (
+            self.kv_buffer[1][real_index : real_index + 1, :, :, :, :] = (
                 data_page_v.reshape(
-                    self.page_num, self.layer_num,self.head_num, self.head_dim,self.page_size
+                    self.page_num,
+                    self.layer_num,
+                    self.head_num,
+                    self.head_dim,
+                    self.page_size,
                 )
             )
         else:
@@ -1079,7 +1174,7 @@ class MHATokenToKVPoolHostHCU(HostKVCache):
                     * self.layer_num
                     * self.head_num
                     * self.head_dim
-                    * self.dtype.itemsize 
+                    * self.dtype.itemsize
                 )
                 v_ptr = (
                     v_buffer_data_ptr
@@ -1087,19 +1182,24 @@ class MHATokenToKVPoolHostHCU(HostKVCache):
                     * self.layer_num
                     * self.head_num
                     * self.head_dim
-                    * self.dtype.itemsize 
+                    * self.dtype.itemsize
                 )
                 ptr_list.append(k_ptr)
                 ptr_list.append(v_ptr)
             element_size = (
-                self.layer_num * self.dtype.itemsize * self.page_size * self.head_num * self.head_dim
+                self.layer_num
+                * self.dtype.itemsize
+                * self.page_size
+                * self.head_num
+                * self.head_dim
             )
             element_size_list = [element_size] * len(ptr_list)
         else:
             raise ValueError(f"HCU HiCache Unsupported layout: {self.layout}")
-        return ptr_list, element_size_list        
+        return ptr_list, element_size_list
 
-class MLATokenToKVPoolHost(HostKVCache):
+
+class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
     device_pool: MLATokenToKVPool
 
     def __init__(
@@ -1147,7 +1247,7 @@ class MLATokenToKVPoolHost(HostKVCache):
         for registering host memory with the disaggregation transfer engine."""
         data_ptrs = [int(self.data_ptrs[i].item()) for i in range(self.layer_num)]
         data_lens = [self.kv_buffer[i].nbytes for i in range(self.layer_num)]
-        item_lens = [self.token_stride_size] * self.layer_num
+        item_lens = [self.token_stride_size * self.page_size] * self.layer_num
         return data_ptrs, data_lens, item_lens
 
     def get_size_per_token(self):
@@ -1334,6 +1434,19 @@ class MLATokenToKVPoolHost(HostKVCache):
                         cache_src_stride_bytes=self.token_stride_size,
                         element_size=self.kv_cache_dim * self.dtype.itemsize,
                     )
+                elif _is_hcu:
+                    # The all-layer table contains raw host virtual addresses.
+                    # Use the per-layer wrapper so ROCm can map each registered
+                    # host tensor through cudaHostGetDevicePointer.
+                    for layer_id in range(self.layer_num):
+                        transfer_kv_per_layer_mla(
+                            src=device_pool.kv_buffer[layer_id],
+                            dst=self.data_refs[layer_id],
+                            src_indices=device_indices,
+                            dst_indices=host_indices,
+                            item_size=self.token_stride_size,
+                            num_warps_per_block=4,
+                        )
                 else:
                     transfer_kv_all_layer_mla(
                         src_layers=device_pool.data_ptrs,

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -117,7 +117,19 @@ class ModelRunnerKVCacheMixin:
                     element_size = torch._utils._element_size(
                         NSATokenToKVPool.index_k_with_scale_buffer_dtype
                     )
-                cell_size += indexer_size_per_token * num_layers * element_size
+                index_cache_ratio = 1
+                if self.enable_hisparse:
+                    from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                    index_cache_ratio = parse_hisparse_config(
+                        self.server_args
+                    ).host_to_device_ratio
+                cell_size += (
+                    indexer_size_per_token
+                    * num_layers
+                    * element_size
+                    * index_cache_ratio
+                )
         else:
             if self.model_config.is_hybrid_swa:
                 full_layers_num = len(self.model_config.full_attention_layer_ids)

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -42,7 +42,12 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring_size
 from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
-from sglang.srt.utils.common import ceil_div, is_float4_e2m1fn_x2
+from sglang.srt.utils.common import (
+    ceil_div,
+    is_float4_e2m1fn_x2,
+    is_hcu,
+    is_hcu_native_fp8_supported,
+)
 
 
 @dataclass
@@ -74,6 +79,8 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+
+_is_hcu = is_hcu()
 
 
 class MemoryPoolConfigurator:
@@ -172,14 +179,34 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             # Add indexer KV cache overhead for NSA models (DeepSeek V3.2)
             if is_deepseek_nsa(model_config.hf_config):
                 index_head_dim = get_nsa_index_head_dim(model_config.hf_config)
-                indexer_size_per_token = (
-                    index_head_dim
-                    + index_head_dim // NSATokenToKVPool.quant_block_size * 4
+                use_bf16_index_cache = _is_hcu and (
+                    kv_cache_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2)
+                    or not is_hcu_native_fp8_supported()
                 )
-                element_size = torch._utils._element_size(
-                    NSATokenToKVPool.index_k_with_scale_buffer_dtype
+                if use_bf16_index_cache:
+                    indexer_size_per_token = index_head_dim
+                    element_size = torch._utils._element_size(torch.bfloat16)
+                else:
+                    indexer_size_per_token = (
+                        index_head_dim
+                        + index_head_dim // NSATokenToKVPool.quant_block_size * 4
+                    )
+                    element_size = torch._utils._element_size(
+                        NSATokenToKVPool.index_k_with_scale_buffer_dtype
+                    )
+                index_cache_ratio = 1
+                if mr.enable_hisparse:
+                    from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                    index_cache_ratio = parse_hisparse_config(
+                        mr.server_args
+                    ).host_to_device_ratio
+                cell_size += (
+                    indexer_size_per_token
+                    * num_layers
+                    * element_size
+                    * index_cache_ratio
                 )
-                cell_size += indexer_size_per_token * num_layers * element_size
         else:
             cell_size = (
                 model_config.get_num_kv_heads(tp_size)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3457,6 +3457,51 @@ class ServerArgs:
                 f"with torch.compile)."
             )
 
+    def _validate_hcu_deepep_topology(self):
+        if (
+            not is_hcu()
+            or self.moe_a2a_backend != "deepep"
+            or self.deepep_mode not in ("auto", "low_latency")
+        ):
+            return
+
+        nnodes_per_tp_group = max(self.nnodes // self.pp_size, 1)
+        if nnodes_per_tp_group == 1:
+            return
+
+        ranks_per_node = self.tp_size // nnodes_per_tp_group
+        if ranks_per_node != 8:
+            raise ValueError(
+                "The current HCU deep_ep_shca multi-node low-latency runtime "
+                "requires exactly 8 TP/EP ranks per node. Got "
+                f"tp_size={self.tp_size}, ep_size={self.ep_size}, "
+                f"nnodes={self.nnodes}, pp_size={self.pp_size}, "
+                f"ranks_per_node={ranks_per_node}, deepep_mode={self.deepep_mode}. "
+                "Use TP16/D2 or TP32/D4 (8 ranks per node), or select a "
+                "validated non-DeepEP MoE A2A backend."
+            )
+
+        if (
+            self.disaggregation_mode == "decode"
+            and self.tp_size == 32
+            and self.dp_size == 32
+            and self.ep_size == 32
+            and self.pp_size == 1
+            and nnodes_per_tp_group == 4
+            and self.enable_dp_attention
+            and self.enable_dp_lm_head
+            and self.disable_cuda_graph
+        ):
+            raise ValueError(
+                "The current HCU TP32/D4 PD Decode path is not correct in eager "
+                "mode with DeepEP low-latency, DP attention, and DP LM head. Got "
+                f"tp_size={self.tp_size}, dp_size={self.dp_size}, "
+                f"ep_size={self.ep_size}, nnodes={self.nnodes}, "
+                f"pp_size={self.pp_size}, execution_mode=eager. "
+                "To start, remove --disable-cuda-graph and use the validated CUDA Graph "
+                "path, or select a validated non-DeepEP MoE A2A backend."
+            )
+
     def _handle_a2a_moe(self):
         if self.enable_deepep_waterfill and self.moe_a2a_backend != "deepep":
             logger.warning(
@@ -3474,6 +3519,8 @@ class ServerArgs:
                 "SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE is set, "
                 "auto-configuring --moe-a2a-backend megamoe."
             )
+
+        self._validate_hcu_deepep_topology()
 
         if self.moe_a2a_backend == "megamoe":
             self.ep_size = self.tp_size

--- a/test/manual/ep/test_deepep_hcu_4x4.py
+++ b/test/manual/ep/test_deepep_hcu_4x4.py
@@ -1,0 +1,106 @@
+"""Minimal HCU DeepEP low-latency reproduction for four nodes by four ranks."""
+
+import os
+import socket
+
+import deep_ep
+import torch
+import torch.distributed as dist
+
+NUM_MAX_DISPATCH_TOKENS_PER_RANK = 128
+HIDDEN_SIZE = 6144
+NUM_EXPERTS = 256
+NUM_TOPK = 8
+NUM_TEST_TOKENS = 4
+
+
+def main() -> None:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    if world_size != 16 or local_world_size != 4:
+        raise ValueError(
+            "This reproduction requires world_size=16 and local_world_size=4; "
+            f"got world_size={world_size}, local_world_size={local_world_size}."
+        )
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="nccl")
+    group = dist.new_group(ranks=list(range(world_size)))
+    print(
+        f"topology rank={rank} node={socket.gethostname()} "
+        f"local_rank={local_rank} device={torch.cuda.current_device()} "
+        f"pid={os.getpid()}",
+        flush=True,
+    )
+
+    rdma_bytes = deep_ep.Buffer.get_low_latency_rdma_size_hint(
+        NUM_MAX_DISPATCH_TOKENS_PER_RANK,
+        HIDDEN_SIZE,
+        world_size,
+        NUM_EXPERTS,
+        num_topk=NUM_TOPK,
+    )
+    print(f"stage=buffer_init_begin rank={rank} pid={os.getpid()}", flush=True)
+    buffer = deep_ep.Buffer(
+        group,
+        num_nvl_bytes=0,
+        num_rdma_bytes=rdma_bytes,
+        low_latency_mode=True,
+        num_qps_per_rank=NUM_EXPERTS // world_size,
+        allow_mnnvl=True,
+        explicitly_destroy=True,
+    )
+    print(f"stage=buffer_init_end rank={rank} pid={os.getpid()}", flush=True)
+
+    try:
+        x = torch.full(
+            (NUM_TEST_TOKENS, HIDDEN_SIZE),
+            rank + 1,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        target_ranks = (torch.arange(NUM_TOPK, device="cuda") + rank) % world_size
+        topk_idx = (target_ranks * (NUM_EXPERTS // world_size)).repeat(
+            NUM_TEST_TOKENS, 1
+        )
+        topk_weights = torch.full(
+            (NUM_TEST_TOKENS, NUM_TOPK),
+            1.0 / NUM_TOPK,
+            dtype=torch.float32,
+            device="cuda",
+        )
+
+        print(f"stage=dispatch_begin rank={rank} pid={os.getpid()}", flush=True)
+        recv_x, _, handle, _, _ = buffer.low_latency_dispatch(
+            x,
+            topk_idx,
+            topk_weights,
+            NUM_MAX_DISPATCH_TOKENS_PER_RANK,
+            NUM_EXPERTS,
+            quant_type=0,
+        )
+        print(f"stage=dispatch_end rank={rank} pid={os.getpid()}", flush=True)
+        combined_x, _, _ = buffer.low_latency_combine(
+            recv_x,
+            topk_idx,
+            topk_weights,
+            handle,
+        )
+        torch.cuda.synchronize()
+
+        if not torch.isfinite(combined_x).all():
+            raise AssertionError(f"rank {rank} produced non-finite combine output")
+        if not torch.allclose(combined_x, x, rtol=1e-3, atol=1e-3):
+            max_diff = (combined_x.float() - x.float()).abs().max().item()
+            raise AssertionError(f"rank {rank} combine mismatch: max_diff={max_diff}")
+        print(f"PASS rank={rank}", flush=True)
+    finally:
+        buffer.destroy()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/managers/test_hisparse_capacity.py
+++ b/test/registered/unit/managers/test_hisparse_capacity.py
@@ -1,0 +1,82 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+
+
+class TestHiSparseCapacity(unittest.TestCase):
+    def test_memory_profile_accounts_for_expanded_index_cache(self):
+        from sglang.srt.model_executor.pool_configurator import (
+            DefaultPoolConfigurator,
+        )
+
+        runner = SimpleNamespace(
+            enable_hisparse=True,
+            kv_cache_dtype=torch.float8_e4m3fn,
+            model_config=SimpleNamespace(
+                hf_config=object(),
+                kv_lora_rank=512,
+                qk_rope_head_dim=64,
+            ),
+            server_args=SimpleNamespace(
+                hisparse_config=(
+                    '{"top_k":2048,"device_buffer_size":12288,"host_to_device_ratio":20}'
+                )
+            ),
+            use_mla_backend=True,
+        )
+
+        with (
+            patch(
+                "sglang.srt.model_executor.pool_configurator.is_deepseek_nsa",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.model_executor.pool_configurator.get_nsa_index_head_dim",
+                return_value=128,
+            ),
+            patch(
+                "sglang.srt.model_executor.pool_configurator.is_float4_e2m1fn_x2",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.model_executor.pool_configurator.get_attention_tp_size",
+                return_value=1,
+            ),
+            patch(
+                "sglang.srt.model_executor.pool_configurator._is_hcu",
+                True,
+                create=True,
+            ),
+            patch(
+                "sglang.srt.model_executor.pool_configurator.is_hcu_native_fp8_supported",
+                return_value=False,
+                create=True,
+            ),
+        ):
+            configurator = DefaultPoolConfigurator.__new__(DefaultPoolConfigurator)
+            cell_size = configurator._compute_cell_size(runner, 2)
+
+        mla_bytes = (512 + 64) * 2 * torch.float8_e4m3fn.itemsize
+        expanded_index_bytes = 128 * 2 * torch.bfloat16.itemsize * 20
+        self.assertEqual(cell_size, mla_bytes + expanded_index_bytes)
+
+    def test_scheduler_uses_hisparse_logical_capacity(self):
+        from sglang.srt.managers.tp_worker import _get_effective_token_capacity
+
+        runner = SimpleNamespace(
+            max_total_num_tokens=62016,
+            token_to_kv_pool_allocator=SimpleNamespace(size=1240320),
+        )
+
+        self.assertEqual(_get_effective_token_capacity(runner, True), 1240320)
+        self.assertEqual(_get_effective_token_capacity(runner, False), 62016)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -13,16 +13,17 @@ from types import SimpleNamespace
 
 import torch
 
-from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.srt.utils import is_cuda, is_hcu, is_hip, is_npu, is_xpu
+from sglang.test.ci.ci_register import register_cuda_ci, register_hcu_ci
 
 register_cuda_ci(est_time=10, stage="stage-b", runner_config="1-gpu-small")
+register_hcu_ci(est_time=10, suite="stage-b-test-1-hcu")
 
 # ---------------------------------------------------------------------------
 # Test configuration (small-scale for fast CI runs)
 # ---------------------------------------------------------------------------
 SIZE = 2048  # device buffer pool size (tokens)
-PAGE_SIZE = 64  # page size (must be 64 for CUDA, 1 for ROCm)
+PAGE_SIZE = 64  # page size (must be 64 for CUDA/HCU, 1 for other ROCm)
 TOP_K = 256  # top-k selection count
 DEVICE_BUFFER_SIZE = 512  # device buffer per request
 HOST_TO_DEVICE_RATIO = 2
@@ -88,7 +89,7 @@ class TestHiSparseUnit(unittest.TestCase):
         cls._original_alloc = ALLOC_MEMORY_FUNCS["cuda"]
         ALLOC_MEMORY_FUNCS["cuda"] = alloc_with_pin_memory
 
-        global_page_size = 1 if is_hip() else PAGE_SIZE
+        global_page_size = 1 if is_hip() and not is_hcu() else PAGE_SIZE
 
         from sglang.srt.mem_cache.hisparse_memory_pool import (
             HiSparseNSATokenToKVPool,
@@ -161,6 +162,7 @@ class TestHiSparseUnit(unittest.TestCase):
         self.coordinator.req_to_device_buffer.zero_()
         self.coordinator.req_device_buffer_size.zero_()
         self.coordinator.req_to_host_pool.fill_(-1)
+        self.coordinator.req_to_host_pool_allocated_len.zero_()
         self.coordinator.req_device_buffer_tokens.fill_(-1)
         self.coordinator.req_device_buffer_token_locs.fill_(-1)
         self.coordinator.lru_slots[:] = self.coordinator._lru_init.view(1, 1, -1)
@@ -237,10 +239,13 @@ class TestHiSparseUnit(unittest.TestCase):
         """Allocate host slots, write known patterns, register in coordinator.
         Returns host_indices (cuda tensor)."""
         host_pool = self.coordinator.mem_pool_host
-        host_indices = host_pool.alloc(fill_len)
-        self.assertIsNotNone(host_indices, "Host alloc failed")
-        host_indices = host_indices.to(device="cuda")
-        self.coordinator.req_to_host_pool[req.req_pool_idx, :fill_len] = host_indices
+        host_indices = host_pool.alloc_paged_token_slots(
+            self.coordinator.req_to_host_pool,
+            self.coordinator.req_to_host_pool_allocated_len,
+            req.req_pool_idx,
+            0,
+            fill_len,
+        )
         for lid in range(LAYER_NUM):
             for i in range(fill_len):
                 host_pool.kv_buffer[lid][host_indices[i]] = self._kv_pattern(lid, i)
@@ -355,6 +360,30 @@ class TestHiSparseUnit(unittest.TestCase):
         self.assertEqual(logical, initial_sizes[0], f"Logical leak {msg}")
         self.assertEqual(hisparse, initial_sizes[1], f"HiSparse leak {msg}")
         self.assertEqual(host, initial_sizes[2], f"Host leak {msg}")
+
+    def test_mla_device_mapping_preserves_int64_dtype(self):
+        """The FP8 MLA KV store operator requires translated locations as int64."""
+        logical_loc = torch.tensor([1], dtype=torch.int64, device="cuda")
+        self.allocator.full_to_hisparse_device_index_mapping[logical_loc] = 7
+
+        translated = self.coordinator.mem_pool_device._translate_loc_to_hisparse_device(
+            logical_loc
+        )
+
+        self.assertEqual(translated.dtype, torch.int64)
+        self.assertEqual(translated.item(), 7)
+
+    def test_hisparse_host_pool_uses_device_page_size(self):
+        """PD source and decode host destination must use the same page size."""
+        self.assertEqual(self.coordinator.mem_pool_host.page_size, self.page_size)
+        _, _, item_lens = self.coordinator.mem_pool_host.get_contiguous_buf_infos()
+        self.assertTrue(
+            all(
+                item_len
+                == self.coordinator.mem_pool_host.token_stride_size * self.page_size
+                for item_len in item_lens
+            )
+        )
 
     # ==================================================================
     # Test: Kernel correctness — short sequence (fast path)
@@ -553,6 +582,70 @@ class TestHiSparseUnit(unittest.TestCase):
 
         self._cleanup_req(req, kv_loc)
         self._assert_sizes_restored(initial, "staging_path")
+
+    def test_decode_backup_after_direct_admission(self):
+        """PD warmup's second decode step backs up the previous token safely."""
+        initial = self._get_initial_sizes()
+        fill_len = 4
+        req = _make_req("decode-backup", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        req_pool_indices = torch.tensor(
+            [req.req_pool_idx], dtype=torch.int64, device="cuda"
+        )
+        last_loc = kv_loc[-1:]
+        allocated_locs = [kv_loc]
+
+        for seq_len in (fill_len + 1, fill_len + 2):
+            seq_lens = torch.tensor([seq_len], dtype=torch.int64, device="cuda")
+            seq_lens_cpu = torch.tensor([seq_len], dtype=torch.int64)
+            out_loc = self.allocator.alloc_decode(
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens_cpu,
+                last_loc=last_loc,
+            )
+            self.assertIsNotNone(out_loc)
+            self.req_to_token_pool.write((req.req_pool_idx, seq_len - 1), out_loc)
+            req.kv_allocated_len = seq_len
+            req.kv_committed_len = seq_len
+
+            self.coordinator.map_last_loc_to_buffer(
+                seq_lens=seq_lens,
+                out_cache_loc=out_loc,
+                req_pool_indices=req_pool_indices,
+                seq_lens_cpu=seq_lens_cpu,
+            )
+            device_loc = self.allocator.full_to_hisparse_device_index_mapping[out_loc]
+            for layer_id in range(LAYER_NUM):
+                self.device_pool.kv_buffer[layer_id][device_loc] = self._kv_pattern(
+                    layer_id, seq_len - 1
+                )
+
+            allocated_locs.append(out_loc)
+            last_loc = out_loc
+
+        self.coordinator.wait_for_pending_backup()
+        torch.cuda.synchronize()
+
+        host_loc = self.coordinator.req_to_host_pool[req.req_pool_idx, fill_len]
+        self.assertGreaterEqual(int(host_loc.item()), 0)
+        for layer_id in range(LAYER_NUM):
+            actual = self.coordinator.mem_pool_host.kv_buffer[layer_id][host_loc]
+            expected = self._kv_pattern(layer_id, fill_len)
+            self.assertTrue(
+                torch.allclose(
+                    actual.float(),
+                    torch.full_like(actual.float(), expected),
+                    atol=1e-2,
+                )
+            )
+
+        self._cleanup_req(req, torch.cat(allocated_locs), logical_only=True)
+        self._assert_sizes_restored(initial, "decode_backup")
 
     # ==================================================================
     # Test: Direct-to-host (PD separated) path

--- a/test/registered/unit/managers/test_scheduler_output_processor.py
+++ b/test/registered/unit/managers/test_scheduler_output_processor.py
@@ -1,0 +1,65 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler_output_processor_mixin import (  # noqa: E402
+    SchedulerOutputProcessorMixin,
+)
+
+register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+
+
+class TestSchedulerOutputProcessor(unittest.TestCase):
+    def test_prefill_converts_batched_logprob_tensors(self):
+        logits_output = SimpleNamespace(
+            next_token_logprobs=None,
+            input_token_logprobs=None,
+            input_top_logprobs_val=torch.tensor([[[-1.0, -2.0]]]),
+            input_top_logprobs_idx=torch.tensor([[[7, 8]]]),
+            input_token_ids_logprobs_val=torch.tensor([[[-3.0, -4.0]]]),
+            next_token_top_logprobs_val=torch.tensor([[1.0, 2.0]]),
+            next_token_top_logprobs_idx=torch.tensor([[3, 4]]),
+            next_token_token_ids_logprobs_val=torch.tensor([[5.0, 6.0]]),
+        )
+        result = SimpleNamespace(
+            copy_done=None,
+            routed_experts_output=None,
+            indexer_topk_output=None,
+            logits_output=logits_output,
+            next_token_ids=torch.empty(0, dtype=torch.int64),
+            extend_input_len_per_req=[],
+            extend_logprob_start_len_per_req=[],
+        )
+        batch = SimpleNamespace(
+            return_logprob=True,
+            reqs=[],
+            prefill_stats=None,
+            dp_cooperation_info=None,
+        )
+        scheduler = SimpleNamespace(
+            is_generation=True,
+            stream_output=MagicMock(),
+            report_prefill_stats=MagicMock(),
+        )
+
+        SchedulerOutputProcessorMixin.process_batch_result_prefill(
+            scheduler, batch, result
+        )
+
+        self.assertEqual(logits_output.next_token_top_logprobs_val, [[1.0, 2.0]])
+        self.assertEqual(logits_output.next_token_top_logprobs_idx, [[3, 4]])
+        self.assertEqual(logits_output.input_top_logprobs_val, [[[-1.0, -2.0]]])
+        self.assertEqual(logits_output.input_top_logprobs_idx, [[[7, 8]]])
+        self.assertEqual(logits_output.input_token_ids_logprobs_val, [[[-3.0, -4.0]]])
+        self.assertEqual(logits_output.next_token_token_ids_logprobs_val, [[5.0, 6.0]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_tokenizer_manager_logprobs.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_logprobs.py
@@ -1,0 +1,29 @@
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: E402
+
+register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+
+
+class TestTokenizerManagerLogprobs(unittest.TestCase):
+    def test_detokenizes_tensor_top_logprobs_without_tensor_truthiness(self):
+        manager = object.__new__(TokenizerManager)
+
+        result = manager.detokenize_top_logprobs_tokens(
+            [torch.tensor([-0.5, -1.5]), torch.tensor([])],
+            [torch.tensor([5, 7]), torch.tensor([], dtype=torch.int64)],
+            decode_to_text=False,
+        )
+
+        self.assertEqual(result, [[(-0.5, 5, None), (-1.5, 7, None)], None])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -23,7 +23,7 @@ from sglang.test.ci.ci_register import register_cpu_ci, register_hcu_ci
 # HCU BW1100 validated on 10.16.1.66/dxl-sglang: three-pass PR-gate smoke passed.
 register_hcu_ci(est_time=30, suite="stage-b-test-1-hcu-small")
 
-from sglang.test.test_utils import (
+from sglang.test.test_utils import (  # noqa: E402
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
     CustomTestCase,
 )
@@ -572,6 +572,76 @@ class TestDeepEPWaterfillArgs(CustomTestCase):
         self.assertEqual(server_args.deepep_mode, "low_latency")
         self.assertFalse(server_args.disable_cuda_graph)
         self.assertTrue(server_args.enforce_shared_experts_fusion)
+
+
+class TestHcuDeepEPTopology(unittest.TestCase):
+    @patch("sglang.srt.server_args.is_hcu", return_value=True)
+    def test_rejects_four_local_ranks_for_multinode_low_latency(self, _mock_is_hcu):
+        server_args = ServerArgs(
+            model_path="dummy",
+            tp_size=16,
+            pp_size=1,
+            dp_size=16,
+            ep_size=16,
+            nnodes=4,
+            moe_a2a_backend="deepep",
+            deepep_mode="low_latency",
+        )
+
+        with self.assertRaises(ValueError) as context:
+            server_args._handle_a2a_moe()
+
+        message = str(context.exception)
+        self.assertIn("tp_size=16", message)
+        self.assertIn("nnodes=4", message)
+        self.assertIn("ranks_per_node=4", message)
+        self.assertIn("deepep_mode=low_latency", message)
+        self.assertIn("TP16/D2", message)
+        self.assertIn("TP32/D4", message)
+
+    @patch("sglang.srt.server_args.is_hcu", return_value=True)
+    def test_allows_eight_local_ranks_for_multinode_low_latency(self, _mock_is_hcu):
+        server_args = ServerArgs(
+            model_path="dummy",
+            tp_size=32,
+            pp_size=1,
+            dp_size=32,
+            ep_size=32,
+            nnodes=4,
+            moe_a2a_backend="deepep",
+            deepep_mode="low_latency",
+        )
+
+        server_args._handle_a2a_moe()
+
+        self.assertEqual(server_args.ep_size, 32)
+
+    @patch("sglang.srt.server_args.is_hcu", return_value=True)
+    def test_rejects_tp32_decode_eager(self, _mock_is_hcu):
+        server_args = ServerArgs(
+            model_path="dummy",
+            disaggregation_mode="decode",
+            tp_size=32,
+            pp_size=1,
+            dp_size=32,
+            ep_size=32,
+            nnodes=4,
+            enable_dp_attention=True,
+            enable_dp_lm_head=True,
+            moe_a2a_backend="deepep",
+            deepep_mode="low_latency",
+            disable_cuda_graph=True,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            server_args._handle_a2a_moe()
+
+        message = str(context.exception)
+        self.assertIn("tp_size=32", message)
+        self.assertIn("dp_size=32", message)
+        self.assertIn("nnodes=4", message)
+        self.assertIn("execution_mode=eager", message)
+        self.assertIn("remove --disable-cuda-graph", message)
 
 
 class TestPrefillOnlyDisableKvCache(unittest.TestCase):


### PR DESCRIPTION
# fix: enable validated HiSparse P4D4 on HCU

## TL;DR

- Fix HCU long-context HiSparse correctness in the ROCm wavefront64 kernel, registered host-memory access, and page-based PD/Mooncake transfers.
- Fix logical-capacity accounting and logprob handling, and reject HCU DeepEP topologies or execution modes known to be incorrect.
- The validated path is 4 Prefill nodes plus 4 Decode nodes, with Decode `TP32/DP32/EP32/PP1`, 8 ranks per node, CUDA Graph, and HiSparse ratio 20.

## Modifications

- **Kernel and host transfer:** use 64-lane ballot, scan, LRU, and portable cache copies on ROCm/HCU; resolve `cudaHostRegister` memory through its device alias; use tensor-aware per-layer copies for HCU device-to-host backup.
- **Host Pool and PD:** align the HiSparse Host Pool with the device page size, allocate and release complete pages with a per-request frontier, advertise the real page size, reject Prefill/Decode mismatches, and use the standard page-based Mooncake transfer path. The removed HiSparse-only registration frame requires Prefill and Decode to use the same message layout.
- **Capacity and output correctness:** preserve `int64` locations for FP8 MLA writes, include the HiSparse ratio when sizing the HCU BF16 NSA index cache, expose allocator logical capacity to the scheduler, and convert logprob tensors to Python lists before scheduler/tokenizer processing.
- **Fail-fast guards:** require 8 TP/EP ranks per node for multi-node HCU DeepEP `auto`/`low_latency`, and reject the known-incorrect 4-node `TP32/DP32/EP32/PP1` Decode eager path while keeping the validated CUDA Graph path available.

## Test Results

- HCU host-register and production-sized ROCm wavefront/LRU JIT tests passed. Focused Host Pool, manager, capacity, scheduler, tokenizer, and server-argument tests also passed; Ruff and staged diff checks were clean.
- Production-scale evidence is from the validated change set before it was rebased; the long-running cases were not rerun after the rebase.
- All 4 Prefill pods, 4 Decode pods, and 1 Router pod stayed Ready with zero restarts. Decode exposed 793,600 logical tokens, completed 32 CUDA Graph captures, and passed PD warmup.
- Strict validation passed on all 32 Decode ranks with identical token sequences and 1,728/1,728 finite logprob values. The OpenAI Chat API test passed, and requests with 23,051 and 134,031 input tokens completed with explicit `max_tokens=128`.
- The fixed 768K Top 5 passed 5/5 at `concurrency=1` with no retries. The largest request used 778,508 input tokens and 778,636 total tokens; usage matched the frozen manifest, pods remained Ready, and the final log scan found no hard runtime errors.
- Validation does not cover TP16/D4, TP32/D4 eager mode, concurrent 768K, the full 50-case dataset, or other backends. A 1,047,040-token configuration failed Host KV allocation, so this change does not claim 1M support.
- No comparable same-version A/B benchmark was run; this PR makes no performance claim.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->