### PR TITLE
[HCU][NSA] 复用已排序 TopK indices，消除 FlashMLA 重复排序

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -96,6 +96,7 @@ SGLang supports various environment variables that can be used to configure its 
 | Environment Variable | Description | Default Value |
 | --- | --- | --- |
 | `SGLANG_NSA_FUSE_TOPK` | Fuse the operation of picking topk logits and picking topk indices from page table  | `true` |
+| `SGLANG_NSA_HCU_REUSE_SORTED_TOPK` | On HCU CP prefill, skip FlashMLA's repeated sort when a layer reuses the previous layer's already sorted TopK indices. | `false` |
 | `SGLANG_NSA_ENABLE_MTP_PRECOMPUTE_METADATA` | Precompute metadata that can be shared among different draft steps when MTP is enabled | `true` |
 | `SGLANG_USE_FUSED_METADATA_COPY` | Control whether to use fused metadata copy kernel for cuda graph replay  | `true` |
 | `SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD` | When the maximum kv len in current prefill batch exceeds this value, the sparse mla kernel will be applied, else it falls back to dense MHA implementation. Default to the index topk of model (2048 for DeepSeek V3.2) | `2048` |

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -478,6 +478,7 @@ class Envs:
 
     # NSA Backend
     SGLANG_NSA_FUSE_TOPK = EnvBool(True)
+    SGLANG_NSA_HCU_REUSE_SORTED_TOPK = EnvBool(False)
     # gfx938 length-masked persistent-MQA packaged in LightOp.
     SGLANG_NSA_HCU_PERSISTENT_MQA_FASTPATH = EnvBool(False)
     SGLANG_NSA_HCU_PERSISTENT_MQA_CTAS = EnvInt(0)

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -1528,6 +1528,10 @@ class NativeSparseAttnBackend(
             q_nope = q_all[:, :, : layer.v_head_dim]
             q_rope = q_all[:, :, layer.v_head_dim :]
 
+        topk_was_padded = (
+            topk_indices is not None and topk_indices.shape[0] != q_nope.shape[0]
+        )
+
         # Align topk_indices with q dimensions
         # This handles cases where q is padded (TP + partial DP attention)
         if topk_indices is not None:
@@ -1632,12 +1636,21 @@ class NativeSparseAttnBackend(
                     kv_cache = _cat([k, k_rope], dim=-1)
                 page_table_1 = topk_indices
 
+            skip_reused_topk_sort = (
+                envs.SGLANG_NSA_HCU_REUSE_SORTED_TOPK.get()
+                and getattr(layer, "reuse_topk_indices", False)
+                and not topk_was_padded
+                and envs.SGLANG_NSA_FUSE_TOPK.get()
+                and topk_transform_method == TopkTransformMethod.RAGGED
+                and forward_batch.hisparse_coordinator is None
+            )
             return self._forward_flashmla_sparse(
                 q_all=q_all,
                 kv_cache=kv_cache,
                 page_table_1=page_table_1,
                 sm_scale=layer.scaling,
                 v_head_dim=layer.v_head_dim,
+                indices_are_sorted=skip_reused_topk_sort,
             )
         elif nsa_impl == "flashmla_kv":
             if q_rope is not None:
@@ -1890,12 +1903,8 @@ class NativeSparseAttnBackend(
         v_head_dim: int,
         page_table_1: torch.Tensor,
         sm_scale: float,
+        indices_are_sorted: bool = False,
     ) -> torch.Tensor:
-        if not _is_hcu:
-            from sgl_kernel.flash_mla import flash_mla_sparse_fwd
-        else:
-            from flash_mla.flash_mla_interface import flash_mla_sparse_fwd
-
         # FlashMLA sparse kernel requires num_heads to be a multiple of 64 (Hopper) or 128 (Blackwell)
         # When using TP, num_heads might be smaller (e.g., 256//8=32)
         num_tokens, num_heads, head_dim = q_all.shape
@@ -1921,13 +1930,45 @@ class NativeSparseAttnBackend(
         # indices shape must be (s_q, h_kv=1, topk), keep h_kv=1 unchanged
         indices_input = page_table_1.unsqueeze(1)
 
-        o, _, _ = flash_mla_sparse_fwd(
-            q=q_input,
-            kv=kv_cache,
-            indices=indices_input,
-            sm_scale=sm_scale,
-            d_v=v_head_dim,
-        )
+        if _is_hcu:
+            from flash_mla import flash_mla_interface
+
+            raw_sparse_prefill_fwd = getattr(
+                getattr(flash_mla_interface, "flash_mla_cuda", None),
+                "sparse_prefill_fwd",
+                None,
+            )
+            can_skip_sort = (
+                indices_are_sorted and raw_sparse_prefill_fwd is not None
+            )
+            if can_skip_sort:
+                o, _, _ = raw_sparse_prefill_fwd(
+                    q_input,
+                    kv_cache,
+                    indices_input,
+                    sm_scale,
+                    v_head_dim,
+                    None,
+                    None,
+                )
+            else:
+                o, _, _ = flash_mla_interface.flash_mla_sparse_fwd(
+                    q=q_input,
+                    kv=kv_cache,
+                    indices=indices_input,
+                    sm_scale=sm_scale,
+                    d_v=v_head_dim,
+                )
+        else:
+            from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+            o, _, _ = flash_mla_sparse_fwd(
+                q=q_input,
+                kv=kv_cache,
+                indices=indices_input,
+                sm_scale=sm_scale,
+                d_v=v_head_dim,
+            )
 
         # Trim output back to original num_heads if we padded
         if (not _is_hcu) and need_padding:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1781,6 +1781,8 @@ class DeepseekV2AttentionMLA(
             quant_config=quant_config,
             prefix=add_prefix("attn_mqa", prefix),
         )
+        # Expose the model's existing TopK-sharing decision to the NSA backend.
+        self.attn_mqa.reuse_topk_indices = bool(self.skip_topk and not self.is_nextn)
 
         self.attn_mha = RadixAttention(
             self.num_local_heads,


### PR DESCRIPTION
## 背景

GLM-5.2 NSA Indexer 大约每 4 层重新计算一次 TopK indices，其余层复用上一层的 TopK tensor。

HCU FlashMLA public wrapper 每次调用 sparse prefill 时都会对 indices 执行排序，导致复用层对同一个已排序 tensor 重复排序。

## 修改内容

- 新增环境变量：
  `SGLANG_NSA_HCU_REUSE_SORTED_TOPK`
- 默认关闭，保证默认行为不变。
- 模型层标记当前 attention 是否复用上一层的 TopK indices。
- 首次生成 TopK 时继续调用 public `flash_mla_sparse_fwd`，完成检查和排序。
- 复用已排序 TopK 时直接调用 raw `sparse_prefill_fwd`，跳过重复排序。
- indices 被 padding、转换或 raw binding 不可用时，自动回退到 public wrapper。
- 非 HCU 路径保持不变。

启用方式：

export SGLANG_NSA_HCU_REUSE_SORTED_TOPK=1

## 修改文件

- `python/sglang/srt/environ.py`
- `python/sglang/srt/models/deepseek_v2.py`
- `python/sglang/srt/layers/attention/nsa_backend.py`
- `docs/references/environment_variables.md`

## 功能验证

- Public wrapper 能够原地排序 indices。
- Public 与 raw FlashMLA 输出数值完全一致，最大绝对误差为 0。
- fresh TopK 走 public wrapper。
- reused TopK 走 raw binding。
- raw binding 不存在时能够回退 public wrapper。

## Profile 结果

测试配置：

- GLM-5.2 FP8
- CP8 / EP8
- 输入长度：32768
- 请求数：16

TP0 Profile 中：

- FlashMLA sparse prefill：约 395 次
- TopK indices sort：约 110 次
- 重复排序次数下降约 72.2%

## 精度结果

| Model | Dataset | Metric | Subset | Num | Score |
|---|---|---|---|---:|---:|
| glm5.2-fp8-cp8ep8 | humaneval | mean_acc | openai_humaneval | 164 | 0.9512 |
| glm5.2-fp8-cp8ep8 | humaneval | mean_acc_pass@1 | openai_humaneval | 164 | 0.9512 |

## 风险控制

- 优化开关默认关闭。
- 只有明确复用且未重新生成、padding 或转换的 TopK indices 才跳过排序。
- 不满足条件时保持原有 FlashMLA public wrapper 路径。