### PR TITLE
fix(moe): 跳过 FP8 激活量化中的填充行

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -1178,11 +1178,13 @@ class DeepEPMoE(FusedMoE):
             q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant(
                 gateup_output,
                 fp8type=0,
+                expert_ids=m_indices,
             )
         else:
             q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant(
                 gateup_output,
                 fp8type=0,
+                expert_ids=m_indices,
                 limit=swiglu_limit,
             )
         del gateup_output


### PR DESCRIPTION
## 改动内容

- DeepEP MoE 的两处 FP8 激活量化调用传入 `expert_ids=m_indices`。
- 让量化算子识别并跳过合成填充行，避免填充 token 参与量化统计或访问无效专家。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：GLM-5.2 IFB/DP padding 场景下需要正确处理 DeepEP 合成行。
- 目标分支：main

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 性能（如涉及） | 不涉及 | - |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [x] 涉及算子/kernel