### PR TITLE
fix(moe): 跳过 DeepEP 预填充的二阶段重叠

### DIFF
--- a/python/sglang/srt/batch_overlap/single_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/single_batch_overlap.py
@@ -104,6 +104,15 @@ def compute_overlap_args(dispatch_output, alt_stream):
 
     hidden_states = dispatch_output.hidden_states
 
+    # DeepEP normal mode (prefill) returns a contiguous [num_tokens, hidden_dim]
+    # tensor. Its contiguous GroupGEMM/combine path does not implement the
+    # down-GEMM/combine signaling below, which is defined for the 3-D masked
+    # layout used by low-latency decode. The shared expert has already been
+    # overlapped with DeepEP dispatch, so only skip the unsupported second
+    # overlap stage here.
+    if hidden_states.ndim != 3:
+        return None, None, {}
+
     num_local_experts, num_tokens_static, hidden_dim = hidden_states.shape
 
     total_num_sms = torch.cuda.get_device_properties(

--- a/test/registered/unit/batch_overlap/test_sbo_deepep_normal_dispatch.py
+++ b/test/registered/unit/batch_overlap/test_sbo_deepep_normal_dispatch.py
@@ -1,0 +1,33 @@
+"""Regression test for DeepEP normal-mode SBO overlap arguments."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.batch_overlap.single_batch_overlap import SboFlags, compute_overlap_args
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestSboDeepEPNormalDispatch(CustomTestCase):
+    @patch.object(
+        SboFlags, "enable_combine_shared_two_stream_overlap", return_value=False
+    )
+    @patch.object(
+        SboFlags, "enable_combine_down_gemm_two_stream_overlap", return_value=True
+    )
+    def test_2d_dispatch_skips_secondary_overlap(self, _down_enabled, _shared_enabled):
+        dispatch_output = SimpleNamespace(hidden_states=torch.empty((4, 16)))
+
+        self.assertEqual(
+            compute_overlap_args(dispatch_output, alt_stream=None),
+            (None, None, {}),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

- DeepEP normal prefill 返回非三维 hidden states 时，跳过 secondary batch overlap。
- 保留原三维输入的重叠执行路径，并补充对应行为测试。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：GLM-5.2 DeepEP normal prefill 的二维输出不能按三维张量解包。
- 目标分支：main

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 不涉及 | - |
| 性能（如涉及） | 未验证 | 二维输入会主动跳过二阶段重叠 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [ ] 涉及算子/kernel

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->