### PR TITLE
fix(attention): 启用 HCU DSA MTP 草稿扩展图

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -120,6 +120,7 @@ from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_cpu,
     is_cuda,
+    is_hcu,
     is_hip,
     is_musa,
     is_npu,
@@ -131,12 +132,18 @@ from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_musa = is_musa()
 _is_hip = is_hip()
 _is_xpu = is_xpu()
 
 
 logger = logging.getLogger(__name__)
+
+
+def _supports_cuda_graph_runner() -> bool:
+    """Whether this platform uses the CUDA-style EAGLE graph runners."""
+    return _is_cuda or _is_hcu or _is_musa
 
 
 class EagleDraftWorker(EagleDraftWorkerBase):
@@ -436,9 +443,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             TokenspeedMLABackend,
             FlashInferAttnBackend,
         ]
-        if _is_cuda or _is_musa:
-            # DSA is CUDA-only; import lazily so non-CUDA builds don't pull in
-            # deep_gemm and the rest of the sparse-attention stack at import time.
+        if _supports_cuda_graph_runner():
+            # Import lazily so unsupported platforms do not pull in the sparse
+            # attention stack at module import time.
             from sglang.srt.layers.attention.dsa_backend import (
                 DeepseekSparseAttnBackend,
             )
@@ -461,8 +468,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             tuple(graph_supported_backend_types),
         )
         supports_cuda_draft_extend_graph = (
-            _is_cuda or _is_musa
-        ) and graph_supported_backend
+            _supports_cuda_graph_runner() and graph_supported_backend
+        )
         # Capture extend
         # TODO: support draft extend cuda graph for more attention backends
         if (

--- a/test/registered/unit/spec/test_eagle_worker_v2_graph_support.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_graph_support.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch
+
+import sglang.srt.speculative.eagle_worker_v2 as eagle_worker_v2
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestEagleWorkerV2GraphSupport(CustomTestCase):
+    def test_hcu_uses_cuda_style_graph_runner(self):
+        with (
+            patch.object(eagle_worker_v2, "_is_cuda", False),
+            patch.object(eagle_worker_v2, "_is_hcu", True),
+            patch.object(eagle_worker_v2, "_is_musa", False),
+        ):
+            self.assertTrue(eagle_worker_v2._supports_cuda_graph_runner())
+
+    def test_plain_hip_does_not_use_cuda_style_graph_runner(self):
+        with (
+            patch.object(eagle_worker_v2, "_is_cuda", False),
+            patch.object(eagle_worker_v2, "_is_hcu", False),
+            patch.object(eagle_worker_v2, "_is_musa", False),
+        ):
+            self.assertFalse(eagle_worker_v2._supports_cuda_graph_runner())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

- 将 HCU 纳入 EAGLE V2 draft-extend CUDA Graph 支持判定。
- HCU 继续使用现有 HIP/AITER draft decode，同时允许 DSA draft-extend backend 进入图路径。
- 增加平台支持条件的契约测试。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：GLM-5.2 MTP 需要在满足原有 batch、DP 和 speculative 条件时启用 HCU draft-extend 图。
- 目标分支：main

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 性能（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [ ] 涉及算子/kernel