### PR TITLE
feat(moe): 增加本地性公平静态分发策略

### DIFF
--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -631,9 +631,12 @@ def compute_logical_to_rank_dispatch_physical_map(
     ep_rank: int,
     seed: int = 42,
 ):
-    from sglang.srt.runtime_context import get_parallel
+    from sglang.srt.runtime_context import get_exec, get_parallel
 
     r = random.Random(seed)
+    dispatch_policy = get_exec().moe.ep_static_dispatch_policy
+    if dispatch_policy not in ("nearest", "locality_fair"):
+        raise ValueError(f"Unknown static expert dispatch policy: {dispatch_policy}")
 
     device = logical_to_all_physical_map.device
     logical_to_all_physical_map = logical_to_all_physical_map.cpu()
@@ -660,6 +663,19 @@ def compute_logical_to_rank_dispatch_physical_map(
             candidate_physical_expert_ids = _logical_to_all_physical_raw(
                 logical_to_all_physical_map, layer_id, logical_expert_id
             )
+
+            if dispatch_policy == "locality_fair":
+                choices = _assign_locality_fair_experts(
+                    candidate_physical_expert_ids=candidate_physical_expert_ids,
+                    ep_size=ep_size,
+                    num_local_gpu_physical_experts=num_local_gpu_physical_experts,
+                    num_gpus_per_node=num_gpus_per_node,
+                    num_local_node_physical_experts=num_local_node_physical_experts,
+                    r=r,
+                )
+                for moe_ep_rank, choice in enumerate(choices):
+                    result_list[moe_ep_rank][layer_id][logical_expert_id] = choice
+                continue
 
             remaining_ranks = []
             for moe_ep_rank in range(ep_size):
@@ -751,6 +767,135 @@ def _find_nearest_expert(
 
     # 4. At last, leave it as -1 to indicate not found.
     return -1
+
+
+def _assign_locality_fair_experts(
+    candidate_physical_expert_ids: List[int],
+    ep_size: int,
+    num_local_gpu_physical_experts: int,
+    num_gpus_per_node: Optional[int],
+    num_local_node_physical_experts: Optional[int],
+    r: random.Random,
+) -> List[int]:
+    """Build one deterministic static source-rank-to-replica assignment.
+
+    Locality is prioritized before fairness: same GPU, then same node when the
+    topology exposes node boundaries, then remote. Assignment counts are local
+    to this logical expert; they balance static source-rank bindings, not live
+    token or queue load.
+    """
+    if ep_size <= 0:
+        raise ValueError(f"ep_size must be positive, got {ep_size}")
+    if num_local_gpu_physical_experts <= 0:
+        raise ValueError(
+            "num_local_gpu_physical_experts must be positive, got "
+            f"{num_local_gpu_physical_experts}"
+        )
+    if not candidate_physical_expert_ids:
+        raise ValueError("locality_fair requires at least one physical replica")
+    if (num_gpus_per_node is None) != (num_local_node_physical_experts is None):
+        raise ValueError(
+            "num_gpus_per_node and num_local_node_physical_experts must either "
+            "both be set or both be None"
+        )
+
+    num_nodes = None
+    if num_gpus_per_node is not None:
+        if num_gpus_per_node <= 0 or ep_size % num_gpus_per_node != 0:
+            raise ValueError(
+                f"ep_size ({ep_size}) must be divisible by positive "
+                f"num_gpus_per_node ({num_gpus_per_node})"
+            )
+        expected_node_experts = num_local_gpu_physical_experts * num_gpus_per_node
+        if num_local_node_physical_experts != expected_node_experts:
+            raise ValueError(
+                "num_local_node_physical_experts must equal "
+                "num_local_gpu_physical_experts * num_gpus_per_node, got "
+                f"{num_local_node_physical_experts} != {expected_node_experts}"
+            )
+        num_nodes = ep_size // num_gpus_per_node
+
+    assignments = [-1] * ep_size
+    assignment_counts = {
+        physical_expert_id: 0 for physical_expert_id in candidate_physical_expert_ids
+    }
+
+    candidates_by_gpu = [[] for _ in range(ep_size)]
+    candidates_by_node = [[] for _ in range(num_nodes or 0)]
+    for physical_expert_id in candidate_physical_expert_ids:
+        gpu_id = _compute_gpu_id_of_physical_expert(
+            physical_expert_id, num_local_gpu_physical_experts
+        )
+        if physical_expert_id < 0 or gpu_id >= ep_size:
+            max_physical_expert_id = ep_size * num_local_gpu_physical_experts - 1
+            raise ValueError(
+                f"physical expert {physical_expert_id} is outside topology "
+                f"range [0, {max_physical_expert_id}]"
+            )
+        candidates_by_gpu[gpu_id].append(physical_expert_id)
+        if num_nodes is not None:
+            node_id = _compute_node_id_of_physical_expert(
+                physical_expert_id, num_local_node_physical_experts
+            )
+            candidates_by_node[node_id].append(physical_expert_id)
+
+    # A same-GPU replica is always the strongest locality choice.
+    for moe_ep_rank in range(ep_size):
+        if candidates_by_gpu[moe_ep_rank]:
+            choice = _choose_least_assigned_expert(
+                candidates_by_gpu[moe_ep_rank], assignment_counts, r
+            )
+            assignments[moe_ep_rank] = choice
+            assignment_counts[choice] += 1
+
+    # Include same-GPU counts while balancing unassigned ranks within a node.
+    if num_gpus_per_node is not None:
+        for node_id, same_node_physical_expert_ids in enumerate(candidates_by_node):
+            if not same_node_physical_expert_ids:
+                continue
+
+            node_rank_begin = node_id * num_gpus_per_node
+            remaining_ranks = [
+                moe_ep_rank
+                for moe_ep_rank in range(
+                    node_rank_begin, node_rank_begin + num_gpus_per_node
+                )
+                if assignments[moe_ep_rank] == -1
+            ]
+            r.shuffle(remaining_ranks)
+            for moe_ep_rank in remaining_ranks:
+                choice = _choose_least_assigned_expert(
+                    same_node_physical_expert_ids, assignment_counts, r
+                )
+                assignments[moe_ep_rank] = choice
+                assignment_counts[choice] += 1
+
+    # Nodes without a replica, or flat topologies without node affinity, fall
+    # back to all replicas while preserving counts from the locality passes.
+    remaining_ranks = [
+        moe_ep_rank
+        for moe_ep_rank, assignment in enumerate(assignments)
+        if assignment == -1
+    ]
+    r.shuffle(remaining_ranks)
+    for moe_ep_rank in remaining_ranks:
+        choice = _choose_least_assigned_expert(
+            candidate_physical_expert_ids, assignment_counts, r
+        )
+        assignments[moe_ep_rank] = choice
+        assignment_counts[choice] += 1
+
+    return assignments
+
+
+def _choose_least_assigned_expert(
+    candidate_physical_expert_ids: List[int],
+    assignment_counts: dict[int, int],
+    r: random.Random,
+) -> int:
+    candidates = candidate_physical_expert_ids.copy()
+    r.shuffle(candidates)
+    return min(candidates, key=assignment_counts.__getitem__)
 
 
 def _fair_choices(arr: List, k: int, r: random.Random) -> List:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -220,7 +220,8 @@ HCU_DSA_PREFILL_BACKEND_CHOICES = {"flashmla_sparse", "flashmla_kv", "flashmla_a
 HCU_DSA_DECODE_BACKEND_CHOICES = {"flashmla_sparse", "flashmla_kv"}
 HCU_GENERIC_KV_CACHE_DTYPE_CHOICES = {"auto", "bf16", "bfloat16", "fp8_e5m2"}
 HCU_NATIVE_FP8_KV_CACHE_DTYPE_CHOICES = {
-    *HCU_GENERIC_KV_CACHE_DTYPE_CHOICES, "fp8_e4m3"
+    *HCU_GENERIC_KV_CACHE_DTYPE_CHOICES,
+    "fp8_e4m3",
 }
 HCU_DSA_KV_CACHE_DTYPE_CHOICES = {"auto", "bf16", "bfloat16", "fp8_e4m3"}
 HCU_DSV4_KV_CACHE_DTYPE_CHOICES = HCU_DSA_KV_CACHE_DTYPE_CHOICES
@@ -1826,10 +1827,14 @@ class ServerArgs:
         NS("exec.kernel"),
     ] = "auto"
     pack_paged_kv_to_varlen_min_kv_tokens: A[
-        int, "Minimum total KV tokens for the packed paged-KV auto policy.", NS("exec.kernel")
+        int,
+        "Minimum total KV tokens for the packed paged-KV auto policy.",
+        NS("exec.kernel"),
     ] = 16384
     pack_paged_kv_to_varlen_min_q_tokens: A[
-        int, "Minimum query tokens for the packed paged-KV auto policy.", NS("exec.kernel")
+        int,
+        "Minimum query tokens for the packed paged-KV auto policy.",
+        NS("exec.kernel"),
     ] = 8192
     mamba_backend: A[
         str,
@@ -2386,6 +2391,16 @@ class ServerArgs:
         "The algorithm to choose ranks for redundant experts in expert parallel.",
         NS("exec.moe"),
     ] = None
+    ep_static_dispatch_policy: A[
+        Literal["nearest", "locality_fair"],
+        "Choose the replica-selection policy for static expert dispatch. "
+        "`nearest` preserves the legacy nearest-replica behavior. "
+        "`locality_fair` builds a deterministic source-rank-to-replica map "
+        "that preserves same-GPU, then same-node locality while balancing "
+        "static bindings among equally local replicas; it does not rebalance "
+        "live token traffic.",
+        NS("exec.moe"),
+    ] = "nearest"
     init_expert_location: A[str, "Initial location of EP experts.", NS("exec.moe")] = (
         "trivial"
     )
@@ -6878,6 +6893,12 @@ class ServerArgs:
         return required
 
     def _handle_eplb_and_dispatch(self):
+        if self.ep_static_dispatch_policy not in ("nearest", "locality_fair"):
+            raise ValueError(
+                "--ep-static-dispatch-policy must be one of "
+                "'nearest' or 'locality_fair'."
+            )
+
         if self.enable_eplb and (self.expert_distribution_recorder_mode is None):
             self.expert_distribution_recorder_mode = "stat"
             logger.warning(
@@ -6893,6 +6914,16 @@ class ServerArgs:
         ):
             self.ep_dispatch_algorithm = (
                 "dynamic" if needs_rank_invariant_dispatch else "static"
+            )
+
+        if (
+            self.ep_static_dispatch_policy != "nearest"
+            and self.ep_dispatch_algorithm != "static"
+        ):
+            raise ValueError(
+                "--ep-static-dispatch-policy locality_fair requires "
+                "--ep-dispatch-algorithm static. It configures a startup-time "
+                "source-rank-to-replica map, not dynamic token balancing."
             )
 
         # `dynamic` / `fake` switch to the row-index pick; `static` reads a

--- a/test/registered/unit/eplb/test_compute_logical_to_rank_dispatch_physical_map.py
+++ b/test/registered/unit/eplb/test_compute_logical_to_rank_dispatch_physical_map.py
@@ -5,15 +5,19 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 
 import unittest
+from collections import Counter
+from random import Random
 
 import torch
 
 from sglang.srt.eplb.expert_location import (
+    _assign_locality_fair_experts,
     _compute_logical_to_all_physical_map,
     append_trivial_expert_slots,
     compute_logical_to_rank_dispatch_physical_map,
 )
 from sglang.srt.runtime_context import get_context
+from sglang.srt.server_args import ServerArgs
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -22,6 +26,7 @@ def _published(
     nnodes: int,
     moe_a2a_backend: str = "deepep",
     ep_join_mode=None,
+    ep_static_dispatch_policy: str = "nearest",
 ):
     """Scoped publish of the config the placement functions read.
 
@@ -33,6 +38,7 @@ def _published(
         nnodes=nnodes,
         moe_a2a_backend=moe_a2a_backend,
         ep_join_mode=ep_join_mode,
+        ep_static_dispatch_policy=ep_static_dispatch_policy,
     )
 
 
@@ -222,6 +228,143 @@ class TestComputeLogicalToRankDispatchPhysicalMap(CustomTestCase):
             )
 
         self.assertEqual(logical_to_physical[0, :16, 0].tolist(), list(range(64, 80)))
+
+
+class TestLocalityFairStaticDispatch(CustomTestCase):
+    """The policy builds static bindings; it does not inspect live token load."""
+
+    CANDIDATES = [0, 4, 12]
+    EP_SIZE = 8
+    NUM_LOCAL_GPU_EXPERTS = 2
+    NUM_GPUS_PER_NODE = 2
+    NUM_LOCAL_NODE_EXPERTS = 4
+
+    @classmethod
+    def _assign(cls, seed=42):
+        return _assign_locality_fair_experts(
+            candidate_physical_expert_ids=cls.CANDIDATES,
+            ep_size=cls.EP_SIZE,
+            num_local_gpu_physical_experts=cls.NUM_LOCAL_GPU_EXPERTS,
+            num_gpus_per_node=cls.NUM_GPUS_PER_NODE,
+            num_local_node_physical_experts=cls.NUM_LOCAL_NODE_EXPERTS,
+            r=Random(seed),
+        )
+
+    def test_same_gpu_then_same_node_then_remote(self):
+        assignments = self._assign()
+
+        # Physical experts 0, 4, and 12 are on source GPUs 0, 2, and 6.
+        self.assertEqual(assignments[0], 0)
+        self.assertEqual(assignments[2], 4)
+        self.assertEqual(assignments[6], 12)
+
+        # Their node peers retain node locality even though no replica is on
+        # those peers' own GPUs.
+        self.assertEqual(assignments[1], 0)
+        self.assertEqual(assignments[3], 4)
+        self.assertEqual(assignments[7], 12)
+
+        # Node 2 has no replica, so ranks 4 and 5 use the fair remote fallback.
+        self.assertIn(assignments[4], self.CANDIDATES)
+        self.assertIn(assignments[5], self.CANDIDATES)
+        counts = Counter(assignments)
+        self.assertLessEqual(max(counts.values()) - min(counts.values()), 1)
+
+    def test_same_seed_is_deterministic(self):
+        self.assertEqual(self._assign(seed=7), self._assign(seed=7))
+
+    def test_flat_topology_skips_same_node_affinity(self):
+        assignments = _assign_locality_fair_experts(
+            candidate_physical_expert_ids=[0, 4],
+            ep_size=4,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=None,
+            num_local_node_physical_experts=None,
+            r=Random(42),
+        )
+
+        self.assertEqual(assignments[0], 0)
+        self.assertEqual(assignments[2], 4)
+        self.assertEqual({assignments[1], assignments[3]}, {0, 4})
+
+    def test_policy_is_wired_through_static_dispatch_map(self):
+        logical_to_all_physical = torch.tensor([[[0, 4, 12]]], dtype=torch.int64)
+        with _published(
+            ep_size=self.EP_SIZE,
+            nnodes=4,
+            ep_static_dispatch_policy="locality_fair",
+        ):
+            actual = [
+                compute_logical_to_rank_dispatch_physical_map(
+                    logical_to_all_physical_map=logical_to_all_physical,
+                    ep_size=self.EP_SIZE,
+                    num_physical_experts=16,
+                    ep_rank=ep_rank,
+                    seed=42,
+                ).item()
+                for ep_rank in range(self.EP_SIZE)
+            ]
+
+        self.assertEqual(actual, self._assign(seed=42))
+
+    def test_server_args_rejects_non_static_opt_in(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep",
+            ep_dispatch_algorithm="dynamic",
+            ep_static_dispatch_policy="locality_fair",
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires.*static"):
+            server_args._handle_eplb_and_dispatch()
+
+    def test_server_args_accepts_static_opt_in(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep",
+            ep_dispatch_algorithm="static",
+            ep_static_dispatch_policy="locality_fair",
+        )
+
+        server_args._handle_eplb_and_dispatch()
+
+    def test_single_rank_topology(self):
+        assignment = _assign_locality_fair_experts(
+            candidate_physical_expert_ids=[0, 1],
+            ep_size=1,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=1,
+            num_local_node_physical_experts=2,
+            r=Random(42),
+        )
+        self.assertEqual(len(assignment), 1)
+        self.assertIn(assignment[0], [0, 1])
+
+    def test_invalid_topology_is_rejected(self):
+        valid = dict(
+            candidate_physical_expert_ids=[0],
+            ep_size=4,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=2,
+            num_local_node_physical_experts=4,
+            r=Random(42),
+        )
+        invalid_overrides = [
+            {"candidate_physical_expert_ids": []},
+            {"ep_size": 0},
+            {"num_local_gpu_physical_experts": 0},
+            {
+                "num_gpus_per_node": None,
+                "num_local_node_physical_experts": 4,
+            },
+            {"num_gpus_per_node": 3, "num_local_node_physical_experts": 6},
+            {"num_local_node_physical_experts": 5},
+            {"candidate_physical_expert_ids": [8]},
+        ]
+
+        for overrides in invalid_overrides:
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                _assign_locality_fair_experts(**(valid | overrides))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 改动内容

- 新增可选的 `locality_fair` EP 静态分发策略。
- 按 GPU 本地、节点本地、远端的优先级选择副本，并在同优先级内按已分配负载公平打散。
- 默认仍使用 `nearest`，并增加拓扑参数校验和静态映射测试。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：GLM-5.2 多副本专家静态布局需要兼顾通信本地性与 rank 间分配公平。
- 目标分支：main

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 不涉及 | 仅改变显式选择该策略时的静态副本映射 |
| 性能（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [ ] 涉及算子/kernel