### PR TITLE
perf(kernel): 增加 HCU MLA 查询拼接内核

### DIFF
--- a/benchmark/kernels/elementwise/benchmark_concat_mla_absorb_q_hcu.py
+++ b/benchmark/kernels/elementwise/benchmark_concat_mla_absorb_q_hcu.py
@@ -1,0 +1,26 @@
+import argparse
+
+import torch
+from sgl_kernel import concat_mla_absorb_q
+
+from sglang.benchmark.bench_utils import run_bench
+
+
+def benchmark(dim_0: int, dim_1: int):
+    q_nope = torch.randn(dim_0, dim_1, 512, device="cuda", dtype=torch.bfloat16)
+    q_rope = torch.randn(dim_0, dim_1, 64, device="cuda", dtype=torch.bfloat16)
+
+    custom_ms, _, _ = run_bench(lambda: concat_mla_absorb_q(q_nope, q_rope))
+    torch_ms, _, _ = run_bench(lambda: torch.cat((q_nope, q_rope), dim=-1))
+    print(
+        f"shape=({dim_0}, {dim_1}) custom={custom_ms:.6f} ms "
+        f"torch={torch_ms:.6f} ms speedup={torch_ms / custom_ms:.2f}x"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dim-0", type=int, default=16)
+    parser.add_argument("--dim-1", type=int, default=128)
+    args = parser.parse_args()
+    benchmark(args.dim_0, args.dim_1)

--- a/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
@@ -42,6 +42,9 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
   m.impl("gelu_and_mul", torch::kCUDA, &gelu_and_mul);
 
+  m.def("concat_mla_absorb_q(Tensor a, Tensor b, Tensor! out) -> ()");
+  m.impl("concat_mla_absorb_q", torch::kCUDA, &concat_mla_absorb_q);
+
   m.def("l2norm(Tensor input, float eps) -> Tensor");
   m.impl("l2norm", torch::kCUDA, &l2norm);
 

--- a/python/sglang/kernels/aot/csrc/elementwise/concat_mla_absorb_q_hcu.cu
+++ b/python/sglang/kernels/aot/csrc/elementwise/concat_mla_absorb_q_hcu.cu
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <hip/hip_runtime.h>
+#include <torch/all.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+constexpr int64_t kALastDim = 512;
+constexpr int64_t kBLastDim = 64;
+constexpr int64_t kOutLastDim = kALastDim + kBLastDim;
+constexpr int64_t kBf16PerVec = 8;
+constexpr int64_t kAVecsPerRow = kALastDim / kBf16PerVec;
+constexpr int64_t kBVecsPerRow = kBLastDim / kBf16PerVec;
+constexpr int kWaveSize = 64;
+constexpr int kThreads = 256;
+constexpr int kWavesPerBlock = kThreads / kWaveSize;
+constexpr int kRowsPerWave = 8;
+constexpr int kRowsPerBlock = kWavesPerBlock * kRowsPerWave;
+
+static_assert(sizeof(uint4) == 16, "uint4 must be a 16-byte vector");
+static_assert(kAVecsPerRow == kWaveSize, "one wave must cover one a row");
+static_assert(kWavesPerBlock == 4, "one block must contain four waves");
+
+__global__ void concat_mla_absorb_q_hcu_kernel(
+    const at::BFloat16* __restrict__ a,
+    const at::BFloat16* __restrict__ b,
+    at::BFloat16* __restrict__ out,
+    int64_t num_rows,
+    int64_t dim_1,
+    int64_t a_stride_0,
+    int64_t a_stride_1,
+    int64_t b_stride_0,
+    int64_t b_stride_1,
+    int64_t out_stride_0,
+    int64_t out_stride_1) {
+  const int lane = threadIdx.x & (kWaveSize - 1);
+  const int wave = threadIdx.x / kWaveSize;
+  const int64_t first_row = static_cast<int64_t>(blockIdx.x) * kRowsPerBlock + wave * kRowsPerWave;
+
+#pragma unroll
+  for (int row_in_wave = 0; row_in_wave < kRowsPerWave; ++row_in_wave) {
+    const int64_t row = first_row + row_in_wave;
+    if (row >= num_rows) return;
+
+    const int64_t idx_0 = row / dim_1;
+    const int64_t idx_1 = row - idx_0 * dim_1;
+    const auto* a_row = a + idx_0 * a_stride_0 + idx_1 * a_stride_1;
+    auto* out_row = out + idx_0 * out_stride_0 + idx_1 * out_stride_1;
+    reinterpret_cast<uint4*>(out_row)[lane] = reinterpret_cast<const uint4*>(a_row)[lane];
+
+    if (lane < kBVecsPerRow) {
+      const auto* b_row = b + idx_0 * b_stride_0 + idx_1 * b_stride_1;
+      reinterpret_cast<uint4*>(out_row)[kAVecsPerRow + lane] = reinterpret_cast<const uint4*>(b_row)[lane];
+    }
+  }
+}
+
+void check_concat_tensor(const at::Tensor& tensor, const char* name, int64_t expected_last_dim) {
+  TORCH_CHECK(tensor.is_cuda(), name, " must be on an HCU device");
+  TORCH_CHECK(tensor.dim() == 3, name, " must be a 3D tensor");
+  TORCH_CHECK(tensor.scalar_type() == at::ScalarType::BFloat16, name, " must have dtype torch.bfloat16");
+  TORCH_CHECK(tensor.size(2) == expected_last_dim, name, ".size(2) must be ", expected_last_dim);
+  TORCH_CHECK(tensor.stride(2) == 1, name, " must be contiguous in its last dimension");
+  TORCH_CHECK(
+      tensor.stride(0) % kBf16PerVec == 0 && tensor.stride(1) % kBf16PerVec == 0,
+      name,
+      " row addresses must be 16-byte aligned");
+  TORCH_CHECK(
+      reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignof(uint4) == 0,
+      name,
+      " base address must be 16-byte aligned");
+}
+
+}  // namespace
+
+void concat_mla_absorb_q(at::Tensor a, at::Tensor b, at::Tensor out) {
+  check_concat_tensor(a, "a", kALastDim);
+  check_concat_tensor(b, "b", kBLastDim);
+  check_concat_tensor(out, "out", kOutLastDim);
+  TORCH_CHECK(a.device() == b.device() && a.device() == out.device(), "all tensors must be on the same device");
+  TORCH_CHECK(
+      a.size(0) == b.size(0) && a.size(0) == out.size(0) && a.size(1) == b.size(1) && a.size(1) == out.size(1),
+      "a, b, and out leading dimensions must match");
+
+  const int64_t num_rows = a.size(0) * a.size(1);
+  if (num_rows == 0) return;
+
+  const int64_t num_blocks = (num_rows + kRowsPerBlock - 1) / kRowsPerBlock;
+  TORCH_CHECK(num_blocks <= std::numeric_limits<uint32_t>::max(), "concat_mla_absorb_q input is too large");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  concat_mla_absorb_q_hcu_kernel<<<static_cast<uint32_t>(num_blocks), kThreads, 0, stream>>>(
+      static_cast<const at::BFloat16*>(a.data_ptr()),
+      static_cast<const at::BFloat16*>(b.data_ptr()),
+      static_cast<at::BFloat16*>(out.data_ptr()),
+      num_rows,
+      a.size(1),
+      a.stride(0),
+      a.stride(1),
+      b.stride(0),
+      b.stride(1),
+      out.stride(0),
+      out.stride(1));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}

--- a/python/sglang/kernels/aot/setup_rocm.py
+++ b/python/sglang/kernels/aot/setup_rocm.py
@@ -50,6 +50,7 @@ sources = [
     "csrc/attention/decode_metadata.cu",
     "csrc/common_extension_rocm.cc",
     "csrc/elementwise/activation.cu",
+    "csrc/elementwise/concat_mla_absorb_q_hcu.cu",
     "csrc/elementwise/deepseek_v4_topk.cu",
     "csrc/elementwise/dsv4_norm_rope.cu",
     "csrc/elementwise/l2norm_kernel.cu",

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -51,12 +51,18 @@ from sglang.kernels.ops.kvcache.kv_indices import (
 from sglang.kernels.ops.kvcache.rope_cache import (
     fused_qk_rope_reshape_and_cache as fused_qk_rope_reshape_and_cache,
 )
-from sglang.srt.utils import is_cuda
+from sglang.srt.environ import envs
+from sglang.srt.utils import is_cuda, is_hcu
 
 _is_cuda = is_cuda()
+_use_hcu_concat_mla_absorb_q = (
+    is_hcu() and envs.SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q.get()
+)
 
 if _is_cuda:
     from sglang.kernels.ops.attention.concat_mla import concat_mla_absorb_q
+elif _use_hcu_concat_mla_absorb_q:
+    from sgl_kernel import concat_mla_absorb_q
 
 
 # When num_kv_heads=1, we have tensors with degenerate strides,
@@ -193,10 +199,22 @@ def mla_quantize_without_rope_for_fp8(
 
 
 def concat_mla_absorb_q_general(q_nope, q_rope):
-    if _is_cuda and q_nope.shape[-1] == 512 and q_rope.shape[-1] == 64:
+    can_use_custom_op = (
+        (_is_cuda or _use_hcu_concat_mla_absorb_q)
+        and q_nope.ndim == q_rope.ndim == 3
+        and q_nope.shape[:-1] == q_rope.shape[:-1]
+        and (q_nope.shape[-1], q_rope.shape[-1]) == (512, 64)
+        and q_nope.dtype == q_rope.dtype == torch.bfloat16
+        and q_nope.is_cuda
+        and q_rope.is_cuda
+        and q_nope.device == q_rope.device
+        and q_nope.stride(-1) == q_rope.stride(-1) == 1
+        and all(stride % 8 == 0 for stride in q_nope.stride()[:-1])
+        and all(stride % 8 == 0 for stride in q_rope.stride()[:-1])
+    )
+    if can_use_custom_op:
         return concat_mla_absorb_q(q_nope, q_rope)
-    else:
-        return torch.cat([q_nope, q_rope], dim=-1)
+    return torch.cat([q_nope, q_rope], dim=-1)
 
 
 @triton.jit

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -841,6 +841,8 @@ class Envs:
         False, deprecated_name="SGLANG_NSA_HIP_DISABLE_PRESHUFFLE"
     )
     SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
+    # Opt-in HCU AOT kernel for concatenating absorbed MLA Q components.
+    SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q = EnvBool(False)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)
     SGLANG_DISABLE_DSA_INDEXER_FUSION = EnvBool(False)

--- a/test/registered/hcu/kernels/test_concat_mla_absorb_q_hcu.py
+++ b/test/registered/hcu/kernels/test_concat_mla_absorb_q_hcu.py
@@ -1,0 +1,40 @@
+import unittest
+
+import torch
+from sgl_kernel import concat_mla_absorb_q
+
+from sglang.test.ci.ci_register import register_hcu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_hcu_ci(est_time=30, suite="stage-b-test-1-hcu-small")
+
+
+class TestConcatMlaAbsorbQHcu(CustomTestCase):
+    def test_matches_torch_cat(self):
+        for dim_0, dim_1 in ((1, 1), (1, 5), (4, 16), (9, 7)):
+            with self.subTest(dim_0=dim_0, dim_1=dim_1):
+                q_nope = torch.randn(
+                    dim_0, dim_1, 512, device="cuda", dtype=torch.bfloat16
+                )
+                q_rope = torch.randn(
+                    dim_0, dim_1, 64, device="cuda", dtype=torch.bfloat16
+                )
+                expected = torch.cat((q_nope, q_rope), dim=-1)
+                actual = concat_mla_absorb_q(q_nope, q_rope)
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_supports_aligned_non_contiguous_rows(self):
+        q_nope_storage = torch.randn(3, 11, 520, device="cuda", dtype=torch.bfloat16)
+        q_rope_storage = torch.randn(3, 11, 72, device="cuda", dtype=torch.bfloat16)
+        q_nope = q_nope_storage[..., :512]
+        q_rope = q_rope_storage[..., :64]
+        self.assertFalse(q_nope.is_contiguous())
+        self.assertFalse(q_rope.is_contiguous())
+
+        actual = concat_mla_absorb_q(q_nope, q_rope)
+        expected = torch.cat((q_nope, q_rope), dim=-1)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

- 增加 HCU wave64 的 MLA absorb query 拼接 AOT kernel。
- 通过 `SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q` 显式开启，默认关闭。
- 保持 CUDA JIT 路径不变，并增加 HCU kernel 测试与 benchmark。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：GLM-5.2 HCU MLA 路径需要减少 query 拼接的额外 kernel 和内存操作。
- 目标分支：main

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 性能（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [x] 涉及算子/kernel