### PR TITLE
fix(quant): 修复 HCU W8A8 hipBLASLt 权重布局

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -46,6 +46,14 @@ from sglang.srt.utils import W8a8GetCacheJSON
 W8A8_TRITONJSON = W8a8GetCacheJSON()
 
 
+def _use_kme_hipblaslt(device: torch.device) -> bool:
+    if device.type != "cuda":
+        return False
+    device_props = torch.cuda.get_device_properties(device)
+    gcn_arch = getattr(device_props, "gcnArchName", "").split(":")[0]
+    return gcn_arch == "gfx928"
+
+
 class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
 
     def __init__(
@@ -119,6 +127,9 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
     def process_weights_after_loading(self, layer) -> None:
         n = layer.weight.shape[0]
         k = layer.weight.shape[1]
+        use_kme_hipblaslt = self.w8a8_strategy == 3 and _use_kme_hipblaslt(
+            layer.weight.device
+        )
 
         if self.w8a8_strategy == 1:
             if [n, k] not in W8A8_TRITONJSON.weight_shapes:
@@ -142,9 +153,6 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
                             best_config=value,
                         )
         elif self.w8a8_strategy == 3:
-            # KME/gfx928 hipBLASLt swapped TN: pack W as col-major [K,N]
-            # stride (1,K). Do not apply the later CHANNEL .t() that would
-            # turn it into contiguous [N,K] for the legacy blaslt path.
             w = layer.weight.data  # [N, K]
             if self.strategy == QuantizationStrategy.TENSOR:
                 max_w_scale, w = requantize_with_max_scale(
@@ -161,9 +169,16 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
             else:
                 raise ValueError(f"Unknown quantization strategy {self.strategy}")
 
-            w_col = torch.empty_strided((k, n), (1, k), device=w.device, dtype=w.dtype)
-            w_col.copy_(w.t().contiguous())
-            layer.weight = Parameter(w_col, requires_grad=False)
+            if use_kme_hipblaslt:
+                # gfx928 KME swapped TN: col-major [K,N], stride (1,K).
+                packed_weight = torch.empty_strided(
+                    (k, n), (1, k), device=w.device, dtype=w.dtype
+                )
+                packed_weight.copy_(w.t().contiguous())
+            else:
+                # gfx936/gfx938 use legacy NT with contiguous [N,K].
+                packed_weight = w.contiguous()
+            layer.weight = Parameter(packed_weight, requires_grad=False)
 
             W8A8_TRITONJSON.gen_model_json()
 
@@ -190,8 +205,13 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
                 layer.input_zero_point = None
 
             if not self.input_symmetric:
-                # W is [K,N] col-major; AZP adj is sum over K -> [1,N]
-                azp_adj = layer.weight.sum(dim=0, keepdim=True, dtype=torch.int32)
+                # AZP adjustment is the reduction over K, normalized to [1,N].
+                if use_kme_hipblaslt:
+                    azp_adj = layer.weight.sum(dim=0, keepdim=True, dtype=torch.int32)
+                else:
+                    azp_adj = layer.weight.sum(
+                        dim=1, keepdim=False, dtype=torch.int32
+                    ).unsqueeze(0)
                 if self.is_static_input_scheme:
                     azp_adj = layer.input_zero_point * azp_adj
                 layer.azp_adj = Parameter(azp_adj, requires_grad=False)

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_w8a8_int8_hcu_layout.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_w8a8_int8_hcu_layout.py
@@ -1,0 +1,94 @@
+"""HCU W8A8 method-3 weight-layout regression tests."""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+from compressed_tensors.quantization import QuantizationStrategy
+from torch.nn import Parameter
+
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    compressed_tensors_w8a8_int8 as w8a8_int8,
+)
+from sglang.test.ci.ci_register import register_hcu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_hcu_ci(est_time=5, suite="stage-b-test-1-hcu-small")
+
+
+class TestCompressedTensorsW8A8Int8HCULayout(CustomTestCase):
+    @staticmethod
+    def _make_scheme():
+        with mock.patch.dict(os.environ, {"W8A8_SUPPORT_METHODS": "3"}):
+            return w8a8_int8.CompressedTensorsW8A8Int8(
+                strategy=QuantizationStrategy.CHANNEL,
+                is_static_input_scheme=False,
+                input_symmetric=False,
+            )
+
+    @staticmethod
+    def _make_layer(weight: torch.Tensor):
+        layer = torch.nn.Module()
+        layer.weight = Parameter(weight.clone(), requires_grad=False)
+        layer.weight_scale = Parameter(
+            torch.ones((weight.shape[0], 1), dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.logical_widths = [weight.shape[0]]
+        return layer
+
+    def test_only_gfx928_selects_kme(self):
+        cuda_device = SimpleNamespace(type="cuda")
+        cases = {
+            "gfx928:sramecc+:xnack-": True,
+            "gfx936:sramecc+:xnack-": False,
+            "gfx938:sramecc+:xnack-": False,
+            "sm_90": False,
+        }
+
+        for arch, expected in cases.items():
+            with self.subTest(arch=arch), mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(gcnArchName=arch),
+            ):
+                self.assertEqual(w8a8_int8._use_kme_hipblaslt(cuda_device), expected)
+
+        with mock.patch.object(torch.cuda, "get_device_properties") as get_props:
+            self.assertFalse(w8a8_int8._use_kme_hipblaslt(SimpleNamespace(type="cpu")))
+            get_props.assert_not_called()
+
+    def test_method3_layout_and_azp_reduction_match(self):
+        weight = torch.tensor(
+            [[1, 2, 3, 4], [5, -1, 0, 2], [-3, 7, 1, -2]],
+            dtype=torch.int8,
+        )
+        expected_azp = weight.sum(dim=1, keepdim=False, dtype=torch.int32).unsqueeze(0)
+
+        for use_kme in (True, False):
+            with self.subTest(use_kme=use_kme):
+                layer = self._make_layer(weight)
+                scheme = self._make_scheme()
+
+                with mock.patch.object(
+                    w8a8_int8, "_use_kme_hipblaslt", return_value=use_kme
+                ), mock.patch.object(w8a8_int8.W8A8_TRITONJSON, "gen_model_json"):
+                    scheme.process_weights_after_loading(layer)
+
+                if use_kme:
+                    self.assertEqual(layer.weight.shape, (4, 3))
+                    self.assertEqual(layer.weight.stride(), (1, 4))
+                    self.assertTrue(torch.equal(layer.weight, weight.t()))
+                else:
+                    self.assertEqual(layer.weight.shape, (3, 4))
+                    self.assertTrue(layer.weight.is_contiguous())
+                    self.assertTrue(torch.equal(layer.weight, weight))
+
+                self.assertEqual(layer.azp_adj.shape, (1, 3))
+                self.assertTrue(torch.equal(layer.azp_adj, expected_azp))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

- 启用 HCU hipBLASLt W8A8 路径（`W8A8_SUPPORT_METHODS=3`）时，仅在 gfx928 使用 KME 的 `[K, N]` 权重布局。
- gfx936/gfx938 保持兼容的 `[N, K]` layout，并同步修正 stride 与 AZP reduction 维度。
- 增加不同 gfx 架构的 hipBLASLt layout contract 测试。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：恢复 GLM-5.2 HCU cookbook 使用 hipBLASLt W8A8 时在 gfx936/gfx938 上的正确权重布局。
- 目标分支：main

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 性能（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [x] 涉及算子/kernel