### PR TITLE
fix(pd): 修复 fake prefill 的 MTP 索引共享种子

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1826,7 +1826,16 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         )
 
         if _is_fake_transfer(decode_req.req, self.scheduler.server_args):
-            pass
+            # Fake PD has no prefill producer. Supply a shape-correct logical
+            # DSA seed only for MTP index-share benchmarking; the normal
+            # request/spec/remap path localizes it for the decode allocator.
+            dsa_seed_dim = self.metadata_buffers.output_dsa_topk_indices_dim
+            if not self.spec_algorithm.is_none() and dsa_seed_dim > 0:
+                output_dsa_topk_indices = torch.zeros(
+                    dsa_seed_dim,
+                    dtype=torch.int32,
+                    device=output_topk_index.device,
+                )
         elif actual_room == 0:
             # Should never happen: _poll_with_metadata_gate already confirmed
             # readiness on all TP ranks. Abort deterministically to avoid

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -2,13 +2,15 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import torch
+
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.decode import (
     DecodePreallocQueue,
     DecodeTransferQueue,
     HiCacheRestoreResult,
 )
-from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.disaggregation.utils import DisaggregationMode, MetadataBuffers
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.managers.scheduler import Scheduler
@@ -30,6 +32,47 @@ class FakeReceiver:
 
 
 class TestDecodeQueueCleanup(CustomTestCase):
+    def test_fake_transfer_supplies_logical_dsa_seed_for_mtp(self):
+        buffers = MetadataBuffers(
+            size=1,
+            hidden_size=2,
+            hidden_states_dtype=torch.float32,
+            output_dsa_topk_indices_dim=3,
+        )
+        req = SimpleNamespace(
+            rid="fake-mtp-seed",
+            bootstrap_host=None,
+            bootstrap_room=7,
+            output_ids=[],
+            pd_rebootstrap_forced_output_id=None,
+            return_logprob=False,
+            return_sampling_mask=False,
+            time_stats=MagicMock(),
+        )
+        receiver = FakeReceiver()
+        decode_req = SimpleNamespace(
+            req=req,
+            kv_receiver=receiver,
+            metadata_buffer_index=0,
+            is_rebootstrap=False,
+        )
+
+        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+        queue.metadata_buffers = buffers
+        queue.spec_algorithm = MagicMock()
+        queue.spec_algorithm.is_none.return_value = False
+        queue.scheduler = SimpleNamespace(
+            server_args=SimpleNamespace(disaggregation_transfer_backend="fake")
+        )
+        queue._commit_hicache_local_restore_to_req = MagicMock()
+
+        queue._commit_transfer_to_req(decode_req)
+
+        self.assertEqual(req.output_dsa_topk_indices.tolist(), [0, 0, 0])
+        self.assertEqual(req.output_dsa_topk_indices.dtype, torch.int32)
+        self.assertTrue(receiver.clear_called)
+        self.assertIsNone(decode_req.kv_receiver)
+
     def test_paged_swa_retraction_resume_uses_physical_page_budget(self):
         page_size = 128
         fill_len = 574


### PR DESCRIPTION
## 改动内容

- fake prefill 没有真实 prefill 生产端时，为当前 DSA 索引共享链路生成 int32 零值逻辑位置种子。
- 沿用 main 的 request、spec input 和 decode 本地槽位重映射流程。
- 不引入 StepInfo 环境变量，也不修改 DP allgather 或 device-group allgather。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：GLM-5.2 fake prefill 场景需要满足首轮 MTP draft decode 的 CUDA Graph 索引种子约束。
- 目标分支：main

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 未验证 | 该种子仅用于 fake prefill 图路径，不代表真实 PD 精度 |
| 性能（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [ ] 涉及算子/kernel

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->