### PR TITLE
fix(attention): 恢复 HCU DSA FlashMLA 后端路由

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable, Optional
+
+import torch
+
+
+def get_flashmla_op(name: str, *, is_hcu: bool) -> Callable[..., Any]:
+    module_name = "flash_mla.flash_mla_interface" if is_hcu else "sgl_kernel.flash_mla"
+    return getattr(import_module(module_name), name)
+
+
+@dataclass(frozen=True)
+class DSAFlashMLAMetadata:
+    """Metadata needed only by FlashMLA.
+
+    CUDA FlashMLA stores scheduler metadata in tensors. HCU FlashMLA stores it
+    in a mutable backend object and initializes the object's tensor fields on
+    the first kernel invocation.
+    """
+
+    flashmla_metadata: Any
+    num_splits: Optional[torch.Tensor]
+
+    def slice(self, sli) -> DSAFlashMLAMetadata:
+        return DSAFlashMLAMetadata(
+            flashmla_metadata=self.flashmla_metadata,
+            num_splits=(None if self.num_splits is None else self.num_splits[sli]),
+        )
+
+    def copy_(self, other: DSAFlashMLAMetadata) -> None:
+        if isinstance(self.flashmla_metadata, torch.Tensor) and isinstance(
+            other.flashmla_metadata, torch.Tensor
+        ):
+            self.flashmla_metadata.copy_(other.flashmla_metadata)
+        else:
+            object.__setattr__(self, "flashmla_metadata", other.flashmla_metadata)
+
+        if isinstance(self.num_splits, torch.Tensor) and isinstance(
+            other.num_splits, torch.Tensor
+        ):
+            self.num_splits.copy_(other.num_splits)
+        else:
+            object.__setattr__(self, "num_splits", other.num_splits)
+
+
+def can_fuse_flashmla_metadata(
+    *metadatas: Optional[DSAFlashMLAMetadata],
+) -> bool:
+    return all(
+        metadata is not None
+        and isinstance(metadata.flashmla_metadata, torch.Tensor)
+        and isinstance(metadata.num_splits, torch.Tensor)
+        for metadata in metadatas
+    )
+
+
+def wrap_flashmla_metadata_result(
+    result: tuple[Any, Optional[torch.Tensor]], *, is_hcu: bool
+) -> DSAFlashMLAMetadata:
+    flashmla_metadata, num_splits = result
+    if is_hcu:
+        num_splits = getattr(flashmla_metadata, "num_splits", num_splits)
+    return DSAFlashMLAMetadata(
+        flashmla_metadata=flashmla_metadata,
+        num_splits=num_splits,
+    )

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -47,6 +47,12 @@ from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
     DSATopKBackend,
     TopkTransformMethod,
 )
+from sglang.srt.layers.attention.dsa.flashmla_backend import (
+    DSAFlashMLAMetadata,
+    can_fuse_flashmla_metadata,
+    get_flashmla_op,
+    wrap_flashmla_metadata_result,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -173,24 +179,6 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
         # view — we want (N_total, 1) regardless.
         seqlens_32 = seqlens_32.reshape(-1)
     return seqlens_32.contiguous().view(-1, 1)
-
-
-@dataclass(frozen=True)
-class DSAFlashMLAMetadata:
-    """Metadata only needed by FlashMLA"""
-
-    flashmla_metadata: torch.Tensor
-    num_splits: torch.Tensor
-
-    def slice(self, sli):
-        return DSAFlashMLAMetadata(
-            flashmla_metadata=self.flashmla_metadata,
-            num_splits=self.num_splits[sli],
-        )
-
-    def copy_(self, other: DSAFlashMLAMetadata):
-        self.flashmla_metadata.copy_(other.flashmla_metadata)
-        self.num_splits.copy_(other.num_splits)
 
 
 @dataclass(frozen=True)
@@ -1740,8 +1728,16 @@ class DeepseekSparseAttnBackend(
         # Track whether fused kernel succeeded
         fused_kernel_succeeded = False
 
-        # Use fused CUDA kernel for all copy operations
-        if not _is_hip:
+        # Use fused CUDA kernel for all copy operations. HCU FlashMLA keeps
+        # scheduler state in a backend object, which the tensor-only fused
+        # copy kernel cannot consume.
+        flashmla_metadata_can_fuse = precomputed.flashmla_metadata is None or (
+            can_fuse_flashmla_metadata(
+                precomputed.flashmla_metadata,
+                metadata.flashmla_metadata,
+            )
+        )
+        if not _is_hip and flashmla_metadata_can_fuse:
             try:
                 from sglang.kernels.ops.attention.fused_metadata_copy import (
                     fused_metadata_copy_cuda,
@@ -2407,16 +2403,21 @@ class DeepseekSparseAttnBackend(
         sm_scale: float,
         topk_length: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+        flash_mla_sparse_fwd = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=_is_hcu)
 
         # FlashMLA sparse kernel requires num_heads to be a multiple of 64 (Hopper) or 128 (Blackwell)
         # When using TP, num_heads might be smaller (e.g., 256//8=32)
         num_tokens, num_heads, head_dim = q_all.shape
 
-        # Determine required padding based on GPU architecture (use cached value)
-        required_padding = 128 if self.device_sm_major >= 10 else 64
-
-        need_padding = num_heads % required_padding != 0
+        # The CUDA kernels require Hopper/Blackwell head padding. HCU's
+        # external FlashMLA implementation accepts the native TP head count.
+        if _is_hcu:
+            required_padding = num_heads
+            need_padding = False
+        else:
+            # Determine required padding based on GPU architecture (use cached value)
+            required_padding = 128 if self.device_sm_major >= 10 else 64
+            need_padding = num_heads % required_padding != 0
 
         if need_padding:
             assert required_padding % num_heads == 0, (
@@ -2811,7 +2812,9 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata,
         page_table_1,
     ) -> torch.Tensor:
-        from sgl_kernel.flash_mla import flash_mla_with_kvcache
+        flash_mla_with_kvcache = get_flashmla_op(
+            "flash_mla_with_kvcache", is_hcu=_is_hcu
+        )
 
         cache_seqlens = metadata.dsa_cache_seqlens_int32
         assert metadata.flashmla_metadata is not None
@@ -3407,24 +3410,22 @@ class DeepseekSparseAttnBackend(
         )
 
     def _compute_flashmla_metadata(self, cache_seqlens: torch.Tensor, seq_len_q: int):
-        from sgl_kernel.flash_mla import get_mla_metadata
+        get_mla_metadata = get_flashmla_op("get_mla_metadata", is_hcu=_is_hcu)
 
         num_heads_q = self.flashmla_kv_num_q_heads
 
-        flashmla_metadata, num_splits = get_mla_metadata(
-            cache_seqlens=cache_seqlens,
-            # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`
-            #      but the name looks like need seq_len_q?
-            num_q_tokens_per_head_k=seq_len_q * num_heads_q // 1,
-            num_heads_k=1,
-            num_heads_q=num_heads_q,
-            is_fp8_kvcache=True,
-            topk=self.dsa_index_topk,
-        )
-
-        return DSAFlashMLAMetadata(
-            flashmla_metadata=flashmla_metadata,
-            num_splits=num_splits,
+        return wrap_flashmla_metadata_result(
+            get_mla_metadata(
+                cache_seqlens=cache_seqlens,
+                # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`
+                #      but the name looks like need seq_len_q?
+                num_q_tokens_per_head_k=seq_len_q * num_heads_q // 1,
+                num_heads_k=1,
+                num_heads_q=num_heads_q,
+                is_fp8_kvcache=True,
+                topk=self.dsa_index_topk,
+            ),
+            is_hcu=_is_hcu,
         )
 
 
@@ -3508,6 +3509,16 @@ class DeepseekSparseAttnMultiStepBackend:
                 for i in range(3):
                     self.attn_backends[i].set_dsa_prefill_impl(forward_batch=None)
 
+                # HCU FlashMLA metadata may be a backend object rather than a
+                # tensor. Fuse it only when every source/destination is a
+                # plain tensor; otherwise copy it with its backend wrapper.
+                fused_flashmla_metadata = can_fuse_flashmla_metadata(
+                    precomputed.flashmla_metadata,
+                    metadata0.flashmla_metadata,
+                    metadata1.flashmla_metadata,
+                    metadata2.flashmla_metadata,
+                )
+
                 # Prepare FlashMLA tensors if needed
                 flashmla_num_splits_src = None
                 flashmla_metadata_src = None
@@ -3518,7 +3529,7 @@ class DeepseekSparseAttnMultiStepBackend:
                 flashmla_metadata_dst1 = None
                 flashmla_metadata_dst2 = None
 
-                if precomputed.flashmla_metadata is not None:
+                if fused_flashmla_metadata:
                     flashmla_num_splits_src = precomputed.flashmla_metadata.num_splits
                     flashmla_metadata_src = (
                         precomputed.flashmla_metadata.flashmla_metadata
@@ -3591,6 +3602,17 @@ class DeepseekSparseAttnMultiStepBackend:
                     precomputed.max_len,
                     precomputed.seqlens_expanded_size,
                 )
+
+                if (
+                    precomputed.flashmla_metadata is not None
+                    and not fused_flashmla_metadata
+                ):
+                    size = precomputed.seqlens_expanded_size
+                    for metadata in (metadata0, metadata1, metadata2):
+                        flashmla_metadata = metadata.flashmla_metadata.slice(
+                            slice(0, size + 1)
+                        )
+                        flashmla_metadata.copy_(precomputed.flashmla_metadata)
 
                 # Copy remaining backends one by one (if > 3 backends)
                 for i in range(3, self.speculative_num_steps - 1):

--- a/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
+++ b/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
@@ -1,0 +1,92 @@
+"""Unit tests for platform-specific DSA FlashMLA routing and metadata."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa.flashmla_backend import (
+    DSAFlashMLAMetadata,
+    can_fuse_flashmla_metadata,
+    get_flashmla_op,
+    wrap_flashmla_metadata_result,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSAFlashMLABackend(CustomTestCase):
+    def test_loader_routes_hcu_to_external_interface(self):
+        expected_op = MagicMock()
+        module = SimpleNamespace(flash_mla_sparse_fwd=expected_op)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa.flashmla_backend.import_module",
+            return_value=module,
+        ) as import_mock:
+            actual_op = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=True)
+
+        self.assertIs(actual_op, expected_op)
+        import_mock.assert_called_once_with("flash_mla.flash_mla_interface")
+
+    def test_loader_keeps_non_hcu_on_sgl_kernel(self):
+        expected_op = MagicMock()
+        module = SimpleNamespace(get_mla_metadata=expected_op)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa.flashmla_backend.import_module",
+            return_value=module,
+        ) as import_mock:
+            actual_op = get_flashmla_op("get_mla_metadata", is_hcu=False)
+
+        self.assertIs(actual_op, expected_op)
+        import_mock.assert_called_once_with("sgl_kernel.flash_mla")
+
+    def test_hcu_metadata_object_is_wrapped_and_copied(self):
+        backend_num_splits = torch.tensor([3], dtype=torch.int32)
+        backend_metadata = SimpleNamespace(num_splits=backend_num_splits)
+        source = wrap_flashmla_metadata_result((backend_metadata, None), is_hcu=True)
+
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=SimpleNamespace(num_splits=None),
+            num_splits=None,
+        )
+        destination.copy_(source)
+
+        self.assertIs(destination.flashmla_metadata, backend_metadata)
+        self.assertIs(destination.num_splits, backend_num_splits)
+        self.assertFalse(can_fuse_flashmla_metadata(source, destination))
+
+    def test_metadata_slice_accepts_uninitialized_hcu_scheduler(self):
+        backend_metadata = SimpleNamespace(num_splits=None)
+        metadata = wrap_flashmla_metadata_result((backend_metadata, None), is_hcu=True)
+
+        sliced = metadata.slice(slice(0, 2))
+
+        self.assertIs(sliced.flashmla_metadata, backend_metadata)
+        self.assertIsNone(sliced.num_splits)
+
+    def test_tensor_metadata_remains_fused_copy_eligible(self):
+        source = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.tensor([1, 2], dtype=torch.int32),
+            num_splits=torch.tensor([3, 4], dtype=torch.int32),
+        )
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.zeros(2, dtype=torch.int32),
+            num_splits=torch.zeros(2, dtype=torch.int32),
+        )
+
+        destination.copy_(source)
+
+        self.assertTrue(
+            torch.equal(destination.flashmla_metadata, source.flashmla_metadata)
+        )
+        self.assertTrue(torch.equal(destination.num_splits, source.num_splits))
+        self.assertTrue(can_fuse_flashmla_metadata(source, destination))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

- HCU DSA sparse、KV decode 和 metadata 路径改为调用外部 `flash_mla.flash_mla_interface`。
- 非 HCU 平台继续使用 `sgl_kernel.flash_mla`，CUDA 路径保持不变。
- 兼容 HCU lazy scheduler object 与 CUDA tensor metadata 两种返回形态。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：main 的 NSA 到 DSA 重构后，HCU FlashMLA 专属路由丢失，GLM-5.2 需要恢复该执行路径。
- 目标分支：main

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 性能（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [x] 涉及算子/kernel