### PR TITLE
fix(attention): 修复 IFB/MTP 的 FlashMLA 填充与元数据重放

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -23,6 +23,9 @@ from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
     bcg_dsa_indexer_prefill_split,
     pcg_dsa_indexer_prefill_split,
 )
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
     DSAPagedMQALogitsBackend,
 )
@@ -392,7 +395,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
     def _should_skip_logits_computation(self, forward_batch: ForwardBatch) -> bool:
         if (
-            forward_batch.forward_mode.is_extend_without_speculative()
+            effective_forward_mode(forward_batch).is_extend_without_speculative()
             and forward_batch.seq_lens_cpu is not None
         ):
             max_kv_len = forward_batch.seq_lens_cpu.max().item()
@@ -759,10 +762,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         kv_cache_fp8 = self._get_index_k_read_buffer(get_token_to_kv_pool(), layer_id)
 
         blocksize = page_size
-        if (
-            forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
-        ):
+        forward_mode = effective_forward_mode(forward_batch)
+        if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
             seqlens_32 = metadata.get_seqlens_expanded()
         else:
             seqlens_32 = metadata.get_seqlens_int32()
@@ -778,14 +779,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         next_n = q_offset // B if B > 0 else 0
         use_cute_dsl = (
             self.paged_mqa_logits_backend.is_cutedsl()
-            and not forward_batch.forward_mode.is_draft_extend_v2()
+            and not forward_mode.is_draft_extend_v2()
         )
         dsl_expand_factor, dsl_atom = 1, 1
-        if (
-            use_cute_dsl
-            and forward_batch.forward_mode.is_target_verify()
-            and next_n >= 2
-        ):
+        if use_cute_dsl and forward_mode.is_target_verify() and next_n >= 2:
             assert pick_dsl_expand is not None, "CuTe DSL paged MQA is CUDA-only."
             dsl_expand_factor, dsl_atom = pick_dsl_expand(
                 next_n,
@@ -799,7 +796,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         use_dg_native = (
             not use_cute_dsl
             and _is_cuda
-            and forward_batch.forward_mode.is_target_verify()
+            and forward_mode.is_target_verify()
             and next_n >= 2
             and ctx_2d is not None
             and ctx_2d.shape == (B, next_n)
@@ -850,7 +847,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 q_offset=q_offset,
                 B=B,
                 next_n=next_n,
-                is_target_verify=forward_batch.forward_mode.is_target_verify(),
+                is_target_verify=forward_mode.is_target_verify(),
                 dsl_expand_factor=dsl_expand_factor,
                 dsl_atom=dsl_atom,
                 blocksize=blocksize,
@@ -965,7 +962,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        assert forward_batch.forward_mode.is_extend_without_speculative()
+        assert effective_forward_mode(forward_batch).is_extend_without_speculative()
 
         page_size = get_token_to_kv_pool().page_size
         if _is_hip:
@@ -1177,7 +1174,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         #   - topk_result: pre-allocated padded buffer to fill in place (a downstream
         #     captured graph reads it at a fixed address). None => return a fresh,
         #     naturally-sized tensor.
-        assert forward_batch.forward_mode.is_extend_without_speculative()
+        assert effective_forward_mode(forward_batch).is_extend_without_speculative()
         x_meta = x[0] if isinstance(x, tuple) else x
 
         # Fast path: only compute and store k cache, skip all q and weights ops.
@@ -1537,6 +1534,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             and q_lora.shape[0] <= DUAL_STREAM_TOKEN_THRESHOLD
         )
 
+        # MLP-sync can temporarily expose decode/verify/draft batches as
+        # EXTEND. Indexer routing must stay tied to the algorithmic mode.
+        forward_mode = effective_forward_mode(forward_batch)
+
         # Determine if should skip topk based on sequence length
         # We can only skip the logits computation if cuda graph is not involved
         skip_logits_computation = False
@@ -1613,7 +1614,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             )
             return maybe_capture_indexer_topk(layer_id, result)
 
-        elif enable_dual_stream and forward_batch.forward_mode.is_decode_or_idle():
+        elif enable_dual_stream and forward_mode.is_decode_or_idle():
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
             if not self.use_dsa_indexer_fusion:
@@ -1762,9 +1763,9 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     return maybe_capture_indexer_topk(layer_id, topk_result)
 
             if (
-                forward_batch.forward_mode.is_decode_or_idle()
-                or forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             ):
                 topk_result = self._get_topk_paged(
                     forward_batch, layer_id, q_fp8, weights, metadata

--- a/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
@@ -57,6 +57,28 @@ def can_fuse_flashmla_metadata(
     )
 
 
+def refresh_flashmla_metadata(
+    destination: DSAFlashMLAMetadata,
+    source: DSAFlashMLAMetadata,
+    sli,
+    *,
+    is_hcu: bool,
+) -> DSAFlashMLAMetadata:
+    """Return the metadata wrapper the next forward must retain.
+
+    Tensor metadata is refreshed in-place so captured data pointers stay
+    stable. HCU scheduler objects carry shape-bound mutable state, so callers
+    must retain the fresh source object instead of mutating a sliced temporary
+    wrapper that the forward never reads.
+    """
+
+    if is_hcu:
+        return source
+    destination_view = destination.slice(sli)
+    destination_view.copy_(source)
+    return destination_view
+
+
 def wrap_flashmla_metadata_result(
     result: tuple[Any, Optional[torch.Tensor]], *, is_hcu: bool
 ) -> DSAFlashMLAMetadata:

--- a/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable, Optional
+
+import torch
+
+
+def get_flashmla_op(name: str, *, is_hcu: bool) -> Callable[..., Any]:
+    module_name = "flash_mla.flash_mla_interface" if is_hcu else "sgl_kernel.flash_mla"
+    return getattr(import_module(module_name), name)
+
+
+@dataclass(frozen=True)
+class DSAFlashMLAMetadata:
+    """Metadata needed only by FlashMLA.
+
+    CUDA FlashMLA stores scheduler metadata in tensors. HCU FlashMLA stores it
+    in a mutable backend object and initializes the object's tensor fields on
+    the first kernel invocation.
+    """
+
+    flashmla_metadata: Any
+    num_splits: Optional[torch.Tensor]
+
+    def slice(self, sli) -> DSAFlashMLAMetadata:
+        return DSAFlashMLAMetadata(
+            flashmla_metadata=self.flashmla_metadata,
+            num_splits=(None if self.num_splits is None else self.num_splits[sli]),
+        )
+
+    def copy_(self, other: DSAFlashMLAMetadata) -> None:
+        if isinstance(self.flashmla_metadata, torch.Tensor) and isinstance(
+            other.flashmla_metadata, torch.Tensor
+        ):
+            self.flashmla_metadata.copy_(other.flashmla_metadata)
+        else:
+            object.__setattr__(self, "flashmla_metadata", other.flashmla_metadata)
+
+        if isinstance(self.num_splits, torch.Tensor) and isinstance(
+            other.num_splits, torch.Tensor
+        ):
+            self.num_splits.copy_(other.num_splits)
+        else:
+            object.__setattr__(self, "num_splits", other.num_splits)
+
+
+def can_fuse_flashmla_metadata(
+    *metadatas: Optional[DSAFlashMLAMetadata],
+) -> bool:
+    return all(
+        metadata is not None
+        and isinstance(metadata.flashmla_metadata, torch.Tensor)
+        and isinstance(metadata.num_splits, torch.Tensor)
+        for metadata in metadatas
+    )
+
+
+def wrap_flashmla_metadata_result(
+    result: tuple[Any, Optional[torch.Tensor]], *, is_hcu: bool
+) -> DSAFlashMLAMetadata:
+    flashmla_metadata, num_splits = result
+    if is_hcu:
+        num_splits = getattr(flashmla_metadata, "num_splits", num_splits)
+    return DSAFlashMLAMetadata(
+        flashmla_metadata=flashmla_metadata,
+        num_splits=num_splits,
+    )

--- a/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
+++ b/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 
 def effective_forward_mode(forward_batch):
     """Return the algorithmic mode before MLP-sync remaps it to EXTEND."""
@@ -10,3 +12,50 @@ def effective_forward_mode(forward_batch):
         if original_forward_mode is None
         else original_forward_mode
     )
+
+
+def get_flashmla_kv_valid_rows(forward_batch, num_rows: int) -> Optional[int]:
+    """Return the real prefix length when MLP-sync padded FlashMLA KV rows."""
+
+    forward_mode = effective_forward_mode(forward_batch)
+    planned_batch_size = getattr(forward_batch, "forward_metadata_planned_bs", None)
+    planned_num_tokens = getattr(
+        forward_batch, "forward_metadata_planned_num_tokens", None
+    )
+    original_batch_size = getattr(forward_batch, "_original_batch_size", None)
+    original_num_tokens = getattr(forward_batch, "_original_num_tokens", None)
+
+    has_planned_layout = (
+        planned_batch_size is not None or planned_num_tokens is not None
+    )
+    if has_planned_layout:
+        if not (
+            isinstance(planned_batch_size, int)
+            and isinstance(planned_num_tokens, int)
+            and planned_batch_size == original_batch_size
+        ):
+            return None
+        real_batch_size = planned_batch_size
+        real_num_tokens = planned_num_tokens
+    else:
+        real_batch_size = original_batch_size
+        real_num_tokens = original_num_tokens
+
+    if forward_mode.is_decode_or_idle():
+        spec_info = getattr(forward_batch, "spec_info", None)
+        if getattr(spec_info, "num_tokens_per_req", None) != 1:
+            return None
+        if isinstance(real_batch_size, int) and 0 <= real_batch_size < num_rows:
+            return real_batch_size
+        return None
+
+    if not (forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2()):
+        return None
+    if not (
+        isinstance(real_batch_size, int)
+        and real_batch_size >= 0
+        and isinstance(real_num_tokens, int)
+        and 0 <= real_num_tokens < num_rows
+    ):
+        return None
+    return real_num_tokens

--- a/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
+++ b/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def effective_forward_mode(forward_batch):
+    """Return the algorithmic mode before MLP-sync remaps it to EXTEND."""
+
+    original_forward_mode = getattr(forward_batch, "_original_forward_mode", None)
+    return (
+        forward_batch.forward_mode
+        if original_forward_mode is None
+        else original_forward_mode
+    )

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -5,6 +5,9 @@ import torch
 import triton
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.dp_attention import DpPaddingMode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     is_in_breakable_cuda_graph,
@@ -143,12 +146,12 @@ def is_graph_dsa_split_op_surface(forward_batch: "ForwardBatch") -> bool:
     return (
         is_cuda()
         and (is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph())
-        and forward_batch.forward_mode.is_extend_without_speculative()
+        and effective_forward_mode(forward_batch).is_extend_without_speculative()
     )
 
 
 def can_dsa_prefill_cp_round_robin_split(forward_batch: "ForwardBatch"):
-    if not forward_batch.forward_mode.is_context_parallel_extend():
+    if not effective_forward_mode(forward_batch).is_context_parallel_extend():
         return False
     cp_size = get_parallel().attn_cp_size
     seq_len = sum(forward_batch.extend_seq_lens_cpu)
@@ -251,7 +254,7 @@ def can_dsa_cp_split(seq_len: int, cp_size: int, use_dsa: bool, forward_batch):
     if (
         cp_size <= 1
         or not use_dsa
-        or not forward_batch.forward_mode.is_context_parallel_extend()
+        or not effective_forward_mode(forward_batch).is_context_parallel_extend()
         or not is_dsa_enable_prefill_cp()
         or sum(forward_batch.extend_seq_lens_cpu) < cp_size
     ):
@@ -325,7 +328,7 @@ def dsa_use_prefill_cp(forward_batch, dsa_enable_prefill_cp=None):
     if (
         forward_batch.attn_cp_metadata is not None
         and dsa_enable_prefill_cp
-        and forward_batch.forward_mode.is_context_parallel_extend()
+        and effective_forward_mode(forward_batch).is_context_parallel_extend()
     ):
         return True
     else:

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -47,6 +47,12 @@ from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
     DSATopKBackend,
     TopkTransformMethod,
 )
+from sglang.srt.layers.attention.dsa.flashmla_backend import (
+    DSAFlashMLAMetadata,
+    can_fuse_flashmla_metadata,
+    get_flashmla_op,
+    wrap_flashmla_metadata_result,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -173,24 +179,6 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
         # view — we want (N_total, 1) regardless.
         seqlens_32 = seqlens_32.reshape(-1)
     return seqlens_32.contiguous().view(-1, 1)
-
-
-@dataclass(frozen=True)
-class DSAFlashMLAMetadata:
-    """Metadata only needed by FlashMLA"""
-
-    flashmla_metadata: torch.Tensor
-    num_splits: torch.Tensor
-
-    def slice(self, sli):
-        return DSAFlashMLAMetadata(
-            flashmla_metadata=self.flashmla_metadata,
-            num_splits=self.num_splits[sli],
-        )
-
-    def copy_(self, other: DSAFlashMLAMetadata):
-        self.flashmla_metadata.copy_(other.flashmla_metadata)
-        self.num_splits.copy_(other.num_splits)
 
 
 @dataclass(frozen=True)
@@ -1740,8 +1728,16 @@ class DeepseekSparseAttnBackend(
         # Track whether fused kernel succeeded
         fused_kernel_succeeded = False
 
-        # Use fused CUDA kernel for all copy operations
-        if not _is_hip:
+        # Use fused CUDA kernel for all copy operations. HCU FlashMLA keeps
+        # scheduler state in a backend object, which the tensor-only fused
+        # copy kernel cannot consume.
+        flashmla_metadata_can_fuse = precomputed.flashmla_metadata is None or (
+            can_fuse_flashmla_metadata(
+                precomputed.flashmla_metadata,
+                metadata.flashmla_metadata,
+            )
+        )
+        if not _is_hip and flashmla_metadata_can_fuse:
             try:
                 from sglang.kernels.ops.attention.fused_metadata_copy import (
                     fused_metadata_copy_cuda,
@@ -2407,16 +2403,21 @@ class DeepseekSparseAttnBackend(
         sm_scale: float,
         topk_length: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+        flash_mla_sparse_fwd = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=_is_hcu)
 
         # FlashMLA sparse kernel requires num_heads to be a multiple of 64 (Hopper) or 128 (Blackwell)
         # When using TP, num_heads might be smaller (e.g., 256//8=32)
         num_tokens, num_heads, head_dim = q_all.shape
 
-        # Determine required padding based on GPU architecture (use cached value)
-        required_padding = 128 if self.device_sm_major >= 10 else 64
-
-        need_padding = num_heads % required_padding != 0
+        # The CUDA kernels require Hopper/Blackwell head padding. HCU's
+        # external FlashMLA implementation accepts the native TP head count.
+        if _is_hcu:
+            required_padding = num_heads
+            need_padding = False
+        else:
+            # Determine required padding based on GPU architecture (use cached value)
+            required_padding = 128 if self.device_sm_major >= 10 else 64
+            need_padding = num_heads % required_padding != 0
 
         if need_padding:
             assert required_padding % num_heads == 0, (
@@ -2811,7 +2812,9 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata,
         page_table_1,
     ) -> torch.Tensor:
-        from sgl_kernel.flash_mla import flash_mla_with_kvcache
+        flash_mla_with_kvcache = get_flashmla_op(
+            "flash_mla_with_kvcache", is_hcu=_is_hcu
+        )
 
         cache_seqlens = metadata.dsa_cache_seqlens_int32
         assert metadata.flashmla_metadata is not None
@@ -3407,24 +3410,22 @@ class DeepseekSparseAttnBackend(
         )
 
     def _compute_flashmla_metadata(self, cache_seqlens: torch.Tensor, seq_len_q: int):
-        from sgl_kernel.flash_mla import get_mla_metadata
+        get_mla_metadata = get_flashmla_op("get_mla_metadata", is_hcu=_is_hcu)
 
         num_heads_q = self.flashmla_kv_num_q_heads
 
-        flashmla_metadata, num_splits = get_mla_metadata(
-            cache_seqlens=cache_seqlens,
-            # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`
-            #      but the name looks like need seq_len_q?
-            num_q_tokens_per_head_k=seq_len_q * num_heads_q // 1,
-            num_heads_k=1,
-            num_heads_q=num_heads_q,
-            is_fp8_kvcache=True,
-            topk=self.dsa_index_topk,
-        )
-
-        return DSAFlashMLAMetadata(
-            flashmla_metadata=flashmla_metadata,
-            num_splits=num_splits,
+        return wrap_flashmla_metadata_result(
+            get_mla_metadata(
+                cache_seqlens=cache_seqlens,
+                # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`
+                #      but the name looks like need seq_len_q?
+                num_q_tokens_per_head_k=seq_len_q * num_heads_q // 1,
+                num_heads_k=1,
+                num_heads_q=num_heads_q,
+                is_fp8_kvcache=True,
+                topk=self.dsa_index_topk,
+            ),
+            is_hcu=_is_hcu,
         )
 
 
@@ -3508,6 +3509,16 @@ class DeepseekSparseAttnMultiStepBackend:
                 for i in range(3):
                     self.attn_backends[i].set_dsa_prefill_impl(forward_batch=None)
 
+                # HCU FlashMLA metadata may be a backend object rather than a
+                # tensor. Fuse it only when every source/destination is a
+                # plain tensor; otherwise copy it with its backend wrapper.
+                fused_flashmla_metadata = can_fuse_flashmla_metadata(
+                    precomputed.flashmla_metadata,
+                    metadata0.flashmla_metadata,
+                    metadata1.flashmla_metadata,
+                    metadata2.flashmla_metadata,
+                )
+
                 # Prepare FlashMLA tensors if needed
                 flashmla_num_splits_src = None
                 flashmla_metadata_src = None
@@ -3518,7 +3529,7 @@ class DeepseekSparseAttnMultiStepBackend:
                 flashmla_metadata_dst1 = None
                 flashmla_metadata_dst2 = None
 
-                if precomputed.flashmla_metadata is not None:
+                if fused_flashmla_metadata:
                     flashmla_num_splits_src = precomputed.flashmla_metadata.num_splits
                     flashmla_metadata_src = (
                         precomputed.flashmla_metadata.flashmla_metadata
@@ -3591,6 +3602,17 @@ class DeepseekSparseAttnMultiStepBackend:
                     precomputed.max_len,
                     precomputed.seqlens_expanded_size,
                 )
+
+                if (
+                    precomputed.flashmla_metadata is not None
+                    and not fused_flashmla_metadata
+                ):
+                    size = precomputed.seqlens_expanded_size
+                    for metadata in (metadata0, metadata1, metadata2):
+                        flashmla_metadata = metadata.flashmla_metadata.slice(
+                            slice(0, size + 1)
+                        )
+                        flashmla_metadata.copy_(precomputed.flashmla_metadata)
 
                 # Copy remaining backends one by one (if > 3 backends)
                 for i in range(3, self.speculative_num_steps - 1):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -55,6 +55,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
 )
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
     effective_forward_mode,
+    get_flashmla_kv_valid_rows,
 )
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
@@ -2158,6 +2159,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                forward_batch=forward_batch,
             )
         elif dsa_impl == "fa3":
             return self._forward_fa3(
@@ -2313,6 +2315,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                forward_batch=forward_batch,
             )
         elif self.dsa_decode_impl == "tilelang":
             # Cat-skip (HIP-only): when caller passes q_rope=None on HIP, q_all
@@ -2811,6 +2814,7 @@ class DeepseekSparseAttnBackend(
         layer,
         metadata: DSAMetadata,
         page_table_1,
+        forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         flash_mla_with_kvcache = get_flashmla_op(
             "flash_mla_with_kvcache", is_hcu=_is_hcu
@@ -2844,24 +2848,49 @@ class DeepseekSparseAttnBackend(
             indices.shape[-1] == self.dsa_index_topk
         )  # requirement of FlashMLA decode kernel
 
-        o, _ = flash_mla_with_kvcache(
-            q=q_input,
-            k_cache=kv_cache,
-            cache_seqlens=cache_seqlens,
-            head_dim_v=v_head_dim,
-            tile_scheduler_metadata=metadata.flashmla_metadata.flashmla_metadata,
-            num_splits=metadata.flashmla_metadata.num_splits,
-            softmax_scale=sm_scale,
-            indices=indices,
-            # doc says it is not used, but if pass in None then error
-            block_table=torch.empty(
-                (q_all.shape[0], 0), dtype=torch.int32, device=q_all.device
-            ),
-            is_fp8_kvcache=True,
-        )
+        # MLP-sync can append synthetic speculative rows. HCU FlashMLA must
+        # only see the real prefix; downstream MLP-sync still needs the padded
+        # output shape, so restore it after the kernel returns.
+        num_total = q_input.shape[0]
+        num_valid = get_flashmla_kv_valid_rows(forward_batch, num_total)
+        needs_repad = _is_hcu and num_valid is not None
+        flashmla_metadata = metadata.flashmla_metadata
+        if needs_repad:
+            q_input = q_input[:num_valid]
+            indices = indices[:num_valid]
+            cache_seqlens = cache_seqlens[:num_valid]
+            if num_valid > 0:
+                flashmla_metadata = self._compute_flashmla_metadata(
+                    cache_seqlens=cache_seqlens,
+                    seq_len_q=1,
+                )
+
+        if needs_repad and num_valid == 0:
+            o = q_input.new_zeros((0, 1, target_q_heads, v_head_dim))
+        else:
+            o, _ = flash_mla_with_kvcache(
+                q=q_input,
+                k_cache=kv_cache,
+                cache_seqlens=cache_seqlens,
+                head_dim_v=v_head_dim,
+                tile_scheduler_metadata=flashmla_metadata.flashmla_metadata,
+                num_splits=flashmla_metadata.num_splits,
+                softmax_scale=sm_scale,
+                indices=indices,
+                # doc says it is not used, but if pass in None then error
+                block_table=torch.empty(
+                    (q_input.shape[0], 0), dtype=torch.int32, device=q_input.device
+                ),
+                is_fp8_kvcache=True,
+            )
+
+        if needs_repad:
+            full_o = o.new_zeros((num_total, *o.shape[1:]))
+            full_o[:num_valid] = o
+            o = full_o
 
         if target_q_heads != num_q_heads:
-            o = o[:, :, :num_q_heads, :]
+            o = o[:, :, :num_q_heads, :].contiguous()
 
         return o
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -51,6 +51,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     DSAFlashMLAMetadata,
     can_fuse_flashmla_metadata,
     get_flashmla_op,
+    refresh_flashmla_metadata,
     wrap_flashmla_metadata_result,
 )
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
@@ -1281,14 +1282,14 @@ class DeepseekSparseAttnBackend(
             seqlens_expanded = cache_seqlens_int32
             dsa_extend_seq_lens_list = [1] * bs
             if self.dsa_decode_impl == "flashmla_kv":
-                flashmla_metadata = self.decode_cuda_graph_metadata[
-                    "flashmla_metadata"
-                ].slice(slice(0, bs + 1))
-                flashmla_metadata.copy_(
+                flashmla_metadata = refresh_flashmla_metadata(
+                    self.decode_cuda_graph_metadata["flashmla_metadata"],
                     self._compute_flashmla_metadata(
                         cache_seqlens=dsa_cache_seqlens_int32,
                         seq_len_q=1,
-                    )
+                    ),
+                    slice(0, bs + 1),
+                    is_hcu=_is_hcu,
                 )
             else:
                 flashmla_metadata = None
@@ -1343,15 +1344,14 @@ class DeepseekSparseAttnBackend(
             dsa_extend_seq_lens_list = [1] * bs * self.speculative_num_draft_tokens
 
             if self.dsa_decode_impl == "flashmla_kv":
-                flashmla_metadata = self.decode_cuda_graph_metadata[
-                    "flashmla_metadata"
-                ].slice(slice(0, bs * self.speculative_num_draft_tokens + 1))
-
-                flashmla_metadata.copy_(
+                flashmla_metadata = refresh_flashmla_metadata(
+                    self.decode_cuda_graph_metadata["flashmla_metadata"],
                     self._compute_flashmla_metadata(
                         cache_seqlens=dsa_cache_seqlens_int32,
                         seq_len_q=1,
-                    )
+                    ),
+                    slice(0, bs * self.speculative_num_draft_tokens + 1),
+                    is_hcu=_is_hcu,
                 )
             else:
                 flashmla_metadata = None
@@ -1697,15 +1697,17 @@ class DeepseekSparseAttnBackend(
             assert metadata.real_page_table is metadata.page_table_1
 
         if self.dsa_decode_impl == "flashmla_kv":
-            flashmla_metadata = metadata.flashmla_metadata.slice(
-                slice(0, seqlens_expanded_size + 1)
-            )
-            flashmla_metadata.copy_(
+            flashmla_metadata = refresh_flashmla_metadata(
+                metadata.flashmla_metadata,
                 self._compute_flashmla_metadata(
                     cache_seqlens=dsa_cache_seqlens,
                     seq_len_q=1,
-                )
+                ),
+                slice(0, seqlens_expanded_size + 1),
+                is_hcu=_is_hcu,
             )
+            if _is_hcu:
+                object.__setattr__(metadata, "flashmla_metadata", flashmla_metadata)
 
         self.forward_metadata = metadata
 
@@ -1850,11 +1852,26 @@ class DeepseekSparseAttnBackend(
                     precomputed.real_page_table
                 )
 
-            # Copy FlashMLA metadata in fallback path
-            if precomputed.flashmla_metadata is not None:
-                size = precomputed.seqlens_expanded_size
-                flashmla_metadata = metadata.flashmla_metadata.slice(slice(0, size + 1))
-                flashmla_metadata.copy_(precomputed.flashmla_metadata)
+        if precomputed.flashmla_metadata is not None and (
+            _is_hcu or not fused_kernel_succeeded
+        ):
+            size = precomputed.seqlens_expanded_size
+            flashmla_source = (
+                self._compute_flashmla_metadata(
+                    cache_seqlens=precomputed.dsa_cache_seqlens,
+                    seq_len_q=1,
+                )
+                if _is_hcu
+                else precomputed.flashmla_metadata
+            )
+            flashmla_metadata = refresh_flashmla_metadata(
+                metadata.flashmla_metadata,
+                flashmla_source,
+                slice(0, size + 1),
+                is_hcu=_is_hcu,
+            )
+            if _is_hcu:
+                object.__setattr__(metadata, "flashmla_metadata", flashmla_metadata)
 
         # Refresh DeepGEMM paged MQA schedule metadata for the actual seqlens of
         # this replay (the captured graph holds stale data otherwise, which can
@@ -3636,11 +3653,31 @@ class DeepseekSparseAttnMultiStepBackend:
                     and not fused_flashmla_metadata
                 ):
                     size = precomputed.seqlens_expanded_size
-                    for metadata in (metadata0, metadata1, metadata2):
-                        flashmla_metadata = metadata.flashmla_metadata.slice(
-                            slice(0, size + 1)
+                    for backend, metadata in zip(
+                        self.attn_backends[:3],
+                        (metadata0, metadata1, metadata2),
+                        strict=True,
+                    ):
+                        flashmla_source = (
+                            backend._compute_flashmla_metadata(
+                                cache_seqlens=precomputed.dsa_cache_seqlens,
+                                seq_len_q=1,
+                            )
+                            if _is_hcu
+                            else precomputed.flashmla_metadata
                         )
-                        flashmla_metadata.copy_(precomputed.flashmla_metadata)
+                        flashmla_metadata = refresh_flashmla_metadata(
+                            metadata.flashmla_metadata,
+                            flashmla_source,
+                            slice(0, size + 1),
+                            is_hcu=_is_hcu,
+                        )
+                        if _is_hcu:
+                            object.__setattr__(
+                                metadata,
+                                "flashmla_metadata",
+                                flashmla_metadata,
+                            )
 
                 # Copy remaining backends one by one (if > 3 backends)
                 for i in range(3, self.speculative_num_steps - 1):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -53,6 +53,9 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     get_flashmla_op,
     wrap_flashmla_metadata_result,
 )
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -765,7 +768,7 @@ class DeepseekSparseAttnBackend(
             req_pool_indices=forward_batch.req_pool_indices,
             seq_lens=forward_batch.seq_lens,
             seq_lens_cpu=seq_lens_cpu,
-            forward_mode=forward_batch.forward_mode,
+            forward_mode=effective_forward_mode(forward_batch),
             spec_info=forward_batch.spec_info,
             out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
             actual_forward_mode=getattr(forward_batch, "actual_forward_mode", None),
@@ -775,8 +778,9 @@ class DeepseekSparseAttnBackend(
         """Init the metadata for a forward pass."""
         batch_size = forward_batch.batch_size
         device = forward_batch.seq_lens.device
+        forward_mode = effective_forward_mode(forward_batch)
 
-        if forward_batch.forward_mode.is_target_verify():
+        if forward_mode.is_target_verify():
             draft_token_num = self.speculative_num_draft_tokens
         else:
             draft_token_num = 0
@@ -805,16 +809,14 @@ class DeepseekSparseAttnBackend(
         dsa_impl_for_batch = (
             self.dsa_decode_impl
             if (
-                forward_batch.forward_mode.is_decode_or_idle()
-                or forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             )
             else self.dsa_prefill_impl
         )
         use_flashmla_kv = (not self.use_mha) and dsa_impl_for_batch == "flashmla_kv"
-        topk_transform_method = self.get_topk_transform_method(
-            forward_batch.forward_mode
-        )
+        topk_transform_method = self.get_topk_transform_method(forward_mode)
         # Batch indices selected when cp enabled: After splitting multiple sequences,
         # a certain cp rank may not have some of these sequences.
         # We use bs_idx_cpu to mark which sequences are finally selected by the current cp rank,
@@ -824,12 +826,12 @@ class DeepseekSparseAttnBackend(
         indexer_seq_lens_cpu = forward_batch.seq_lens_cpu
         indexer_seq_lens = forward_batch.seq_lens
 
-        if forward_batch.forward_mode.is_decode_or_idle():
+        if forward_mode.is_decode_or_idle():
             extend_seq_lens_cpu = [1] * batch_size
             max_seqlen_q = 1
             cu_seqlens_q = self.get_device_int32_arange(batch_size + 1)
             seqlens_expanded = cache_seqlens_int32
-        elif forward_batch.forward_mode.is_target_verify():
+        elif forward_mode.is_target_verify():
             max_seqlen_q = 1
             cu_seqlens_q = torch.arange(
                 0,
@@ -850,7 +852,7 @@ class DeepseekSparseAttnBackend(
             page_table = torch.repeat_interleave(
                 page_table, repeats=self.speculative_num_draft_tokens, dim=0
             )
-        elif forward_batch.forward_mode.is_draft_extend_v2():
+        elif forward_mode.is_draft_extend_v2():
             if forward_batch.extend_prefix_lens_cpu is None:
                 assert forward_batch.extend_prefix_lens is not None
                 forward_batch.extend_prefix_lens_cpu = (
@@ -883,7 +885,7 @@ class DeepseekSparseAttnBackend(
                 sum(extend_seq_lens_cpu),
                 self.speculative_num_draft_tokens,
             )
-            if forward_batch.forward_mode.is_draft_extend_v2():
+            if forward_mode.is_draft_extend_v2():
                 # DRAFT_EXTEND_V2: V2 worker pre-fills draft KV cache with ALL speculated
                 # tokens upfront. All requests extend by the same fixed
                 # (speculative_num_draft_tokens). Use scalar to avoid GPU sync.
@@ -897,7 +899,7 @@ class DeepseekSparseAttnBackend(
                 page_table = torch.repeat_interleave(
                     page_table, repeats=forward_batch.extend_seq_lens, dim=0
                 )
-        elif forward_batch.forward_mode.is_extend():
+        elif forward_mode.is_extend():
             assert (
                 forward_batch.extend_seq_lens_cpu is not None
                 and forward_batch.extend_seq_lens is not None
@@ -999,7 +1001,7 @@ class DeepseekSparseAttnBackend(
                     extend_seq_lens,
                 )
         else:
-            assert False, f"Unsupported {forward_batch.forward_mode = }"
+            assert False, f"Unsupported {forward_mode = }"
 
         indexer_k_start_end, token_to_batch_idx = self._cal_indexer_k_start_end(
             forward_batch, bs_idx_cpu
@@ -1018,12 +1020,12 @@ class DeepseekSparseAttnBackend(
         paged_mqa_schedule_metadata = None
         paged_mqa_ctx_lens_2d = None
         if is_cuda() and (
-            forward_batch.forward_mode.is_decode_or_idle()
-            or forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
+            forward_mode.is_decode_or_idle()
+            or forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
         ):
             paged_mqa_ctx_lens_2d = self._build_paged_mqa_schedule_2d_ctx_lens(
-                forward_batch.forward_mode,
+                forward_mode,
                 cache_seqlens_int32,
                 seqlens_expanded,
                 forward_batch.batch_size,
@@ -1076,7 +1078,7 @@ class DeepseekSparseAttnBackend(
         forward_batch: ForwardBatch,
         bs_idx: Optional[List[int]] = None,
     ):
-        if not forward_batch.forward_mode.is_extend_without_speculative():
+        if not effective_forward_mode(forward_batch).is_extend_without_speculative():
             return None, None
         if forward_batch.batch_size == 0 or (bs_idx is not None and len(bs_idx) == 0):
             empty_t = torch.empty(0, dtype=torch.int32, device=self.device)
@@ -1114,7 +1116,7 @@ class DeepseekSparseAttnBackend(
                 (extend_seq_len,), k_offset, dtype=torch.int32, device=self.device
             )
             kv_len = seq_len
-            if forward_batch.forward_mode.is_target_verify():
+            if effective_forward_mode(forward_batch).is_target_verify():
                 kv_len += self.speculative_num_draft_tokens
             seq_lens_expanded = torch.arange(
                 kv_len - extend_seq_len + 1,
@@ -1897,11 +1899,13 @@ class DeepseekSparseAttnBackend(
         metadata = self.forward_metadata
         assert causal, "DSA is causal only"
 
+        forward_mode = effective_forward_mode(forward_batch)
         dsa_impl = (
             self.dsa_decode_impl
             if (
-                forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             )
             else self.dsa_prefill_impl
         )
@@ -1921,7 +1925,7 @@ class DeepseekSparseAttnBackend(
                 cos_sin_cache,
                 is_neox,
                 llama_4_scaling,
-                is_prefill=True,
+                is_prefill=not forward_mode.is_decode_or_idle(),
             )
 
         if k is not None:
@@ -1970,9 +1974,7 @@ class DeepseekSparseAttnBackend(
             q_rope = q_all[:, :, layer.v_head_dim :]
 
         # NOTE(dark): here, we use page size = 1
-        topk_transform_method = self.get_topk_transform_method(
-            forward_batch.forward_mode
-        )
+        topk_transform_method = self.get_topk_transform_method(forward_mode)
 
         if self.use_fused_topk:
             if topk_indices is not None:
@@ -2003,8 +2005,8 @@ class DeepseekSparseAttnBackend(
                     page_size=1,
                     output_num_tokens=q_nope.shape[0],
                     page_table_is_expanded=(
-                        forward_batch.forward_mode.is_target_verify()
-                        or forward_batch.forward_mode.is_draft_extend_v2()
+                        forward_mode.is_target_verify()
+                        or forward_mode.is_draft_extend_v2()
                     ),
                     cu_seqlens_q=metadata.cu_seqlens_q,
                 )
@@ -2477,7 +2479,8 @@ class DeepseekSparseAttnBackend(
             return False
         # RAGGED routing requires exactly EXTEND (excludes decode/idle, MIXED,
         # target-verify and draft-extend, which use dsa_decode_impl anyway).
-        if forward_batch.forward_mode != ForwardMode.EXTEND:
+        forward_mode = effective_forward_mode(forward_batch)
+        if forward_mode != ForwardMode.EXTEND:
             return False
         # Per-batch dense fallback (il <= threshold) reads bf16 q directly.
         if self.use_mha:
@@ -2490,10 +2493,7 @@ class DeepseekSparseAttnBackend(
             return False
         if is_dsa_enable_prefill_cp():
             return False
-        if (
-            self.get_topk_transform_method(forward_batch.forward_mode)
-            != TopkTransformMethod.RAGGED
-        ):
+        if self.get_topk_transform_method(forward_mode) != TopkTransformMethod.RAGGED:
             return False
         # Mirror the helper's head-padding compatibility check.
         if num_heads % 64 != 0 and 64 % num_heads != 0:
@@ -3216,8 +3216,8 @@ class DeepseekSparseAttnBackend(
                 page_size=1,
                 output_num_tokens=q.shape[0],
                 page_table_is_expanded=(
-                    forward_batch.forward_mode.is_target_verify()
-                    or forward_batch.forward_mode.is_draft_extend_v2()
+                    effective_forward_mode(forward_batch).is_target_verify()
+                    or effective_forward_mode(forward_batch).is_draft_extend_v2()
                 ),
                 cu_seqlens_q=metadata.cu_seqlens_q,
             )
@@ -3326,7 +3326,8 @@ class DeepseekSparseAttnBackend(
             # guarantee correctness.
             self.use_mha = False
         elif (
-            forward_batch and forward_batch.forward_mode.is_extend_without_speculative()
+            forward_batch
+            and effective_forward_mode(forward_batch).is_extend_without_speculative()
         ):
             # Check if sequence meets criteria for MHA_ONE_SHOT
             assert forward_batch.seq_lens_cpu is not None
@@ -3356,7 +3357,7 @@ class DeepseekSparseAttnBackend(
                 if (
                     is_blackwell()
                     and forward_batch is not None
-                    and forward_batch.forward_mode == ForwardMode.EXTEND
+                    and effective_forward_mode(forward_batch) == ForwardMode.EXTEND
                 ):
                     total_kv_tokens = forward_batch.seq_lens_sum
                     total_q_tokens = forward_batch.extend_num_tokens
@@ -3394,15 +3395,13 @@ class DeepseekSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:
+        forward_mode = effective_forward_mode(forward_batch)
         force_unfused = not self.use_fused_topk or (
-            self.hisparse_coordinator is not None
-            and forward_batch.forward_mode.is_decode_or_idle()
+            self.hisparse_coordinator is not None and forward_mode.is_decode_or_idle()
         )
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,
-            topk_transform_method=self.get_topk_transform_method(
-                forward_batch.forward_mode
-            ),
+            topk_transform_method=self.get_topk_transform_method(forward_mode),
             topk_backend=self.dsa_topk_backend,
             paged_mqa_schedule_metadata=self.forward_metadata.paged_mqa_schedule_metadata,
             paged_mqa_ctx_lens_2d=self.forward_metadata.paged_mqa_ctx_lens_2d,

--- a/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
+++ b/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
@@ -1,0 +1,92 @@
+"""Unit tests for platform-specific DSA FlashMLA routing and metadata."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa.flashmla_backend import (
+    DSAFlashMLAMetadata,
+    can_fuse_flashmla_metadata,
+    get_flashmla_op,
+    wrap_flashmla_metadata_result,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSAFlashMLABackend(CustomTestCase):
+    def test_loader_routes_hcu_to_external_interface(self):
+        expected_op = MagicMock()
+        module = SimpleNamespace(flash_mla_sparse_fwd=expected_op)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa.flashmla_backend.import_module",
+            return_value=module,
+        ) as import_mock:
+            actual_op = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=True)
+
+        self.assertIs(actual_op, expected_op)
+        import_mock.assert_called_once_with("flash_mla.flash_mla_interface")
+
+    def test_loader_keeps_non_hcu_on_sgl_kernel(self):
+        expected_op = MagicMock()
+        module = SimpleNamespace(get_mla_metadata=expected_op)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa.flashmla_backend.import_module",
+            return_value=module,
+        ) as import_mock:
+            actual_op = get_flashmla_op("get_mla_metadata", is_hcu=False)
+
+        self.assertIs(actual_op, expected_op)
+        import_mock.assert_called_once_with("sgl_kernel.flash_mla")
+
+    def test_hcu_metadata_object_is_wrapped_and_copied(self):
+        backend_num_splits = torch.tensor([3], dtype=torch.int32)
+        backend_metadata = SimpleNamespace(num_splits=backend_num_splits)
+        source = wrap_flashmla_metadata_result((backend_metadata, None), is_hcu=True)
+
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=SimpleNamespace(num_splits=None),
+            num_splits=None,
+        )
+        destination.copy_(source)
+
+        self.assertIs(destination.flashmla_metadata, backend_metadata)
+        self.assertIs(destination.num_splits, backend_num_splits)
+        self.assertFalse(can_fuse_flashmla_metadata(source, destination))
+
+    def test_metadata_slice_accepts_uninitialized_hcu_scheduler(self):
+        backend_metadata = SimpleNamespace(num_splits=None)
+        metadata = wrap_flashmla_metadata_result((backend_metadata, None), is_hcu=True)
+
+        sliced = metadata.slice(slice(0, 2))
+
+        self.assertIs(sliced.flashmla_metadata, backend_metadata)
+        self.assertIsNone(sliced.num_splits)
+
+    def test_tensor_metadata_remains_fused_copy_eligible(self):
+        source = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.tensor([1, 2], dtype=torch.int32),
+            num_splits=torch.tensor([3, 4], dtype=torch.int32),
+        )
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.zeros(2, dtype=torch.int32),
+            num_splits=torch.zeros(2, dtype=torch.int32),
+        )
+
+        destination.copy_(source)
+
+        self.assertTrue(
+            torch.equal(destination.flashmla_metadata, source.flashmla_metadata)
+        )
+        self.assertTrue(torch.equal(destination.num_splits, source.num_splits))
+        self.assertTrue(can_fuse_flashmla_metadata(source, destination))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
+++ b/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     DSAFlashMLAMetadata,
     can_fuse_flashmla_metadata,
     get_flashmla_op,
+    refresh_flashmla_metadata,
     wrap_flashmla_metadata_result,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -86,6 +87,76 @@ class TestDSAFlashMLABackend(CustomTestCase):
         )
         self.assertTrue(torch.equal(destination.num_splits, source.num_splits))
         self.assertTrue(can_fuse_flashmla_metadata(source, destination))
+
+    def test_hcu_refresh_returns_fresh_scheduler_object(self):
+        captured_scheduler = SimpleNamespace(
+            have_initialized=True,
+            config="batch-6",
+            tile_scheduler_metadata=object(),
+            num_splits=object(),
+        )
+        fresh_scheduler = SimpleNamespace(
+            have_initialized=False,
+            config=None,
+            tile_scheduler_metadata=None,
+            num_splits=None,
+        )
+        destination = DSAFlashMLAMetadata(captured_scheduler, None)
+        source = DSAFlashMLAMetadata(fresh_scheduler, None)
+
+        refreshed = refresh_flashmla_metadata(
+            destination,
+            source,
+            slice(0, 6),
+            is_hcu=True,
+        )
+
+        self.assertIs(refreshed, source)
+        self.assertIs(refreshed.flashmla_metadata, fresh_scheduler)
+        self.assertIs(destination.flashmla_metadata, captured_scheduler)
+
+    def test_tensor_refresh_keeps_destination_storage(self):
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.zeros(2, dtype=torch.int32),
+            num_splits=torch.zeros(3, dtype=torch.int32),
+        )
+        source = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.tensor([1, 2], dtype=torch.int32),
+            num_splits=torch.tensor([3, 4], dtype=torch.int32),
+        )
+        destination_metadata = destination.flashmla_metadata
+        destination_splits = destination.num_splits
+
+        refreshed = refresh_flashmla_metadata(
+            destination,
+            source,
+            slice(0, 2),
+            is_hcu=False,
+        )
+
+        self.assertIs(refreshed.flashmla_metadata, destination_metadata)
+        self.assertEqual(refreshed.num_splits.data_ptr(), destination_splits.data_ptr())
+        self.assertTrue(
+            torch.equal(refreshed.flashmla_metadata, source.flashmla_metadata)
+        )
+        self.assertTrue(torch.equal(refreshed.num_splits, source.num_splits))
+
+    def test_hcu_refresh_does_not_share_schedulers_across_steps(self):
+        destination = DSAFlashMLAMetadata(SimpleNamespace(), None)
+        first = DSAFlashMLAMetadata(SimpleNamespace(have_initialized=False), None)
+        second = DSAFlashMLAMetadata(SimpleNamespace(have_initialized=False), None)
+
+        first_refreshed = refresh_flashmla_metadata(
+            destination, first, slice(0, 6), is_hcu=True
+        )
+        second_refreshed = refresh_flashmla_metadata(
+            destination, second, slice(0, 6), is_hcu=True
+        )
+
+        self.assertIsNot(
+            first_refreshed.flashmla_metadata,
+            second_refreshed.flashmla_metadata,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
+++ b/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
@@ -5,11 +5,26 @@ from types import SimpleNamespace
 
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
     effective_forward_mode,
+    get_flashmla_kv_valid_rows,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _Mode:
+    def __init__(self, kind):
+        self.kind = kind
+
+    def is_decode_or_idle(self):
+        return self.kind in ("decode", "idle")
+
+    def is_target_verify(self):
+        return self.kind == "target_verify"
+
+    def is_draft_extend_v2(self):
+        return self.kind == "draft_extend_v2"
 
 
 class TestDSAForwardBatchUtils(CustomTestCase):
@@ -37,6 +52,67 @@ class TestDSAForwardBatchUtils(CustomTestCase):
         forward_batch = SimpleNamespace(forward_mode=current_mode)
 
         self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+    def test_target_verify_uses_planned_five_of_six_rows(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=1,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_draft_extend_v2_uses_original_layout_without_preplan(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("draft_extend_v2"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=None,
+            forward_metadata_planned_num_tokens=None,
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_decode_uses_request_rows_instead_of_transient_token_rows(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("decode"),
+            _original_batch_size=5,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=5,
+            forward_metadata_planned_num_tokens=25,
+            spec_info=SimpleNamespace(num_tokens_per_req=1),
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_inconsistent_plan_does_not_trim(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=2,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertIsNone(get_flashmla_kv_valid_rows(forward_batch, 6))
+
+    def test_unpadded_rows_do_not_trigger_repad(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=1,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertIsNone(get_flashmla_kv_valid_rows(forward_batch, 5))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
+++ b/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
@@ -1,0 +1,43 @@
+"""Unit tests for DSA forward-batch layout helpers."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDSAForwardBatchUtils(CustomTestCase):
+    def test_effective_mode_uses_original_mode_during_mlp_sync(self):
+        current_mode = object()
+        original_mode = object()
+        forward_batch = SimpleNamespace(
+            forward_mode=current_mode,
+            _original_forward_mode=original_mode,
+        )
+
+        self.assertIs(effective_forward_mode(forward_batch), original_mode)
+
+    def test_effective_mode_handles_explicit_none(self):
+        current_mode = object()
+        forward_batch = SimpleNamespace(
+            forward_mode=current_mode,
+            _original_forward_mode=None,
+        )
+
+        self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+    def test_effective_mode_handles_missing_original_field(self):
+        current_mode = object()
+        forward_batch = SimpleNamespace(forward_mode=current_mode)
+
+        self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

- DSA backend、indexer 和 CP 判断统一读取 padding 前保存的有效 forward mode。
- HCU `flashmla_kv` 在 IFB/MTP 合成填充场景中只向 kernel 传入有效行，按有效行重算 metadata，零有效行跳过 kernel，并把输出回填到物理行数。
- 修复 HCU lazy FlashMLA scheduler object 在 capture、replay、precomputed 和 multi-step 场景中的更新与隔离问题。
- CUDA tensor metadata 继续原位 `slice+copy`，不改变 captured storage。
- 不修改 DP allgather，也不迁移旧 NSA mapper。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：GLM-5.2 IFB + CP + MTP 的 planned token、request 和物理 padding 行数量不同，HCU FlashMLA 必须按有效行执行并保持 graph replay metadata 正确。
- 目标分支：main
- 依赖 PR：#200 HCU DSA FlashMLA 后端路由

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 未验证 | 重点验证 IFB + CP8 + MTP 的 5/1/6 多步场景 |
| 性能（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [x] 涉及算子/kernel