### PR TITLE
feat(attention): 增加 HCU 持久化分页 MQA 快速路径

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -840,6 +840,9 @@ class Envs:
     SGLANG_DSA_HIP_DISABLE_PRESHUFFLE = EnvBoolWithAlias(
         False, deprecated_name="SGLANG_NSA_HIP_DISABLE_PRESHUFFLE"
     )
+    # Opt-in gfx938 persistent paged-MQA path provided by LightOp.
+    SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH = EnvBool(False)
+    SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS = EnvInt(0)
     SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -70,10 +70,22 @@ _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 _use_fast_hadamard_transform = get_bool_env_var("SGLANG_USE_FAST_HADAMARD_TRANSFORM")
+_use_hcu_persistent_mqa = _is_hcu and envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH.get()
 
 if _is_hcu:
     from lightop import attention as lightop_attention
     from lightop import kvcache as lightop_kvcache
+
+    if _use_hcu_persistent_mqa:
+        _hcu_persistent_mqa_package_operation = getattr(
+            lightop_attention,
+            "paged_mqa_logits_length_masked",
+            None,
+        )
+        from sglang.srt.layers.attention.dsa.hcu_persistent_mqa import (
+            paged_mqa_logits_length_masked,
+            preload_hcu_persistent_mqa,
+        )
 
     from sglang.kernels.ops.attention.dsa.triton_kernel import (
         fused_get_logits_head_gate_triton,
@@ -376,6 +388,18 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         self.paged_mqa_logits_backend = DSAPagedMQALogitsBackend.resolve(
             get_exec().kernel.dsa_paged_mqa_logits_backend
         )
+        if _use_hcu_persistent_mqa:
+            device_props = torch.cuda.get_device_properties(torch.cuda.current_device())
+            device_arch = getattr(device_props, "gcnArchName", "")
+            if not device_arch:
+                device_arch = device_props.name
+            device_arch = device_arch.split(":")[0]
+            preload_hcu_persistent_mqa(
+                is_hcu=_is_hcu,
+                arch_name=device_arch,
+                num_cus=device_props.multi_processor_count,
+                package_operation=_hcu_persistent_mqa_package_operation,
+            )
 
     @staticmethod
     def _use_hcu_bf16_index_cache(pool) -> bool:
@@ -1023,15 +1047,40 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 active_weights = weights[:q_offset].to(torch.float32)
             else:
                 active_weights = weights[:q_offset]
-            logits = _hcu_paged_mqa_logits(
-                q_fp8[:q_offset],
-                kv_cache,
-                active_weights,
-                seqlens_32,
-                block_tables,
-                schedule_metadata,
-                max_seq_len,
-            )
+            active_q = q_fp8[:q_offset]
+            logits = None
+            if _use_hcu_persistent_mqa and not use_bf16_index_cache:
+                topk_context_lens = metadata.get_seqlens_expanded()
+                logits = paged_mqa_logits_length_masked(
+                    active_q.unsqueeze(1),
+                    kv_cache,
+                    active_weights,
+                    seqlens_32,
+                    block_tables,
+                    schedule_metadata,
+                    max_seq_len,
+                    is_hcu=_is_hcu,
+                    page_size=page_size,
+                    fuse_topk=envs.SGLANG_DSA_FUSE_TOPK.get(),
+                    force_unfused_topk=getattr(metadata, "force_unfused_topk", False),
+                    topk_transform_method_name=getattr(
+                        getattr(metadata, "topk_transform_method", None),
+                        "name",
+                        "",
+                    ),
+                    index_topk=self.index_topk,
+                    topk_context_lens=topk_context_lens,
+                )
+            if logits is None:
+                logits = _hcu_paged_mqa_logits(
+                    active_q,
+                    kv_cache,
+                    active_weights,
+                    seqlens_32,
+                    block_tables,
+                    schedule_metadata,
+                    max_seq_len,
+                )
         else:
             kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
             assert len(kv_cache_fp8.shape) == 2

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -69,6 +69,21 @@ _is_hcu = is_hcu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
+_use_fast_hadamard_transform = get_bool_env_var("SGLANG_USE_FAST_HADAMARD_TRANSFORM")
+
+if _is_hcu:
+    from lightop import attention as lightop_attention
+    from lightop import kvcache as lightop_kvcache
+
+    from sglang.kernels.ops.attention.dsa.triton_kernel import (
+        fused_get_logits_head_gate_triton,
+        hadamard_transform_optimized,
+    )
+
+    if _use_fast_hadamard_transform:
+        from fast_hadamard_transform import (
+            hadamard_transform as hcu_fast_hadamard_transform,
+        )
 
 if not _is_npu:
     from sglang.kernels.ops.attention.dsa import (
@@ -88,13 +103,13 @@ if _is_cuda:
 else:
     pick_dsl_expand = None
 
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip and not _is_hcu
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
 # Whether the aiter preshuffle paged-MQA path (page_size=64 + Preshuffle=True +
 # KVBlockSize=64) can be used. Falls back to the legacy page_size=1 / KVBlockSize=1
 # path when the gluon kernel is unavailable (Triton<3.5 and no AOT bundle).
-_use_aiter_preshuffle = aiter_can_use_preshuffle_paged_mqa()
+_use_aiter_preshuffle = not _is_hcu and aiter_can_use_preshuffle_paged_mqa()
 if _use_aiter and not _use_aiter_preshuffle:
     logger.warning(
         "ROCm DSA indexer: aiter preshuffle paged-MQA path is unavailable "
@@ -183,9 +198,49 @@ def _broadcast_indexer_topk_from_rank0(
     return topk_indices
 
 
-def rotate_activation(x: torch.Tensor) -> torch.Tensor:
+def _hcu_paged_mqa_logits(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    seqlens: torch.Tensor,
+    block_tables: torch.Tensor,
+    schedule_metadata: Optional[torch.Tensor],
+    max_seq_len: int,
+) -> torch.Tensor:
+    return lightop_attention.paged_mqa_logits(
+        q.unsqueeze(1),
+        kv_cache,
+        weights,
+        seqlens,
+        block_tables,
+        schedule_metadata,
+        max_seq_len,
+        clean_logits=True,
+    )
+
+
+def _hcu_mqa_logits(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+    kv_scale: Optional[torch.Tensor],
+) -> torch.Tensor:
+    return lightop_attention.mqa_logits(
+        q,
+        kv,
+        weights,
+        ks,
+        ke,
+        kv_scale=kv_scale,
+        clean_logit=True,
+    )
+
+
+def rotate_activation(x: torch.Tensor, apply_scale: bool = True) -> torch.Tensor:
     # from sgl_kernel import hadamard_transform
-    if _is_hip:
+    if _is_hip and not _is_hcu:
         from fast_hadamard_transform import hadamard_transform
     elif _is_xpu:
         from sgl_kernel import hadamard_transform
@@ -196,7 +251,12 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
     assert (
         hidden_size & (hidden_size - 1)
     ) == 0, "Hidden size must be a power of 2 for Hadamard transform."
-    return hadamard_transform(x, scale=hidden_size**-0.5)
+    scale = hidden_size**-0.5 if apply_scale else 1.0
+    if _is_hcu and _use_fast_hadamard_transform:
+        return hcu_fast_hadamard_transform(x, scale=scale)
+    if _is_hcu:
+        return hadamard_transform_optimized(x, scale=scale)
+    return hadamard_transform(x, scale=scale)
 
 
 class Indexer(DSANPUIndexerMixin, BaseFusedOp):
@@ -317,6 +377,74 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             get_exec().kernel.dsa_paged_mqa_logits_backend
         )
 
+    @staticmethod
+    def _use_hcu_bf16_index_cache(pool) -> bool:
+        return _is_hcu and not getattr(pool, "use_fp8_index_k_cache", True)
+
+    @staticmethod
+    def _get_gate_input_tensor(
+        x: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+    ) -> torch.Tensor:
+        if not isinstance(x, tuple):
+            return x
+
+        assert len(x) in (
+            2,
+            3,
+        ), "For tuple input, only (x, x_s) or (x, x_s, y) formats are accepted"
+        x_q, x_s = x[0], x[1]
+        if (
+            x_s is not None
+            and x_q.dim() == 2
+            and x_s.dim() == 2
+            and x_q.shape[0] == x_s.shape[0]
+        ):
+            m, n = x_q.shape
+            ng = x_s.shape[1]
+            if ng > 0 and n % ng == 0:
+                group = n // ng
+                return (
+                    x_q.to(torch.float32)
+                    .view(m, ng, group)
+                    .mul_(x_s.to(torch.float32).unsqueeze(-1))
+                    .view(m, n)
+                    .to(torch.bfloat16)
+                )
+        return x_q.to(torch.bfloat16)
+
+    def _get_bf16_logits_head_gate(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]]
+    ) -> torch.Tensor:
+        weights = self._project_and_scale_head_gates(self._get_gate_input_tensor(x))
+        return weights.unsqueeze(-1) * self.softmax_scale
+
+    def _hcu_fused_qk_quant_and_store(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        pool,
+        layer_id: int,
+        out_cache_loc: torch.Tensor,
+        weights: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        if hasattr(pool, "invalidate_index_buffer_for_layer"):
+            pool.invalidate_index_buffer_for_layer(layer_id)
+
+        hadamard_scale = self.hidden_size**-0.5
+        return lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
+            query,
+            key,
+            pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+            out_cache_loc.contiguous(),
+            pool.page_size,
+            weights,
+            hadamard_scale * self.softmax_scale,
+            hadamard_scale,
+            1e-5,
+            False,
+            not _is_fp8_fnuz,
+        )
+
     @contextlib.contextmanager
     def _with_real_sm_count(self):
         # When pipeline parallelism is enabled, each PP rank initiates a recv operation after the _pp_launch_batch
@@ -366,6 +494,13 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]], q_scale: torch.Tensor
     ):
         weights = self._weights_proj_bf16_in_fp32_out(x)
+        if _is_hcu:
+            return fused_get_logits_head_gate_triton(
+                weights=weights,
+                q_scale=q_scale,
+                n_heads=self.n_heads,
+                softmax_scale=self.softmax_scale,
+            )
         weights = weights * self.n_heads**-0.5
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights
@@ -391,6 +526,11 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         return x if self.use_dsa_indexer_fusion else rotate_activation(x)
 
     def _should_skip_logits_computation(self, forward_batch: ForwardBatch) -> bool:
+        # The HCU path does not use the generic act_quant fallback that powers
+        # the K-only shortcut, so keep query preparation and LightOp storage
+        # together even for short prefill requests.
+        if _is_hcu:
+            return False
         if (
             forward_batch.forward_mode.is_extend_without_speculative()
             and forward_batch.seq_lens_cpu is not None
@@ -406,8 +546,50 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         positions: torch.Tensor,
         enable_dual_stream: bool,
         forward_batch: ForwardBatch,
+        apply_hadamard_scale: bool = True,
     ):
         weights_raw = None
+        if _is_hcu:
+            query, _ = self.wq_b(q_lora)
+            query = rearrange(query, "l (h d) -> l h d", d=self.head_dim)
+            key, _ = self.wk(x)
+            if key.ndim == 2:
+                key = key.view(key.shape[0], -1, self.head_dim)
+
+            lightop_attention.fuse_layernorm_rotary_embedding(
+                positions,
+                query,
+                key,
+                self.head_dim,
+                self._indexer_cos_sin_cache,
+                False,
+                None,
+                None,
+                self.k_norm.weight,
+                getattr(self.k_norm, "bias", None),
+                None,
+                None,
+                self.k_norm.variance_epsilon,
+            )
+            query = rotate_activation(query, apply_scale=apply_hadamard_scale)
+            key = rotate_activation(key, apply_scale=apply_hadamard_scale)
+
+            if is_cp_v2_active(forward_batch):
+                key = get_cp_strategy().materialize_full_indexer_k_cache(
+                    key, forward_batch
+                )
+            elif (
+                forward_batch.attn_cp_metadata is not None
+                and self.dsa_enable_prefill_cp
+            ):
+                key = cp_all_gather_rerange_output(
+                    key.contiguous(),
+                    self.cp_size,
+                    forward_batch,
+                    torch.cuda.current_stream(),
+                )
+            return query, key, weights_raw
+
         if enable_dual_stream:
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
@@ -679,6 +861,20 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             return pool.get_broadcastable_index_k_with_scale_buffer(layer_id)
         return pool.get_index_k_with_scale_buffer(layer_id=layer_id)
 
+    def _get_hcu_paged_index_k_cache(
+        self, pool, layer_id: int
+    ) -> Tuple[torch.Tensor, bool]:
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
+        if use_bf16_index_cache:
+            return pool.get_index_k_buffer(layer_id=layer_id), True
+
+        kv_cache = self._get_index_k_read_buffer(pool, layer_id)
+        assert len(kv_cache.shape) == 2
+        return (
+            kv_cache.view(kv_cache.shape[0], pool.page_size, 1, self.head_dim + 4),
+            False,
+        )
+
     @staticmethod
     def _pad_heads_for_deep_gemm(q_fp8, weights):
         """Pad q and weights to 32 heads when num_heads < 32,
@@ -736,9 +932,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        page_size = get_token_to_kv_pool().page_size
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
         # NOTE(dark): blocksize = 64 is hardcoded in deep_gemm
-        if _is_hip:
+        if _is_hip and not _is_hcu:
             if _use_aiter_preshuffle:
                 assert (
                     page_size % 16 == 0
@@ -750,14 +947,12 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         else:
             assert page_size == 64, "only support page size 64"
         # NOTE(dark): this support extend/decode/decode+graph
-        if _is_hip and not _use_aiter_preshuffle:
+        if _is_hip and not _is_hcu and not _use_aiter_preshuffle:
             block_tables = metadata.get_page_table_1()
         else:
             block_tables = metadata.get_page_table_64()
 
         max_seq_len = block_tables.shape[1] * page_size
-        kv_cache_fp8 = self._get_index_k_read_buffer(get_token_to_kv_pool(), layer_id)
-
         blocksize = page_size
         if (
             forward_batch.forward_mode.is_target_verify()
@@ -817,15 +1012,33 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     seqlens_32_2d, blocksize, self.sm_count
                 )
 
-        assert len(kv_cache_fp8.shape) == 2
-        block_kv = page_size
-        num_heads_kv = 1
-        head_dim_with_sf = 132
-        kv_cache_fp8 = kv_cache_fp8.view(
-            kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
-        )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
+
+        if self.paged_mqa_logits_backend.is_lightop():
+            kv_cache, use_bf16_index_cache = self._get_hcu_paged_index_k_cache(
+                pool, layer_id
+            )
+            if use_bf16_index_cache:
+                active_weights = weights[:q_offset].to(torch.float32)
+            else:
+                active_weights = weights[:q_offset]
+            logits = _hcu_paged_mqa_logits(
+                q_fp8[:q_offset],
+                kv_cache,
+                active_weights,
+                seqlens_32,
+                block_tables,
+                schedule_metadata,
+                max_seq_len,
+            )
+        else:
+            kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
+            assert len(kv_cache_fp8.shape) == 2
+            block_kv = page_size
+            kv_cache_fp8 = kv_cache_fp8.view(
+                kv_cache_fp8.shape[0], block_kv, 1, self.head_dim + 4
+            )
 
         if self.paged_mqa_logits_backend.is_aiter():
             logits = aiter_paged_mqa_logits(
@@ -838,6 +1051,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 preshuffle=_use_aiter_preshuffle,
                 kv_block_size=block_kv,
             )
+        elif self.paged_mqa_logits_backend.is_lightop():
+            pass
         elif use_cute_dsl:
             logits = cutedsl_paged_mqa_logits(
                 q_fp8,
@@ -967,8 +1182,9 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         assert forward_batch.forward_mode.is_extend_without_speculative()
 
-        page_size = get_token_to_kv_pool().page_size
-        if _is_hip:
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
+        if _is_hip and not _is_hcu:
             if _use_aiter_preshuffle:
                 assert (
                     page_size % 16 == 0
@@ -987,7 +1203,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         )
         weights = weights.squeeze(-1)
 
-        if _is_hip and not _use_aiter_preshuffle:
+        if _is_hip and not _is_hcu and not _use_aiter_preshuffle:
             block_tables = metadata.get_page_table_1()
         else:
             block_tables = metadata.get_page_table_64()
@@ -1015,26 +1231,41 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         indexer_seq_lens_cpu = metadata.get_indexer_seq_len_cpu()
         seq_len_sum = torch.sum(indexer_seq_lens_cpu).item()
         max_seq_len = torch.max(indexer_seq_lens_cpu).item()
-        k_fp8, k_scale = get_token_to_kv_pool().get_index_k_scale_buffer(
-            layer_id,
-            metadata.get_indexer_seq_len(),
-            block_tables,
-            seq_len_sum,
-            max_seq_len,
-        )
-        if _is_fp8_fnuz:
-            k_fp8 = k_fp8.view(torch.float8_e4m3fnuz)
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
+        if use_bf16_index_cache:
+            kv_bf16 = torch.cat(
+                [
+                    pool.get_index_k_continuous(
+                        layer_id,
+                        int(indexer_seq_lens_cpu[batch_idx].item()),
+                        block_tables[batch_idx],
+                    )
+                    for batch_idx in range(batch_size)
+                ],
+                dim=0,
+            )
+            k_offset = kv_bf16.shape[0]
         else:
-            k_fp8 = k_fp8.view(torch.float8_e4m3fn)
+            k_fp8, k_scale = pool.get_index_k_scale_buffer(
+                layer_id,
+                metadata.get_indexer_seq_len(),
+                block_tables,
+                seq_len_sum,
+                max_seq_len,
+            )
+            if _is_fp8_fnuz:
+                k_fp8 = k_fp8.view(torch.float8_e4m3fnuz)
+            else:
+                k_fp8 = k_fp8.view(torch.float8_e4m3fn)
 
-        k_scale = k_scale.view(torch.float32).squeeze(-1)
-        kv_fp8 = (k_fp8, k_scale)
+            k_scale = k_scale.view(torch.float32).squeeze(-1)
+            kv_fp8 = (k_fp8, k_scale)
+            k_offset = k_fp8.shape[0]
 
         # Check if we need to chunk to avoid OOM
         seq_lens_expanded = metadata.get_seqlens_expanded()
         token_to_batch_idx = metadata.get_token_to_batch_idx()
         q_offset = ks.shape[0]
-        k_offset = k_fp8.shape[0]
         need_chunk, logits_budget_bytes = self._should_chunk_mqa_logits(
             q_offset, k_offset, device_index
         )
@@ -1042,7 +1273,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if not need_chunk:
             assert q_fp8[:q_offset].shape[0] != 0
             with self._with_real_sm_count():
-                if _is_hip:
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8[:q_offset],
+                        kv_bf16,
+                        weights[:q_offset].to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    kv, scale = kv_fp8
+                    logits = _hcu_mqa_logits(
+                        q_fp8[:q_offset],
+                        kv,
+                        weights[:q_offset],
+                        ks,
+                        ke,
+                        kv_scale=scale,
+                    )
+                elif _is_hip:
                     from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 
                     kv, scale = kv_fp8
@@ -1101,7 +1351,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             end = min(start + max_rows, q_offset)
 
             with self._with_real_sm_count():
-                if _is_hip:
+                if use_bf16_index_cache:
+                    logits_chunk = _hcu_mqa_logits(
+                        q_fp8[start:end],
+                        kv_bf16,
+                        weights[start:end].to(torch.float32),
+                        ks[start:end],
+                        ke[start:end],
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    kv, scale = kv_fp8
+                    logits_chunk = _hcu_mqa_logits(
+                        q_fp8[start:end],
+                        kv,
+                        weights[start:end],
+                        ks[start:end],
+                        ke[start:end],
+                        kv_scale=scale,
+                    )
+                elif _is_hip:
                     from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 
                     kv, scale = kv_fp8
@@ -1257,12 +1526,15 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        page_size = get_token_to_kv_pool().page_size
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
         assert page_size == 64, "only support page size 64"
         assert len(weights.shape) == 3
         weights = weights.squeeze(-1)
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
         k_fp8_list = []
         k_scale_list = []
+        k_bf16_list = []
         ks_list = []
         ke_offset_list = []
         offset = 0
@@ -1286,23 +1558,27 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 end_seq_position += pre_chunk_offset
                 if offset == 0 and batch_idx != 0:
                     offset += forward_batch.extend_seq_lens_cpu[batch_idx - 1]
-                k_fp8 = get_token_to_kv_pool().get_index_k_continuous(
+                index_k = pool.get_index_k_continuous(
                     layer_id,
                     end_seq_position,
                     block_tables[batch_idx],
                 )
-                k_scale = get_token_to_kv_pool().get_index_k_scale_continuous(
-                    layer_id,
-                    end_seq_position,
-                    block_tables[batch_idx],
-                )
+                if not use_bf16_index_cache:
+                    k_scale = pool.get_index_k_scale_continuous(
+                        layer_id,
+                        end_seq_position,
+                        block_tables[batch_idx],
+                    )
 
                 extend_seq_len = end_seq_position - start_seq_position
                 ks = torch.full(
                     (extend_seq_len,), offset, dtype=torch.int32, device="cuda"
                 )
-                k_fp8_list.append(k_fp8)
-                k_scale_list.append(k_scale)
+                if use_bf16_index_cache:
+                    k_bf16_list.append(index_k)
+                else:
+                    k_fp8_list.append(index_k)
+                    k_scale_list.append(k_scale)
                 ks_list.append(ks)
                 ke_offset = torch.arange(
                     start_seq_position + 1,
@@ -1317,23 +1593,49 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 actual_seq_q_list.append(actual_seq_q)
                 batch_idx_list.append(batch_idx)
 
-            k_fp8 = torch.cat(k_fp8_list, dim=0).view(torch.float8_e4m3fn)
-            k_scale = torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
-            kv_fp8 = (k_fp8, k_scale)
             ks = torch.cat(ks_list, dim=0)
             ke_offset = torch.cat(ke_offset_list, dim=0)
             ke = ks + ke_offset
             actual_seq_q = torch.cat(actual_seq_q_list, dim=0)
             with self._with_real_sm_count():
-                q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(q_fp8, weights)
-                logits = deep_gemm.fp8_mqa_logits(
-                    q_padded,
-                    kv_fp8,
-                    w_padded,
-                    ks,
-                    ke,
-                    clean_logits=False,
-                )
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        torch.cat(k_bf16_list, dim=0),
+                        weights.to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    k_fp8 = torch.cat(k_fp8_list, dim=0).view(fp8_dtype)
+                    k_scale = (
+                        torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
+                    )
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        k_fp8,
+                        weights,
+                        ks,
+                        ke,
+                        kv_scale=k_scale,
+                    )
+                else:
+                    k_fp8 = torch.cat(k_fp8_list, dim=0).view(torch.float8_e4m3fn)
+                    k_scale = (
+                        torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
+                    )
+                    q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(
+                        q_fp8, weights
+                    )
+                    logits = deep_gemm.fp8_mqa_logits(
+                        q_padded,
+                        (k_fp8, k_scale),
+                        w_padded,
+                        ks,
+                        ke,
+                        clean_logits=False,
+                    )
             topk_result = metadata.topk_transform(
                 logits,
                 self.index_topk,
@@ -1348,20 +1650,11 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 - forward_batch.extend_seq_lens_cpu[0]
                 + kv_len
             )
-            k_fp8 = get_token_to_kv_pool().get_index_k_continuous(
+            index_k = pool.get_index_k_continuous(
                 layer_id,
                 kv_len,
                 block_tables[0],
             )
-            k_scale = get_token_to_kv_pool().get_index_k_scale_continuous(
-                layer_id,
-                kv_len,
-                block_tables[0],
-            )
-
-            k_fp8 = k_fp8.view(torch.float8_e4m3fn)
-            k_scale = k_scale.view(torch.float32).squeeze(-1)
-            kv_fp8 = (k_fp8, k_scale)
             ks = torch.full((actual_seq_q,), offset, dtype=torch.int32, device="cuda")
             ke_offset = torch.arange(
                 (kv_len - actual_seq_q) + 1,
@@ -1372,15 +1665,44 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             ke = ks + ke_offset
 
             with self._with_real_sm_count():
-                q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(q_fp8, weights)
-                logits = deep_gemm.fp8_mqa_logits(
-                    q_padded,
-                    kv_fp8,
-                    w_padded,
-                    ks,
-                    ke,
-                    clean_logits=False,
-                )
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        index_k,
+                        weights.to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                else:
+                    k_scale = pool.get_index_k_scale_continuous(
+                        layer_id,
+                        kv_len,
+                        block_tables[0],
+                    )
+                    k_fp8 = index_k.view(fp8_dtype if _is_hcu else torch.float8_e4m3fn)
+                    k_scale = k_scale.view(torch.float32).squeeze(-1)
+                    if _is_hcu:
+                        logits = _hcu_mqa_logits(
+                            q_fp8,
+                            k_fp8,
+                            weights,
+                            ks,
+                            ke,
+                            kv_scale=k_scale,
+                        )
+                    else:
+                        q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(
+                            q_fp8, weights
+                        )
+                        logits = deep_gemm.fp8_mqa_logits(
+                            q_padded,
+                            (k_fp8, k_scale),
+                            w_padded,
+                            ks,
+                            ke,
+                            clean_logits=False,
+                        )
             actual_seq_q = torch.tensor([actual_seq_q], dtype=torch.int32).to(
                 device="cuda", non_blocking=True
             )
@@ -1419,6 +1741,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
         if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
+            return
+
+        if _is_hcu:
+            if self._use_hcu_bf16_index_cache(pool):
+                pool.set_index_k_buffer(
+                    layer_id=layer_id,
+                    loc=out_cache_loc,
+                    index_k=key,
+                )
+                return
+
+            lightop_kvcache.fuse_act_quant_and_store_index_k_cache(
+                key,
+                pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+                out_cache_loc.contiguous(),
+                pool.page_size,
+                1e-5,
+                False,
+                not _is_fp8_fnuz,
+            )
             return
 
         if (
@@ -1503,9 +1845,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         layer_id: int,
         return_indices: bool = True,
     ) -> Optional[torch.Tensor]:
-        if _is_hip:
+        act_quant = None
+        if _is_hip and not _is_hcu:
             from sglang.kernels.ops.attention.dsa.tilelang_kernel import act_quant
-        elif not _is_npu:
+        elif not _is_npu and not _is_hcu:
             from sglang.kernels.ops.attention.dsa.triton_kernel import act_quant
 
         if TYPE_CHECKING:
@@ -1516,7 +1859,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         x_meta = x[0] if isinstance(x, tuple) else x
 
         in_piecewise_or_breakable_cuda_graph = (
-            _is_in_piecewise_or_breakable_cuda_graph()
+            not _is_hcu and _is_in_piecewise_or_breakable_cuda_graph()
         )
 
         # In piecewise/breakable CUDA graph mode, metadata is fetched inside
@@ -1567,7 +1910,51 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             self.weights_proj, "set_lora", False
         )
 
-        if (
+        if _is_hcu:
+            pool = get_token_to_kv_pool()
+            x_for_gate = self._get_gate_input_tensor(x)
+            if self._use_hcu_bf16_index_cache(pool):
+                q_fp8, key, _ = self._get_q_k_bf16(
+                    q_lora,
+                    x,
+                    positions,
+                    False,
+                    forward_batch=forward_batch,
+                )
+                self._store_index_k_cache(
+                    forward_batch=forward_batch,
+                    layer_id=layer_id,
+                    key=key,
+                )
+                if weights_proj_lora:
+                    weights = (
+                        self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
+                    ).unsqueeze(-1) * self.softmax_scale
+                else:
+                    weights = self._get_bf16_logits_head_gate(x_for_gate)
+            else:
+                query, key, _ = self._get_q_k_bf16(
+                    q_lora,
+                    x,
+                    positions,
+                    False,
+                    forward_batch=forward_batch,
+                    apply_hadamard_scale=False,
+                )
+                q_fp8_raw, q_scale, _ = self._hcu_fused_qk_quant_and_store(
+                    query,
+                    key,
+                    pool,
+                    layer_id,
+                    forward_batch.out_cache_loc,
+                )
+                q_fp8 = q_fp8_raw.view(fp8_dtype)
+                if weights_proj_lora:
+                    gate = self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
+                    weights = self._apply_q_scale_and_softmax_scale(gate, q_scale)
+                else:
+                    weights = self._get_logits_head_gate(x_for_gate, q_scale)
+        elif (
             self.use_dsa_indexer_fusion
             and not in_piecewise_or_breakable_cuda_graph
             and forward_batch.attn_cp_metadata is None

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -430,7 +430,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
 
-        hadamard_scale = self.hidden_size**-0.5
+        hadamard_scale = self.head_dim**-0.5
         return lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
             query,
             key,

--- a/python/sglang/srt/layers/attention/dsa/hcu_persistent_mqa.py
+++ b/python/sglang/srt/layers/attention/dsa/hcu_persistent_mqa.py
@@ -1,0 +1,367 @@
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime gate for the packaged gfx938 persistent paged-MQA fastpath."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+import torch
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+_EXTENSION_API_NAME = "paged_mqa_logits_length_masked"
+
+_selected_operation: Optional[Callable[..., torch.Tensor]] = None
+_preload_failure: Optional[str] = None
+_preloaded_hardware: Optional[tuple[str, int]] = None
+_logged_hits: set[tuple[int, int, int]] = set()
+_logged_misses: set[str] = set()
+
+
+def resolve_persistent_ctas(
+    configured_ctas: int, *, batch_size: int, max_context_len: int
+) -> int:
+    """Resolve graph-stable persistent grid size from capture-stable shapes."""
+
+    _validate_configured_ctas(configured_ctas)
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if max_context_len <= 0:
+        raise ValueError(f"max_context_len must be positive, got {max_context_len}")
+    if configured_ctas:
+        return configured_ctas
+
+    max_chunks = (max_context_len + 255) // 256
+    batch_aware_floor = max(128, (2048 + batch_size - 1) // batch_size)
+    return min(max_chunks, batch_aware_floor)
+
+
+def _validate_configured_ctas(configured_ctas: int) -> None:
+    if configured_ctas < 0 or configured_ctas > 4096:
+        raise ValueError(
+            "SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS must be 0 (auto) or in "
+            f"[1, 4096], got {configured_ctas}"
+        )
+
+
+def _input_gate_miss_reason(
+    *,
+    is_hcu: bool,
+    page_size: int,
+    q: torch.Tensor,
+    fused_kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    schedule_meta: Any,
+    max_context_len: int,
+) -> Optional[str]:
+    if not is_hcu:
+        return "device backend is not HCU"
+    if page_size != 64:
+        return f"page_size must be 64, got {page_size}"
+    if schedule_meta is not None:
+        return "schedule_meta must be None"
+    if max_context_len <= 0:
+        return f"max_context_len must be positive, got {max_context_len}"
+
+    if q.device.type != "cuda":
+        return f"q must be an HCU/HIP tensor, got device {q.device}"
+    if q.dtype != torch.float8_e4m3fn:
+        return f"q dtype must be float8_e4m3fn, got {q.dtype}"
+    if q.dim() != 4 or tuple(q.shape[1:]) != (1, 32, 128):
+        return f"q shape must be [batch, 1, 32, 128], got {tuple(q.shape)}"
+    if q.shape[0] <= 0:
+        return "q batch size must be positive"
+    if not q.is_contiguous():
+        return "q must be contiguous"
+
+    reference_device = q.device
+    for name, tensor in (
+        ("fused_kv_cache", fused_kv_cache),
+        ("weights", weights),
+        ("context_lens", context_lens),
+        ("block_table", block_table),
+    ):
+        if tensor.device != reference_device:
+            return f"{name} must be on {reference_device}, got {tensor.device}"
+
+    if fused_kv_cache.dtype != torch.uint8:
+        return f"fused_kv_cache dtype must be uint8, got {fused_kv_cache.dtype}"
+    if fused_kv_cache.dim() != 4 or tuple(fused_kv_cache.shape[1:]) != (
+        64,
+        1,
+        132,
+    ):
+        return (
+            "fused_kv_cache shape must be [num_blocks, 64, 1, 132], got "
+            f"{tuple(fused_kv_cache.shape)}"
+        )
+    if fused_kv_cache.shape[0] <= 0:
+        return "fused_kv_cache must contain at least one block"
+    if tuple(fused_kv_cache.stride()) != (8448, 132, 132, 1):
+        return (
+            "fused_kv_cache stride must be [8448, 132, 132, 1], got "
+            f"{tuple(fused_kv_cache.stride())}"
+        )
+
+    batch_size = q.shape[0]
+    if (
+        weights.dtype != torch.float32
+        or weights.dim() != 2
+        or tuple(weights.shape) != (batch_size, 32)
+        or not weights.is_contiguous()
+    ):
+        return (
+            "weights must be contiguous float32 [batch, 32], got "
+            f"dtype={weights.dtype}, shape={tuple(weights.shape)}, "
+            f"contiguous={weights.is_contiguous()}"
+        )
+    if (
+        context_lens.dtype != torch.int32
+        or context_lens.dim() != 1
+        or tuple(context_lens.shape) != (batch_size,)
+        or not context_lens.is_contiguous()
+    ):
+        return (
+            "context_lens must be contiguous int32 [batch], got "
+            f"dtype={context_lens.dtype}, shape={tuple(context_lens.shape)}, "
+            f"contiguous={context_lens.is_contiguous()}"
+        )
+    if (
+        block_table.dtype != torch.int32
+        or block_table.dim() != 2
+        or block_table.shape[0] != batch_size
+        or block_table.shape[1] <= 0
+        or block_table.stride(1) != 1
+    ):
+        return (
+            "block_table must be int32 [batch, pages] with stride(1)=1, got "
+            f"dtype={block_table.dtype}, shape={tuple(block_table.shape)}, "
+            f"stride={tuple(block_table.stride())}"
+        )
+    block_table_capacity = block_table.shape[1] * page_size
+    if max_context_len != block_table_capacity:
+        return (
+            f"max_context_len {max_context_len} must equal block-table capacity "
+            f"{block_table_capacity}"
+        )
+    return None
+
+
+def _hardware_gate_miss_reason(*, arch_name: str, num_cus: int) -> Optional[str]:
+    if not arch_name.startswith("gfx938"):
+        return f"GPU architecture must be gfx938, got {arch_name or 'unknown'}"
+    if num_cus != 64:
+        return f"gfx938 specialization requires 64 CUs, got {num_cus}"
+    return None
+
+
+def _consumer_gate_miss_reason(
+    *,
+    fuse_topk: bool,
+    force_unfused_topk: bool,
+    topk_transform_method_name: str,
+    index_topk: int,
+    score_context_lens: torch.Tensor,
+    topk_context_lens: torch.Tensor,
+) -> Optional[str]:
+    if not fuse_topk:
+        return "SGLANG_DSA_FUSE_TOPK must be enabled"
+    if topk_transform_method_name != "PAGED":
+        return (
+            "metadata.topk_transform_method must be PAGED, got "
+            f"{topk_transform_method_name or 'unknown'}"
+        )
+    if index_topk != 2048:
+        return f"index_topk must be 2048, got {index_topk}"
+    if score_context_lens is not topk_context_lens:
+        topk_consumer = (
+            "fast_topk_v2" if force_unfused_topk else "fast_topk_transform_fused"
+        )
+        return (
+            "MQA context_lens must be the exact tensor consumed by production "
+            f"{topk_consumer}"
+        )
+    return None
+
+
+def _select_package_operation(package_operation: Any) -> None:
+    global _selected_operation
+
+    if _selected_operation is not None:
+        return
+    if not callable(package_operation):
+        raise RuntimeError(
+            "installed LightOp package does not export callable "
+            f"{_EXTENSION_API_NAME}"
+        )
+    _selected_operation = package_operation
+    logger.info("Using packaged LightOp persistent paged-MQA operation")
+
+
+def _raise_unavailable(reason: str) -> None:
+    raise RuntimeError(f"HCU persistent paged-MQA fastpath unavailable: {reason}")
+
+
+def _log_consumer_fallback(reason: str) -> None:
+    if reason not in _logged_misses:
+        _logged_misses.add(reason)
+        logger.warning(
+            "HCU persistent paged-MQA fastpath missed; using production LightOp: %s",
+            reason,
+        )
+
+
+def preload_hcu_persistent_mqa(
+    *,
+    is_hcu: bool,
+    arch_name: str,
+    num_cus: int,
+    package_operation: Any = None,
+) -> None:
+    """Validate and select the packaged LightOp API before graph capture."""
+
+    global _preload_failure, _preloaded_hardware
+
+    if not envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH.get():
+        return
+
+    if _preload_failure is not None:
+        _raise_unavailable(_preload_failure)
+
+    if not is_hcu:
+        reason = "device backend is not HCU"
+    else:
+        reason = _hardware_gate_miss_reason(
+            arch_name=arch_name,
+            num_cus=num_cus,
+        )
+    if reason is not None:
+        _preload_failure = reason
+        _raise_unavailable(reason)
+
+    try:
+        _validate_configured_ctas(envs.SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS.get())
+        _select_package_operation(package_operation)
+        _preloaded_hardware = (arch_name, num_cus)
+    except (RuntimeError, ValueError) as error:
+        _preload_failure = str(error)
+        _raise_unavailable(_preload_failure)
+
+
+def _log_hit_once(*, q_rows: int, max_context_len: int, resolved_ctas: int) -> None:
+    hit_key = (q_rows, max_context_len, resolved_ctas)
+    if hit_key in _logged_hits:
+        return
+    _logged_hits.add(hit_key)
+    logger.info(
+        "HCU persistent paged-MQA fastpath HIT source=lightop-package q_rows=%d "
+        "max_context_len=%d resolved_ctas=%d; kernel writes only the valid "
+        "prefix and downstream production TopK must use the same context_lens",
+        q_rows,
+        max_context_len,
+        resolved_ctas,
+    )
+
+
+def paged_mqa_logits_length_masked(
+    q: torch.Tensor,
+    fused_kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    schedule_meta: Any,
+    max_context_len: int,
+    *,
+    is_hcu: bool,
+    page_size: int,
+    fuse_topk: bool,
+    force_unfused_topk: bool,
+    topk_transform_method_name: str,
+    index_topk: int,
+    topk_context_lens: torch.Tensor,
+) -> Optional[torch.Tensor]:
+    """Use the length-masked kernel only when producer and consumer agree."""
+
+    if not envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH.get():
+        return None
+
+    if _preload_failure is not None:
+        _raise_unavailable(_preload_failure)
+
+    reason = _input_gate_miss_reason(
+        is_hcu=is_hcu,
+        page_size=page_size,
+        q=q,
+        fused_kv_cache=fused_kv_cache,
+        weights=weights,
+        context_lens=context_lens,
+        block_table=block_table,
+        schedule_meta=schedule_meta,
+        max_context_len=max_context_len,
+    )
+    if reason is not None:
+        _raise_unavailable(reason)
+
+    reason = _consumer_gate_miss_reason(
+        fuse_topk=fuse_topk,
+        force_unfused_topk=force_unfused_topk,
+        topk_transform_method_name=topk_transform_method_name,
+        index_topk=index_topk,
+        score_context_lens=context_lens,
+        topk_context_lens=topk_context_lens,
+    )
+    if reason is not None:
+        # Forward modes may use different TopK metadata. A mismatch must use the
+        # regular kernel, which initializes all logits before that consumer.
+        _log_consumer_fallback(reason)
+        return None
+
+    operation = _selected_operation
+    if _preloaded_hardware is None or operation is None:
+        _raise_unavailable("packaged LightOp operation was not preloaded")
+
+    try:
+        resolved_ctas = resolve_persistent_ctas(
+            envs.SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS.get(),
+            batch_size=q.shape[0],
+            max_context_len=max_context_len,
+        )
+    except ValueError as error:
+        _raise_unavailable(str(error))
+
+    logits = operation(
+        q,
+        fused_kv_cache,
+        weights,
+        context_lens,
+        block_table,
+        schedule_meta,
+        max_context_len,
+        True,
+        4,
+        resolved_ctas,
+    )
+    _log_hit_once(
+        q_rows=q.shape[0],
+        max_context_len=max_context_len,
+        resolved_ctas=resolved_ctas,
+    )
+    return logits

--- a/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from enum import Enum
 
-from sglang.srt.utils import is_hip, is_sm100_supported
+from sglang.srt.utils import is_hcu, is_hip, is_sm100_supported
 
 
 class DSAPagedMQALogitsBackend(Enum):
     DEEPGEMM = "deepgemm"
     CUTEDSL = "cutedsl"
     AITER = "aiter"
+    LIGHTOP = "lightop"
 
     def is_deepgemm(self) -> bool:
         return self == DSAPagedMQALogitsBackend.DEEPGEMM
@@ -19,8 +20,21 @@ class DSAPagedMQALogitsBackend(Enum):
     def is_aiter(self) -> bool:
         return self == DSAPagedMQALogitsBackend.AITER
 
+    def is_lightop(self) -> bool:
+        return self == DSAPagedMQALogitsBackend.LIGHTOP
+
     @staticmethod
     def resolve(value: str) -> DSAPagedMQALogitsBackend:
+        # HCU reports itself as a HIP platform, but its DSA indexer uses the
+        # LightOp page-64 layout rather than AITER's ROCm layout.
+        if is_hcu():
+            if value not in ("auto", "lightop"):
+                raise ValueError(
+                    f"dsa_paged_mqa_logits_backend={value!r} is not supported on "
+                    "HCU; only 'lightop' is implemented."
+                )
+            return DSAPagedMQALogitsBackend.LIGHTOP
+
         if is_hip():
             if value not in ("auto", "aiter"):
                 raise ValueError(
@@ -33,6 +47,8 @@ class DSAPagedMQALogitsBackend(Enum):
             return DSAPagedMQALogitsBackend.DEEPGEMM
         if value == "aiter":
             raise ValueError("dsa_paged_mqa_logits_backend='aiter' requires ROCm.")
+        if value == "lightop":
+            raise ValueError("dsa_paged_mqa_logits_backend='lightop' requires HCU.")
         if value == "cutedsl":
             if not is_sm100_supported():
                 raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -220,7 +220,8 @@ HCU_DSA_PREFILL_BACKEND_CHOICES = {"flashmla_sparse", "flashmla_kv", "flashmla_a
 HCU_DSA_DECODE_BACKEND_CHOICES = {"flashmla_sparse", "flashmla_kv"}
 HCU_GENERIC_KV_CACHE_DTYPE_CHOICES = {"auto", "bf16", "bfloat16", "fp8_e5m2"}
 HCU_NATIVE_FP8_KV_CACHE_DTYPE_CHOICES = {
-    *HCU_GENERIC_KV_CACHE_DTYPE_CHOICES, "fp8_e4m3"
+    *HCU_GENERIC_KV_CACHE_DTYPE_CHOICES,
+    "fp8_e4m3",
 }
 HCU_DSA_KV_CACHE_DTYPE_CHOICES = {"auto", "bf16", "bfloat16", "fp8_e4m3"}
 HCU_DSV4_KV_CACHE_DTYPE_CHOICES = HCU_DSA_KV_CACHE_DTYPE_CHOICES
@@ -377,7 +378,13 @@ NSA_CHOICES = DSA_CHOICES  # deprecated alias
 
 DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
 
-DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter"]
+DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = [
+    "auto",
+    "deepgemm",
+    "cutedsl",
+    "aiter",
+    "lightop",
+]
 
 MAMBA_RADIX_CACHE_STRATEGY_CHOICES = [
     "auto",
@@ -1785,7 +1792,7 @@ class ServerArgs:
     dsa_paged_mqa_logits_backend: A[
         str,
         Arg(
-            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only).",
+            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm, LightOp on HCU), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only), 'lightop' (HCU only).",
             choices=DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES,
         ),
         NS("exec.kernel"),
@@ -1826,10 +1833,14 @@ class ServerArgs:
         NS("exec.kernel"),
     ] = "auto"
     pack_paged_kv_to_varlen_min_kv_tokens: A[
-        int, "Minimum total KV tokens for the packed paged-KV auto policy.", NS("exec.kernel")
+        int,
+        "Minimum total KV tokens for the packed paged-KV auto policy.",
+        NS("exec.kernel"),
     ] = 16384
     pack_paged_kv_to_varlen_min_q_tokens: A[
-        int, "Minimum query tokens for the packed paged-KV auto policy.", NS("exec.kernel")
+        int,
+        "Minimum query tokens for the packed paged-KV auto policy.",
+        NS("exec.kernel"),
     ] = 8192
     mamba_backend: A[
         str,

--- a/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
@@ -251,7 +251,8 @@ class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
 
     def test_fused_qk_quant_store_keeps_lightop_scale_contract(self):
         indexer = object.__new__(Indexer)
-        indexer.hidden_size = 256
+        indexer.hidden_size = 6144
+        indexer.head_dim = 128
         indexer.softmax_scale = 0.125
         pool = SimpleNamespace(
             page_size=64,
@@ -281,7 +282,7 @@ class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
             )
 
         self.assertEqual(result, expected)
-        hadamard_scale = 256**-0.5
+        hadamard_scale = 128**-0.5
         lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.assert_called_once_with(
             sentinel.query,
             sentinel.key,

--- a/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
@@ -1,0 +1,301 @@
+"""Unit coverage for the HCU DSA indexer's LightOp contracts."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, sentinel
+
+import torch
+
+from sglang.srt.layers.attention.dsa import dsa_indexer as indexer_module
+from sglang.srt.layers.attention.dsa import paged_mqa_logits_backend as backend_module
+from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
+    DSAPagedMQALogitsBackend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestHCUDSAPagedMQABackend(CustomTestCase):
+    def test_hcu_resolves_before_generic_hip(self):
+        with (
+            patch.object(backend_module, "is_hcu", return_value=True),
+            patch.object(backend_module, "is_hip", return_value=True),
+        ):
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("auto"),
+                DSAPagedMQALogitsBackend.LIGHTOP,
+            )
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("lightop"),
+                DSAPagedMQALogitsBackend.LIGHTOP,
+            )
+            with self.assertRaisesRegex(ValueError, "only 'lightop'"):
+                DSAPagedMQALogitsBackend.resolve("aiter")
+
+    def test_non_hcu_hip_keeps_aiter(self):
+        with (
+            patch.object(backend_module, "is_hcu", return_value=False),
+            patch.object(backend_module, "is_hip", return_value=True),
+        ):
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("auto"),
+                DSAPagedMQALogitsBackend.AITER,
+            )
+
+
+class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
+    def test_qk_prepare_uses_lightop_fused_layernorm_rope(self):
+        indexer = object.__new__(Indexer)
+        indexer.wq_b = MagicMock(return_value=(sentinel.query_projection, None))
+        indexer.wk = MagicMock(return_value=(sentinel.key_projection, None))
+        indexer.head_dim = 128
+        indexer.k_norm = SimpleNamespace(
+            weight=sentinel.norm_weight,
+            bias=sentinel.norm_bias,
+            variance_epsilon=1e-6,
+        )
+        indexer.rotary_emb = SimpleNamespace(cos_sin_cache=sentinel.cos_sin_cache)
+        indexer.dsa_enable_prefill_cp = False
+        query = MagicMock()
+        key = MagicMock(ndim=3)
+        forward_batch = SimpleNamespace(attn_cp_metadata=None)
+        lightop_attention = MagicMock()
+
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(indexer_module, "rearrange", return_value=query),
+            patch.object(
+                indexer_module, "rotate_activation", side_effect=lambda x, **_: x
+            ),
+            patch.object(indexer_module, "is_cp_v2_active", return_value=False),
+            patch.object(
+                indexer_module,
+                "lightop_attention",
+                lightop_attention,
+                create=True,
+            ),
+        ):
+            got_query, got_key, weights_raw = indexer._get_q_k_bf16(
+                sentinel.q_lora,
+                sentinel.x,
+                sentinel.positions,
+                False,
+                forward_batch,
+            )
+
+        self.assertIs(got_query, query)
+        self.assertIs(got_key, key)
+        self.assertIsNone(weights_raw)
+        lightop_attention.fuse_layernorm_rotary_embedding.assert_called_once_with(
+            sentinel.positions,
+            query,
+            key,
+            128,
+            sentinel.cos_sin_cache,
+            False,
+            None,
+            None,
+            sentinel.norm_weight,
+            sentinel.norm_bias,
+            None,
+            None,
+            1e-6,
+        )
+
+    def test_paged_and_ragged_mqa_abis(self):
+        lightop_attention = MagicMock()
+        lightop_attention.paged_mqa_logits.return_value = sentinel.paged_logits
+        lightop_attention.mqa_logits.return_value = sentinel.ragged_logits
+        q = MagicMock()
+        q.unsqueeze.return_value = sentinel.q_next_n
+
+        with patch.object(
+            indexer_module,
+            "lightop_attention",
+            lightop_attention,
+            create=True,
+        ):
+            paged_result = indexer_module._hcu_paged_mqa_logits(
+                q,
+                sentinel.kv_cache,
+                sentinel.weights,
+                sentinel.seqlens,
+                sentinel.block_tables,
+                None,
+                4096,
+            )
+            ragged_result = indexer_module._hcu_mqa_logits(
+                sentinel.q,
+                sentinel.kv,
+                sentinel.weights,
+                sentinel.ks,
+                sentinel.ke,
+                sentinel.kv_scale,
+            )
+
+        self.assertIs(paged_result, sentinel.paged_logits)
+        lightop_attention.paged_mqa_logits.assert_called_once_with(
+            sentinel.q_next_n,
+            sentinel.kv_cache,
+            sentinel.weights,
+            sentinel.seqlens,
+            sentinel.block_tables,
+            None,
+            4096,
+            clean_logits=True,
+        )
+        self.assertIs(ragged_result, sentinel.ragged_logits)
+        lightop_attention.mqa_logits.assert_called_once_with(
+            sentinel.q,
+            sentinel.kv,
+            sentinel.weights,
+            sentinel.ks,
+            sentinel.ke,
+            kv_scale=sentinel.kv_scale,
+            clean_logit=True,
+        )
+
+    def test_paged_cache_layout_selects_bf16_or_fp8(self):
+        indexer = object.__new__(Indexer)
+        indexer.head_dim = 128
+        bf16_cache = torch.empty((2, 64, 1, 128), dtype=torch.bfloat16)
+        bf16_pool = SimpleNamespace(
+            use_fp8_index_k_cache=False,
+            get_index_k_buffer=MagicMock(return_value=bf16_cache),
+        )
+        fp8_raw = torch.empty((2, 64 * 132), dtype=torch.uint8)
+        fp8_pool = SimpleNamespace(
+            use_fp8_index_k_cache=True,
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=fp8_raw),
+        )
+
+        with patch.object(indexer_module, "_is_hcu", True):
+            got_bf16, is_bf16 = indexer._get_hcu_paged_index_k_cache(
+                bf16_pool, layer_id=3
+            )
+            got_fp8, is_fp8_bf16 = indexer._get_hcu_paged_index_k_cache(
+                fp8_pool, layer_id=3
+            )
+
+        self.assertIs(got_bf16, bf16_cache)
+        self.assertTrue(is_bf16)
+        self.assertEqual(got_fp8.shape, (2, 64, 1, 132))
+        self.assertFalse(is_fp8_bf16)
+        bf16_pool.get_index_k_buffer.assert_called_once_with(layer_id=3)
+        fp8_pool.get_index_k_with_scale_buffer.assert_called_once_with(layer_id=3)
+
+    def test_hcu_cache_store_uses_native_layout(self):
+        indexer = object.__new__(Indexer)
+        forward_batch = SimpleNamespace(out_cache_loc=MagicMock())
+        key = sentinel.key
+        bf16_pool = SimpleNamespace(
+            use_fp8_index_k_cache=False,
+            set_index_k_buffer=MagicMock(),
+        )
+        fp8_pool = SimpleNamespace(
+            use_fp8_index_k_cache=True,
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=sentinel.fp8_cache),
+        )
+        lightop_kvcache = MagicMock()
+
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+            patch.object(
+                indexer_module, "get_token_to_kv_pool", return_value=bf16_pool
+            ),
+        ):
+            indexer._store_index_k_cache(forward_batch, layer_id=4, key=key)
+
+        bf16_pool.set_index_k_buffer.assert_called_once_with(
+            layer_id=4,
+            loc=forward_batch.out_cache_loc,
+            index_k=key,
+        )
+        lightop_kvcache.fuse_act_quant_and_store_index_k_cache.assert_not_called()
+
+        contiguous_loc = sentinel.contiguous_loc
+        forward_batch.out_cache_loc.contiguous.return_value = contiguous_loc
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(indexer_module, "_is_fp8_fnuz", False),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+            patch.object(indexer_module, "get_token_to_kv_pool", return_value=fp8_pool),
+        ):
+            indexer._store_index_k_cache(forward_batch, layer_id=4, key=key)
+
+        lightop_kvcache.fuse_act_quant_and_store_index_k_cache.assert_called_once_with(
+            key,
+            sentinel.fp8_cache,
+            contiguous_loc,
+            64,
+            1e-5,
+            False,
+            True,
+        )
+
+    def test_fused_qk_quant_store_keeps_lightop_scale_contract(self):
+        indexer = object.__new__(Indexer)
+        indexer.hidden_size = 256
+        indexer.softmax_scale = 0.125
+        pool = SimpleNamespace(
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=sentinel.fp8_cache),
+        )
+        out_cache_loc = MagicMock()
+        out_cache_loc.contiguous.return_value = sentinel.contiguous_loc
+        expected = (sentinel.q_fp8, sentinel.q_scale, None)
+        lightop_kvcache = MagicMock()
+        lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.return_value = expected
+
+        with (
+            patch.object(indexer_module, "_is_fp8_fnuz", False),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+        ):
+            result = indexer._hcu_fused_qk_quant_and_store(
+                sentinel.query,
+                sentinel.key,
+                pool,
+                layer_id=5,
+                out_cache_loc=out_cache_loc,
+            )
+
+        self.assertEqual(result, expected)
+        hadamard_scale = 256**-0.5
+        lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.assert_called_once_with(
+            sentinel.query,
+            sentinel.key,
+            sentinel.fp8_cache,
+            sentinel.contiguous_loc,
+            64,
+            None,
+            hadamard_scale * 0.125,
+            hadamard_scale,
+            1e-5,
+            False,
+            True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/dsa/test_hcu_persistent_mqa.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_persistent_mqa.py
@@ -1,0 +1,258 @@
+"""Unit coverage for the HCU persistent paged-MQA safety gates."""
+
+import unittest
+from unittest.mock import MagicMock, patch, sentinel
+
+import torch
+
+from sglang.srt.layers.attention.dsa import hcu_persistent_mqa
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _mock_tensor(*, dtype, shape, stride, device=torch.device("cuda:0")):
+    tensor = MagicMock()
+    tensor.dtype = dtype
+    tensor.device = device
+    tensor.shape = shape
+    tensor.dim.return_value = len(shape)
+    tensor.stride.return_value = stride
+    tensor.stride.side_effect = lambda dim=None: stride if dim is None else stride[dim]
+    tensor.is_contiguous.return_value = True
+    return tensor
+
+
+class TestHCUPersistentMQAGates(CustomTestCase):
+    def setUp(self):
+        self.saved_operation = hcu_persistent_mqa._selected_operation
+        self.saved_failure = hcu_persistent_mqa._preload_failure
+        self.saved_hardware = hcu_persistent_mqa._preloaded_hardware
+        hcu_persistent_mqa._selected_operation = None
+        hcu_persistent_mqa._preload_failure = None
+        hcu_persistent_mqa._preloaded_hardware = None
+        hcu_persistent_mqa._logged_hits.clear()
+        hcu_persistent_mqa._logged_misses.clear()
+
+    def tearDown(self):
+        hcu_persistent_mqa._selected_operation = self.saved_operation
+        hcu_persistent_mqa._preload_failure = self.saved_failure
+        hcu_persistent_mqa._preloaded_hardware = self.saved_hardware
+        hcu_persistent_mqa._logged_hits.clear()
+        hcu_persistent_mqa._logged_misses.clear()
+
+    def test_auto_ctas_are_graph_stable_and_bounded(self):
+        self.assertEqual(
+            hcu_persistent_mqa.resolve_persistent_ctas(
+                0, batch_size=8, max_context_len=65536
+            ),
+            256,
+        )
+        self.assertEqual(
+            hcu_persistent_mqa.resolve_persistent_ctas(
+                96, batch_size=8, max_context_len=65536
+            ),
+            96,
+        )
+        with self.assertRaisesRegex(ValueError, r"\[1, 4096\]"):
+            hcu_persistent_mqa.resolve_persistent_ctas(
+                4097, batch_size=8, max_context_len=65536
+            )
+
+    def test_hardware_gate_is_exactly_gfx938_with_64_cus(self):
+        self.assertIsNone(
+            hcu_persistent_mqa._hardware_gate_miss_reason(
+                arch_name="gfx938:sramecc+", num_cus=64
+            )
+        )
+        self.assertIn(
+            "gfx938",
+            hcu_persistent_mqa._hardware_gate_miss_reason(
+                arch_name="gfx936", num_cus=64
+            ),
+        )
+        self.assertIn(
+            "64 CUs",
+            hcu_persistent_mqa._hardware_gate_miss_reason(
+                arch_name="gfx938", num_cus=60
+            ),
+        )
+
+    def test_input_gate_accepts_only_native_fp8_page64_layout(self):
+        batch_size = 2
+        q = _mock_tensor(
+            dtype=torch.float8_e4m3fn,
+            shape=(batch_size, 1, 32, 128),
+            stride=(4096, 4096, 128, 1),
+        )
+        kv_cache = _mock_tensor(
+            dtype=torch.uint8,
+            shape=(4, 64, 1, 132),
+            stride=(8448, 132, 132, 1),
+        )
+        weights = _mock_tensor(
+            dtype=torch.float32,
+            shape=(batch_size, 32),
+            stride=(32, 1),
+        )
+        context_lens = _mock_tensor(
+            dtype=torch.int32,
+            shape=(batch_size,),
+            stride=(1,),
+        )
+        block_table = _mock_tensor(
+            dtype=torch.int32,
+            shape=(batch_size, 4),
+            stride=(4, 1),
+        )
+
+        kwargs = dict(
+            is_hcu=True,
+            page_size=64,
+            q=q,
+            fused_kv_cache=kv_cache,
+            weights=weights,
+            context_lens=context_lens,
+            block_table=block_table,
+            schedule_meta=None,
+            max_context_len=256,
+        )
+        self.assertIsNone(hcu_persistent_mqa._input_gate_miss_reason(**kwargs))
+
+        kv_cache.stride.side_effect = lambda dim=None: (
+            (1, 1, 1, 1) if dim is None else 1
+        )
+        self.assertIn(
+            "packed stride",
+            hcu_persistent_mqa._input_gate_miss_reason(**kwargs),
+        )
+
+    def test_consumer_requires_the_exact_context_length_tensor(self):
+        context_lens = sentinel.context_lens
+        common = dict(
+            fuse_topk=True,
+            force_unfused_topk=False,
+            topk_transform_method_name="PAGED",
+            index_topk=2048,
+            score_context_lens=context_lens,
+        )
+        self.assertIsNone(
+            hcu_persistent_mqa._consumer_gate_miss_reason(
+                **common,
+                topk_context_lens=context_lens,
+            )
+        )
+        self.assertIn(
+            "exact tensor",
+            hcu_persistent_mqa._consumer_gate_miss_reason(
+                **common,
+                topk_context_lens=sentinel.other_context_lens,
+            ),
+        )
+
+    def test_consumer_mismatch_falls_back_without_calling_package(self):
+        operation = MagicMock()
+        hcu_persistent_mqa._selected_operation = operation
+        hcu_persistent_mqa._preloaded_hardware = ("gfx938", 64)
+
+        with (
+            patch.object(
+                hcu_persistent_mqa.envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH,
+                "get",
+                return_value=True,
+            ),
+            patch.object(
+                hcu_persistent_mqa,
+                "_input_gate_miss_reason",
+                return_value=None,
+            ),
+            patch.object(
+                hcu_persistent_mqa,
+                "_consumer_gate_miss_reason",
+                return_value="context_lens mismatch",
+            ),
+        ):
+            result = hcu_persistent_mqa.paged_mqa_logits_length_masked(
+                sentinel.q,
+                sentinel.kv_cache,
+                sentinel.weights,
+                sentinel.context_lens,
+                sentinel.block_table,
+                None,
+                65536,
+                is_hcu=True,
+                page_size=64,
+                fuse_topk=True,
+                force_unfused_topk=False,
+                topk_transform_method_name="PAGED",
+                index_topk=2048,
+                topk_context_lens=sentinel.other_context_lens,
+            )
+
+        self.assertIsNone(result)
+        operation.assert_not_called()
+
+    def test_eligible_call_uses_packaged_operation(self):
+        q = MagicMock()
+        q.shape = (8, 1, 32, 128)
+        operation = MagicMock(return_value=sentinel.logits)
+        hcu_persistent_mqa._selected_operation = operation
+        hcu_persistent_mqa._preloaded_hardware = ("gfx938", 64)
+
+        with (
+            patch.object(
+                hcu_persistent_mqa.envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH,
+                "get",
+                return_value=True,
+            ),
+            patch.object(
+                hcu_persistent_mqa.envs.SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS,
+                "get",
+                return_value=0,
+            ),
+            patch.object(
+                hcu_persistent_mqa,
+                "_input_gate_miss_reason",
+                return_value=None,
+            ),
+            patch.object(
+                hcu_persistent_mqa,
+                "_consumer_gate_miss_reason",
+                return_value=None,
+            ),
+        ):
+            result = hcu_persistent_mqa.paged_mqa_logits_length_masked(
+                q,
+                sentinel.kv_cache,
+                sentinel.weights,
+                sentinel.context_lens,
+                sentinel.block_table,
+                None,
+                65536,
+                is_hcu=True,
+                page_size=64,
+                fuse_topk=True,
+                force_unfused_topk=False,
+                topk_transform_method_name="PAGED",
+                index_topk=2048,
+                topk_context_lens=sentinel.context_lens,
+            )
+
+        self.assertIs(result, sentinel.logits)
+        operation.assert_called_once_with(
+            q,
+            sentinel.kv_cache,
+            sentinel.weights,
+            sentinel.context_lens,
+            sentinel.block_table,
+            None,
+            65536,
+            True,
+            4,
+            256,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

- 增加默认关闭的 HCU LightOp 持久化分页 MQA 快速路径。
- 仅在 gfx938、64 CU、page size 64、原生 FP8 cache 和固定 q/cache/weights 布局全部满足时启用。
- persistent kernel 的 `context_lens` 必须与下游 production TopK 消费的张量为同一对象；consumer 条件不满足时安全回退到普通 LightOp。
- BF16 index cache、非 PAGED TopK、关闭 fused TopK 或不匹配的 forward mode 均保持现有路径。
- 显式开启但硬件、输入布局或 LightOp ABI 不满足时快速报错，避免静默调用错误 kernel。
- 支持 `SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS` 配置固定或自动 persistent CTAs。

## 动机 / 关联

- 关联 Issue：无
- 关联需求/客户：GLM-5.2 HCU DSA indexer 需要在严格受控的 gfx938 原生 FP8 场景降低分页 MQA 调度开销。
- 目标分支：main
- 依赖 PR：#202 HCU LightOp DSA indexer 路径

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 推理无报错 | 未验证 | 统一在 `main_glm52` 集成分支验证 |
| 精度（如涉及） | 未验证 | 重点验证 persistent 命中与 fallback 的结果一致性 |
| 性能（如涉及） | 未验证 | 统一在 `main_glm52` 集成分支验证 |

## 环境快照

<!-- 统一在 main_glm52 集成分支验证时补充 sglang-envinfo 输出 -->

## 影响面

- [x] 仅 HCU/DCU 分支代码，不影响通用路径
- [ ] 改动通用路径
- [x] 涉及算子/kernel