### PR TITLE
feat(glm5): 完善 GLM5.2 HCU 推理支持

### DIFF
--- a/benchmark/kernels/elementwise/benchmark_concat_mla_absorb_q_hcu.py
+++ b/benchmark/kernels/elementwise/benchmark_concat_mla_absorb_q_hcu.py
@@ -1,0 +1,26 @@
+import argparse
+
+import torch
+from sgl_kernel import concat_mla_absorb_q
+
+from sglang.benchmark.bench_utils import run_bench
+
+
+def benchmark(dim_0: int, dim_1: int):
+    q_nope = torch.randn(dim_0, dim_1, 512, device="cuda", dtype=torch.bfloat16)
+    q_rope = torch.randn(dim_0, dim_1, 64, device="cuda", dtype=torch.bfloat16)
+
+    custom_ms, _, _ = run_bench(lambda: concat_mla_absorb_q(q_nope, q_rope))
+    torch_ms, _, _ = run_bench(lambda: torch.cat((q_nope, q_rope), dim=-1))
+    print(
+        f"shape=({dim_0}, {dim_1}) custom={custom_ms:.6f} ms "
+        f"torch={torch_ms:.6f} ms speedup={torch_ms / custom_ms:.2f}x"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dim-0", type=int, default=16)
+    parser.add_argument("--dim-1", type=int, default=128)
+    args = parser.parse_args()
+    benchmark(args.dim_0, args.dim_1)

--- a/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
@@ -42,6 +42,9 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
   m.impl("gelu_and_mul", torch::kCUDA, &gelu_and_mul);
 
+  m.def("concat_mla_absorb_q(Tensor a, Tensor b, Tensor! out) -> ()");
+  m.impl("concat_mla_absorb_q", torch::kCUDA, &concat_mla_absorb_q);
+
   m.def("l2norm(Tensor input, float eps) -> Tensor");
   m.impl("l2norm", torch::kCUDA, &l2norm);
 

--- a/python/sglang/kernels/aot/csrc/elementwise/concat_mla_absorb_q_hcu.cu
+++ b/python/sglang/kernels/aot/csrc/elementwise/concat_mla_absorb_q_hcu.cu
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <hip/hip_runtime.h>
+#include <torch/all.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+constexpr int64_t kALastDim = 512;
+constexpr int64_t kBLastDim = 64;
+constexpr int64_t kOutLastDim = kALastDim + kBLastDim;
+constexpr int64_t kBf16PerVec = 8;
+constexpr int64_t kAVecsPerRow = kALastDim / kBf16PerVec;
+constexpr int64_t kBVecsPerRow = kBLastDim / kBf16PerVec;
+constexpr int kWaveSize = 64;
+constexpr int kThreads = 256;
+constexpr int kWavesPerBlock = kThreads / kWaveSize;
+constexpr int kRowsPerWave = 8;
+constexpr int kRowsPerBlock = kWavesPerBlock * kRowsPerWave;
+
+static_assert(sizeof(uint4) == 16, "uint4 must be a 16-byte vector");
+static_assert(kAVecsPerRow == kWaveSize, "one wave must cover one a row");
+static_assert(kWavesPerBlock == 4, "one block must contain four waves");
+
+__global__ void concat_mla_absorb_q_hcu_kernel(
+    const at::BFloat16* __restrict__ a,
+    const at::BFloat16* __restrict__ b,
+    at::BFloat16* __restrict__ out,
+    int64_t num_rows,
+    int64_t dim_1,
+    int64_t a_stride_0,
+    int64_t a_stride_1,
+    int64_t b_stride_0,
+    int64_t b_stride_1,
+    int64_t out_stride_0,
+    int64_t out_stride_1) {
+  const int lane = threadIdx.x & (kWaveSize - 1);
+  const int wave = threadIdx.x / kWaveSize;
+  const int64_t first_row = static_cast<int64_t>(blockIdx.x) * kRowsPerBlock + wave * kRowsPerWave;
+
+#pragma unroll
+  for (int row_in_wave = 0; row_in_wave < kRowsPerWave; ++row_in_wave) {
+    const int64_t row = first_row + row_in_wave;
+    if (row >= num_rows) return;
+
+    const int64_t idx_0 = row / dim_1;
+    const int64_t idx_1 = row - idx_0 * dim_1;
+    const auto* a_row = a + idx_0 * a_stride_0 + idx_1 * a_stride_1;
+    auto* out_row = out + idx_0 * out_stride_0 + idx_1 * out_stride_1;
+    reinterpret_cast<uint4*>(out_row)[lane] = reinterpret_cast<const uint4*>(a_row)[lane];
+
+    if (lane < kBVecsPerRow) {
+      const auto* b_row = b + idx_0 * b_stride_0 + idx_1 * b_stride_1;
+      reinterpret_cast<uint4*>(out_row)[kAVecsPerRow + lane] = reinterpret_cast<const uint4*>(b_row)[lane];
+    }
+  }
+}
+
+void check_concat_tensor(const at::Tensor& tensor, const char* name, int64_t expected_last_dim) {
+  TORCH_CHECK(tensor.is_cuda(), name, " must be on an HCU device");
+  TORCH_CHECK(tensor.dim() == 3, name, " must be a 3D tensor");
+  TORCH_CHECK(tensor.scalar_type() == at::ScalarType::BFloat16, name, " must have dtype torch.bfloat16");
+  TORCH_CHECK(tensor.size(2) == expected_last_dim, name, ".size(2) must be ", expected_last_dim);
+  TORCH_CHECK(tensor.stride(2) == 1, name, " must be contiguous in its last dimension");
+  TORCH_CHECK(
+      tensor.stride(0) % kBf16PerVec == 0 && tensor.stride(1) % kBf16PerVec == 0,
+      name,
+      " row addresses must be 16-byte aligned");
+  TORCH_CHECK(
+      reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignof(uint4) == 0,
+      name,
+      " base address must be 16-byte aligned");
+}
+
+}  // namespace
+
+void concat_mla_absorb_q(at::Tensor a, at::Tensor b, at::Tensor out) {
+  check_concat_tensor(a, "a", kALastDim);
+  check_concat_tensor(b, "b", kBLastDim);
+  check_concat_tensor(out, "out", kOutLastDim);
+  TORCH_CHECK(a.device() == b.device() && a.device() == out.device(), "all tensors must be on the same device");
+  TORCH_CHECK(
+      a.size(0) == b.size(0) && a.size(0) == out.size(0) && a.size(1) == b.size(1) && a.size(1) == out.size(1),
+      "a, b, and out leading dimensions must match");
+
+  const int64_t num_rows = a.size(0) * a.size(1);
+  if (num_rows == 0) return;
+
+  const int64_t num_blocks = (num_rows + kRowsPerBlock - 1) / kRowsPerBlock;
+  TORCH_CHECK(num_blocks <= std::numeric_limits<uint32_t>::max(), "concat_mla_absorb_q input is too large");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  concat_mla_absorb_q_hcu_kernel<<<static_cast<uint32_t>(num_blocks), kThreads, 0, stream>>>(
+      static_cast<const at::BFloat16*>(a.data_ptr()),
+      static_cast<const at::BFloat16*>(b.data_ptr()),
+      static_cast<at::BFloat16*>(out.data_ptr()),
+      num_rows,
+      a.size(1),
+      a.stride(0),
+      a.stride(1),
+      b.stride(0),
+      b.stride(1),
+      out.stride(0),
+      out.stride(1));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}

--- a/python/sglang/kernels/aot/setup_rocm.py
+++ b/python/sglang/kernels/aot/setup_rocm.py
@@ -50,6 +50,7 @@ sources = [
     "csrc/attention/decode_metadata.cu",
     "csrc/common_extension_rocm.cc",
     "csrc/elementwise/activation.cu",
+    "csrc/elementwise/concat_mla_absorb_q_hcu.cu",
     "csrc/elementwise/deepseek_v4_topk.cu",
     "csrc/elementwise/dsv4_norm_rope.cu",
     "csrc/elementwise/l2norm_kernel.cu",

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -51,12 +51,18 @@ from sglang.kernels.ops.kvcache.kv_indices import (
 from sglang.kernels.ops.kvcache.rope_cache import (
     fused_qk_rope_reshape_and_cache as fused_qk_rope_reshape_and_cache,
 )
-from sglang.srt.utils import is_cuda
+from sglang.srt.environ import envs
+from sglang.srt.utils import is_cuda, is_hcu
 
 _is_cuda = is_cuda()
+_use_hcu_concat_mla_absorb_q = (
+    is_hcu() and envs.SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q.get()
+)
 
 if _is_cuda:
     from sglang.kernels.ops.attention.concat_mla import concat_mla_absorb_q
+elif _use_hcu_concat_mla_absorb_q:
+    from sgl_kernel import concat_mla_absorb_q
 
 
 # When num_kv_heads=1, we have tensors with degenerate strides,
@@ -193,10 +199,22 @@ def mla_quantize_without_rope_for_fp8(
 
 
 def concat_mla_absorb_q_general(q_nope, q_rope):
-    if _is_cuda and q_nope.shape[-1] == 512 and q_rope.shape[-1] == 64:
+    can_use_custom_op = (
+        (_is_cuda or _use_hcu_concat_mla_absorb_q)
+        and q_nope.ndim == q_rope.ndim == 3
+        and q_nope.shape[:-1] == q_rope.shape[:-1]
+        and (q_nope.shape[-1], q_rope.shape[-1]) == (512, 64)
+        and q_nope.dtype == q_rope.dtype == torch.bfloat16
+        and q_nope.is_cuda
+        and q_rope.is_cuda
+        and q_nope.device == q_rope.device
+        and q_nope.stride(-1) == q_rope.stride(-1) == 1
+        and all(stride % 8 == 0 for stride in q_nope.stride()[:-1])
+        and all(stride % 8 == 0 for stride in q_rope.stride()[:-1])
+    )
+    if can_use_custom_op:
         return concat_mla_absorb_q(q_nope, q_rope)
-    else:
-        return torch.cat([q_nope, q_rope], dim=-1)
+    return torch.cat([q_nope, q_rope], dim=-1)
 
 
 @triton.jit

--- a/python/sglang/srt/batch_overlap/single_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/single_batch_overlap.py
@@ -104,6 +104,15 @@ def compute_overlap_args(dispatch_output, alt_stream):
 
     hidden_states = dispatch_output.hidden_states
 
+    # DeepEP normal mode (prefill) returns a contiguous [num_tokens, hidden_dim]
+    # tensor. Its contiguous GroupGEMM/combine path does not implement the
+    # down-GEMM/combine signaling below, which is defined for the 3-D masked
+    # layout used by low-latency decode. The shared expert has already been
+    # overlapped with DeepEP dispatch, so only skip the unsupported second
+    # overlap stage here.
+    if hidden_states.ndim != 3:
+        return None, None, {}
+
     num_local_experts, num_tokens_static, hidden_dim = hidden_states.shape
 
     total_num_sms = torch.cuda.get_device_properties(

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1826,7 +1826,16 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         )
 
         if _is_fake_transfer(decode_req.req, self.scheduler.server_args):
-            pass
+            # Fake PD has no prefill producer. Supply a shape-correct logical
+            # DSA seed only for MTP index-share benchmarking; the normal
+            # request/spec/remap path localizes it for the decode allocator.
+            dsa_seed_dim = self.metadata_buffers.output_dsa_topk_indices_dim
+            if not self.spec_algorithm.is_none() and dsa_seed_dim > 0:
+                output_dsa_topk_indices = torch.zeros(
+                    dsa_seed_dim,
+                    dtype=torch.int32,
+                    device=output_topk_index.device,
+                )
         elif actual_room == 0:
             # Should never happen: _poll_with_metadata_gate already confirmed
             # readiness on all TP ranks. Abort deterministically to avoid

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -844,6 +844,8 @@ class Envs:
     SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH = EnvBool(False)
     SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS = EnvInt(0)
     SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
+    # Opt-in HCU AOT kernel for concatenating absorbed MLA Q components.
+    SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q = EnvBool(False)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)
     SGLANG_DISABLE_DSA_INDEXER_FUSION = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -840,6 +840,9 @@ class Envs:
     SGLANG_DSA_HIP_DISABLE_PRESHUFFLE = EnvBoolWithAlias(
         False, deprecated_name="SGLANG_NSA_HIP_DISABLE_PRESHUFFLE"
     )
+    # Opt-in gfx938 persistent paged-MQA path provided by LightOp.
+    SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH = EnvBool(False)
+    SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS = EnvInt(0)
     SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -631,9 +631,12 @@ def compute_logical_to_rank_dispatch_physical_map(
     ep_rank: int,
     seed: int = 42,
 ):
-    from sglang.srt.runtime_context import get_parallel
+    from sglang.srt.runtime_context import get_exec, get_parallel
 
     r = random.Random(seed)
+    dispatch_policy = get_exec().moe.ep_static_dispatch_policy
+    if dispatch_policy not in ("nearest", "locality_fair"):
+        raise ValueError(f"Unknown static expert dispatch policy: {dispatch_policy}")
 
     device = logical_to_all_physical_map.device
     logical_to_all_physical_map = logical_to_all_physical_map.cpu()
@@ -660,6 +663,19 @@ def compute_logical_to_rank_dispatch_physical_map(
             candidate_physical_expert_ids = _logical_to_all_physical_raw(
                 logical_to_all_physical_map, layer_id, logical_expert_id
             )
+
+            if dispatch_policy == "locality_fair":
+                choices = _assign_locality_fair_experts(
+                    candidate_physical_expert_ids=candidate_physical_expert_ids,
+                    ep_size=ep_size,
+                    num_local_gpu_physical_experts=num_local_gpu_physical_experts,
+                    num_gpus_per_node=num_gpus_per_node,
+                    num_local_node_physical_experts=num_local_node_physical_experts,
+                    r=r,
+                )
+                for moe_ep_rank, choice in enumerate(choices):
+                    result_list[moe_ep_rank][layer_id][logical_expert_id] = choice
+                continue
 
             remaining_ranks = []
             for moe_ep_rank in range(ep_size):
@@ -751,6 +767,135 @@ def _find_nearest_expert(
 
     # 4. At last, leave it as -1 to indicate not found.
     return -1
+
+
+def _assign_locality_fair_experts(
+    candidate_physical_expert_ids: List[int],
+    ep_size: int,
+    num_local_gpu_physical_experts: int,
+    num_gpus_per_node: Optional[int],
+    num_local_node_physical_experts: Optional[int],
+    r: random.Random,
+) -> List[int]:
+    """Build one deterministic static source-rank-to-replica assignment.
+
+    Locality is prioritized before fairness: same GPU, then same node when the
+    topology exposes node boundaries, then remote. Assignment counts are local
+    to this logical expert; they balance static source-rank bindings, not live
+    token or queue load.
+    """
+    if ep_size <= 0:
+        raise ValueError(f"ep_size must be positive, got {ep_size}")
+    if num_local_gpu_physical_experts <= 0:
+        raise ValueError(
+            "num_local_gpu_physical_experts must be positive, got "
+            f"{num_local_gpu_physical_experts}"
+        )
+    if not candidate_physical_expert_ids:
+        raise ValueError("locality_fair requires at least one physical replica")
+    if (num_gpus_per_node is None) != (num_local_node_physical_experts is None):
+        raise ValueError(
+            "num_gpus_per_node and num_local_node_physical_experts must either "
+            "both be set or both be None"
+        )
+
+    num_nodes = None
+    if num_gpus_per_node is not None:
+        if num_gpus_per_node <= 0 or ep_size % num_gpus_per_node != 0:
+            raise ValueError(
+                f"ep_size ({ep_size}) must be divisible by positive "
+                f"num_gpus_per_node ({num_gpus_per_node})"
+            )
+        expected_node_experts = num_local_gpu_physical_experts * num_gpus_per_node
+        if num_local_node_physical_experts != expected_node_experts:
+            raise ValueError(
+                "num_local_node_physical_experts must equal "
+                "num_local_gpu_physical_experts * num_gpus_per_node, got "
+                f"{num_local_node_physical_experts} != {expected_node_experts}"
+            )
+        num_nodes = ep_size // num_gpus_per_node
+
+    assignments = [-1] * ep_size
+    assignment_counts = {
+        physical_expert_id: 0 for physical_expert_id in candidate_physical_expert_ids
+    }
+
+    candidates_by_gpu = [[] for _ in range(ep_size)]
+    candidates_by_node = [[] for _ in range(num_nodes or 0)]
+    for physical_expert_id in candidate_physical_expert_ids:
+        gpu_id = _compute_gpu_id_of_physical_expert(
+            physical_expert_id, num_local_gpu_physical_experts
+        )
+        if physical_expert_id < 0 or gpu_id >= ep_size:
+            max_physical_expert_id = ep_size * num_local_gpu_physical_experts - 1
+            raise ValueError(
+                f"physical expert {physical_expert_id} is outside topology "
+                f"range [0, {max_physical_expert_id}]"
+            )
+        candidates_by_gpu[gpu_id].append(physical_expert_id)
+        if num_nodes is not None:
+            node_id = _compute_node_id_of_physical_expert(
+                physical_expert_id, num_local_node_physical_experts
+            )
+            candidates_by_node[node_id].append(physical_expert_id)
+
+    # A same-GPU replica is always the strongest locality choice.
+    for moe_ep_rank in range(ep_size):
+        if candidates_by_gpu[moe_ep_rank]:
+            choice = _choose_least_assigned_expert(
+                candidates_by_gpu[moe_ep_rank], assignment_counts, r
+            )
+            assignments[moe_ep_rank] = choice
+            assignment_counts[choice] += 1
+
+    # Include same-GPU counts while balancing unassigned ranks within a node.
+    if num_gpus_per_node is not None:
+        for node_id, same_node_physical_expert_ids in enumerate(candidates_by_node):
+            if not same_node_physical_expert_ids:
+                continue
+
+            node_rank_begin = node_id * num_gpus_per_node
+            remaining_ranks = [
+                moe_ep_rank
+                for moe_ep_rank in range(
+                    node_rank_begin, node_rank_begin + num_gpus_per_node
+                )
+                if assignments[moe_ep_rank] == -1
+            ]
+            r.shuffle(remaining_ranks)
+            for moe_ep_rank in remaining_ranks:
+                choice = _choose_least_assigned_expert(
+                    same_node_physical_expert_ids, assignment_counts, r
+                )
+                assignments[moe_ep_rank] = choice
+                assignment_counts[choice] += 1
+
+    # Nodes without a replica, or flat topologies without node affinity, fall
+    # back to all replicas while preserving counts from the locality passes.
+    remaining_ranks = [
+        moe_ep_rank
+        for moe_ep_rank, assignment in enumerate(assignments)
+        if assignment == -1
+    ]
+    r.shuffle(remaining_ranks)
+    for moe_ep_rank in remaining_ranks:
+        choice = _choose_least_assigned_expert(
+            candidate_physical_expert_ids, assignment_counts, r
+        )
+        assignments[moe_ep_rank] = choice
+        assignment_counts[choice] += 1
+
+    return assignments
+
+
+def _choose_least_assigned_expert(
+    candidate_physical_expert_ids: List[int],
+    assignment_counts: dict[int, int],
+    r: random.Random,
+) -> int:
+    candidates = candidate_physical_expert_ids.copy()
+    r.shuffle(candidates)
+    return min(candidates, key=assignment_counts.__getitem__)
 
 
 def _fair_choices(arr: List, k: int, r: random.Random) -> List:

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -433,7 +433,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
 
-        hadamard_scale = self.hidden_size**-0.5
+        hadamard_scale = self.head_dim**-0.5
         return lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
             query,
             key,

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -73,10 +73,22 @@ _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 _use_fast_hadamard_transform = get_bool_env_var("SGLANG_USE_FAST_HADAMARD_TRANSFORM")
+_use_hcu_persistent_mqa = _is_hcu and envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH.get()
 
 if _is_hcu:
     from lightop import attention as lightop_attention
     from lightop import kvcache as lightop_kvcache
+
+    if _use_hcu_persistent_mqa:
+        _hcu_persistent_mqa_package_operation = getattr(
+            lightop_attention,
+            "paged_mqa_logits_length_masked",
+            None,
+        )
+        from sglang.srt.layers.attention.dsa.hcu_persistent_mqa import (
+            paged_mqa_logits_length_masked,
+            preload_hcu_persistent_mqa,
+        )
 
     from sglang.kernels.ops.attention.dsa.triton_kernel import (
         fused_get_logits_head_gate_triton,
@@ -379,6 +391,18 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         self.paged_mqa_logits_backend = DSAPagedMQALogitsBackend.resolve(
             get_exec().kernel.dsa_paged_mqa_logits_backend
         )
+        if _use_hcu_persistent_mqa:
+            device_props = torch.cuda.get_device_properties(torch.cuda.current_device())
+            device_arch = getattr(device_props, "gcnArchName", "")
+            if not device_arch:
+                device_arch = device_props.name
+            device_arch = device_arch.split(":")[0]
+            preload_hcu_persistent_mqa(
+                is_hcu=_is_hcu,
+                arch_name=device_arch,
+                num_cus=device_props.multi_processor_count,
+                package_operation=_hcu_persistent_mqa_package_operation,
+            )
 
     @staticmethod
     def _use_hcu_bf16_index_cache(pool) -> bool:
@@ -1020,15 +1044,40 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 active_weights = weights[:q_offset].to(torch.float32)
             else:
                 active_weights = weights[:q_offset]
-            logits = _hcu_paged_mqa_logits(
-                q_fp8[:q_offset],
-                kv_cache,
-                active_weights,
-                seqlens_32,
-                block_tables,
-                schedule_metadata,
-                max_seq_len,
-            )
+            active_q = q_fp8[:q_offset]
+            logits = None
+            if _use_hcu_persistent_mqa and not use_bf16_index_cache:
+                topk_context_lens = metadata.get_seqlens_expanded()
+                logits = paged_mqa_logits_length_masked(
+                    active_q.unsqueeze(1),
+                    kv_cache,
+                    active_weights,
+                    seqlens_32,
+                    block_tables,
+                    schedule_metadata,
+                    max_seq_len,
+                    is_hcu=_is_hcu,
+                    page_size=page_size,
+                    fuse_topk=envs.SGLANG_DSA_FUSE_TOPK.get(),
+                    force_unfused_topk=getattr(metadata, "force_unfused_topk", False),
+                    topk_transform_method_name=getattr(
+                        getattr(metadata, "topk_transform_method", None),
+                        "name",
+                        "",
+                    ),
+                    index_topk=self.index_topk,
+                    topk_context_lens=topk_context_lens,
+                )
+            if logits is None:
+                logits = _hcu_paged_mqa_logits(
+                    active_q,
+                    kv_cache,
+                    active_weights,
+                    seqlens_32,
+                    block_tables,
+                    schedule_metadata,
+                    max_seq_len,
+                )
         else:
             kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
             assert len(kv_cache_fp8.shape) == 2

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -23,6 +23,9 @@ from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
     bcg_dsa_indexer_prefill_split,
     pcg_dsa_indexer_prefill_split,
 )
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
     DSAPagedMQALogitsBackend,
 )
@@ -392,7 +395,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
     def _should_skip_logits_computation(self, forward_batch: ForwardBatch) -> bool:
         if (
-            forward_batch.forward_mode.is_extend_without_speculative()
+            effective_forward_mode(forward_batch).is_extend_without_speculative()
             and forward_batch.seq_lens_cpu is not None
         ):
             max_kv_len = forward_batch.seq_lens_cpu.max().item()
@@ -759,10 +762,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         kv_cache_fp8 = self._get_index_k_read_buffer(get_token_to_kv_pool(), layer_id)
 
         blocksize = page_size
-        if (
-            forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
-        ):
+        forward_mode = effective_forward_mode(forward_batch)
+        if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
             seqlens_32 = metadata.get_seqlens_expanded()
         else:
             seqlens_32 = metadata.get_seqlens_int32()
@@ -778,14 +779,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         next_n = q_offset // B if B > 0 else 0
         use_cute_dsl = (
             self.paged_mqa_logits_backend.is_cutedsl()
-            and not forward_batch.forward_mode.is_draft_extend_v2()
+            and not forward_mode.is_draft_extend_v2()
         )
         dsl_expand_factor, dsl_atom = 1, 1
-        if (
-            use_cute_dsl
-            and forward_batch.forward_mode.is_target_verify()
-            and next_n >= 2
-        ):
+        if use_cute_dsl and forward_mode.is_target_verify() and next_n >= 2:
             assert pick_dsl_expand is not None, "CuTe DSL paged MQA is CUDA-only."
             dsl_expand_factor, dsl_atom = pick_dsl_expand(
                 next_n,
@@ -799,7 +796,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         use_dg_native = (
             not use_cute_dsl
             and _is_cuda
-            and forward_batch.forward_mode.is_target_verify()
+            and forward_mode.is_target_verify()
             and next_n >= 2
             and ctx_2d is not None
             and ctx_2d.shape == (B, next_n)
@@ -850,7 +847,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 q_offset=q_offset,
                 B=B,
                 next_n=next_n,
-                is_target_verify=forward_batch.forward_mode.is_target_verify(),
+                is_target_verify=forward_mode.is_target_verify(),
                 dsl_expand_factor=dsl_expand_factor,
                 dsl_atom=dsl_atom,
                 blocksize=blocksize,
@@ -965,7 +962,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        assert forward_batch.forward_mode.is_extend_without_speculative()
+        assert effective_forward_mode(forward_batch).is_extend_without_speculative()
 
         page_size = get_token_to_kv_pool().page_size
         if _is_hip:
@@ -1177,7 +1174,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         #   - topk_result: pre-allocated padded buffer to fill in place (a downstream
         #     captured graph reads it at a fixed address). None => return a fresh,
         #     naturally-sized tensor.
-        assert forward_batch.forward_mode.is_extend_without_speculative()
+        assert effective_forward_mode(forward_batch).is_extend_without_speculative()
         x_meta = x[0] if isinstance(x, tuple) else x
 
         # Fast path: only compute and store k cache, skip all q and weights ops.
@@ -1537,6 +1534,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             and q_lora.shape[0] <= DUAL_STREAM_TOKEN_THRESHOLD
         )
 
+        # MLP-sync can temporarily expose decode/verify/draft batches as
+        # EXTEND. Indexer routing must stay tied to the algorithmic mode.
+        forward_mode = effective_forward_mode(forward_batch)
+
         # Determine if should skip topk based on sequence length
         # We can only skip the logits computation if cuda graph is not involved
         skip_logits_computation = False
@@ -1613,7 +1614,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             )
             return maybe_capture_indexer_topk(layer_id, result)
 
-        elif enable_dual_stream and forward_batch.forward_mode.is_decode_or_idle():
+        elif enable_dual_stream and forward_mode.is_decode_or_idle():
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
             if not self.use_dsa_indexer_fusion:
@@ -1762,9 +1763,9 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     return maybe_capture_indexer_topk(layer_id, topk_result)
 
             if (
-                forward_batch.forward_mode.is_decode_or_idle()
-                or forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             ):
                 topk_result = self._get_topk_paged(
                     forward_batch, layer_id, q_fp8, weights, metadata

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -72,6 +72,21 @@ _is_hcu = is_hcu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
+_use_fast_hadamard_transform = get_bool_env_var("SGLANG_USE_FAST_HADAMARD_TRANSFORM")
+
+if _is_hcu:
+    from lightop import attention as lightop_attention
+    from lightop import kvcache as lightop_kvcache
+
+    from sglang.kernels.ops.attention.dsa.triton_kernel import (
+        fused_get_logits_head_gate_triton,
+        hadamard_transform_optimized,
+    )
+
+    if _use_fast_hadamard_transform:
+        from fast_hadamard_transform import (
+            hadamard_transform as hcu_fast_hadamard_transform,
+        )
 
 if not _is_npu:
     from sglang.kernels.ops.attention.dsa import (
@@ -91,13 +106,13 @@ if _is_cuda:
 else:
     pick_dsl_expand = None
 
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip and not _is_hcu
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
 # Whether the aiter preshuffle paged-MQA path (page_size=64 + Preshuffle=True +
 # KVBlockSize=64) can be used. Falls back to the legacy page_size=1 / KVBlockSize=1
 # path when the gluon kernel is unavailable (Triton<3.5 and no AOT bundle).
-_use_aiter_preshuffle = aiter_can_use_preshuffle_paged_mqa()
+_use_aiter_preshuffle = not _is_hcu and aiter_can_use_preshuffle_paged_mqa()
 if _use_aiter and not _use_aiter_preshuffle:
     logger.warning(
         "ROCm DSA indexer: aiter preshuffle paged-MQA path is unavailable "
@@ -186,9 +201,49 @@ def _broadcast_indexer_topk_from_rank0(
     return topk_indices
 
 
-def rotate_activation(x: torch.Tensor) -> torch.Tensor:
+def _hcu_paged_mqa_logits(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    seqlens: torch.Tensor,
+    block_tables: torch.Tensor,
+    schedule_metadata: Optional[torch.Tensor],
+    max_seq_len: int,
+) -> torch.Tensor:
+    return lightop_attention.paged_mqa_logits(
+        q.unsqueeze(1),
+        kv_cache,
+        weights,
+        seqlens,
+        block_tables,
+        schedule_metadata,
+        max_seq_len,
+        clean_logits=True,
+    )
+
+
+def _hcu_mqa_logits(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+    kv_scale: Optional[torch.Tensor],
+) -> torch.Tensor:
+    return lightop_attention.mqa_logits(
+        q,
+        kv,
+        weights,
+        ks,
+        ke,
+        kv_scale=kv_scale,
+        clean_logit=True,
+    )
+
+
+def rotate_activation(x: torch.Tensor, apply_scale: bool = True) -> torch.Tensor:
     # from sgl_kernel import hadamard_transform
-    if _is_hip:
+    if _is_hip and not _is_hcu:
         from fast_hadamard_transform import hadamard_transform
     elif _is_xpu:
         from sgl_kernel import hadamard_transform
@@ -199,7 +254,12 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
     assert (
         hidden_size & (hidden_size - 1)
     ) == 0, "Hidden size must be a power of 2 for Hadamard transform."
-    return hadamard_transform(x, scale=hidden_size**-0.5)
+    scale = hidden_size**-0.5 if apply_scale else 1.0
+    if _is_hcu and _use_fast_hadamard_transform:
+        return hcu_fast_hadamard_transform(x, scale=scale)
+    if _is_hcu:
+        return hadamard_transform_optimized(x, scale=scale)
+    return hadamard_transform(x, scale=scale)
 
 
 class Indexer(DSANPUIndexerMixin, BaseFusedOp):
@@ -320,6 +380,74 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             get_exec().kernel.dsa_paged_mqa_logits_backend
         )
 
+    @staticmethod
+    def _use_hcu_bf16_index_cache(pool) -> bool:
+        return _is_hcu and not getattr(pool, "use_fp8_index_k_cache", True)
+
+    @staticmethod
+    def _get_gate_input_tensor(
+        x: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+    ) -> torch.Tensor:
+        if not isinstance(x, tuple):
+            return x
+
+        assert len(x) in (
+            2,
+            3,
+        ), "For tuple input, only (x, x_s) or (x, x_s, y) formats are accepted"
+        x_q, x_s = x[0], x[1]
+        if (
+            x_s is not None
+            and x_q.dim() == 2
+            and x_s.dim() == 2
+            and x_q.shape[0] == x_s.shape[0]
+        ):
+            m, n = x_q.shape
+            ng = x_s.shape[1]
+            if ng > 0 and n % ng == 0:
+                group = n // ng
+                return (
+                    x_q.to(torch.float32)
+                    .view(m, ng, group)
+                    .mul_(x_s.to(torch.float32).unsqueeze(-1))
+                    .view(m, n)
+                    .to(torch.bfloat16)
+                )
+        return x_q.to(torch.bfloat16)
+
+    def _get_bf16_logits_head_gate(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]]
+    ) -> torch.Tensor:
+        weights = self._project_and_scale_head_gates(self._get_gate_input_tensor(x))
+        return weights.unsqueeze(-1) * self.softmax_scale
+
+    def _hcu_fused_qk_quant_and_store(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        pool,
+        layer_id: int,
+        out_cache_loc: torch.Tensor,
+        weights: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        if hasattr(pool, "invalidate_index_buffer_for_layer"):
+            pool.invalidate_index_buffer_for_layer(layer_id)
+
+        hadamard_scale = self.hidden_size**-0.5
+        return lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
+            query,
+            key,
+            pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+            out_cache_loc.contiguous(),
+            pool.page_size,
+            weights,
+            hadamard_scale * self.softmax_scale,
+            hadamard_scale,
+            1e-5,
+            False,
+            not _is_fp8_fnuz,
+        )
+
     @contextlib.contextmanager
     def _with_real_sm_count(self):
         # When pipeline parallelism is enabled, each PP rank initiates a recv operation after the _pp_launch_batch
@@ -369,6 +497,13 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]], q_scale: torch.Tensor
     ):
         weights = self._weights_proj_bf16_in_fp32_out(x)
+        if _is_hcu:
+            return fused_get_logits_head_gate_triton(
+                weights=weights,
+                q_scale=q_scale,
+                n_heads=self.n_heads,
+                softmax_scale=self.softmax_scale,
+            )
         weights = weights * self.n_heads**-0.5
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights
@@ -394,6 +529,11 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         return x if self.use_dsa_indexer_fusion else rotate_activation(x)
 
     def _should_skip_logits_computation(self, forward_batch: ForwardBatch) -> bool:
+        # The HCU path does not use the generic act_quant fallback that powers
+        # the K-only shortcut, so keep query preparation and LightOp storage
+        # together even for short prefill requests.
+        if _is_hcu:
+            return False
         if (
             effective_forward_mode(forward_batch).is_extend_without_speculative()
             and forward_batch.seq_lens_cpu is not None
@@ -409,8 +549,50 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         positions: torch.Tensor,
         enable_dual_stream: bool,
         forward_batch: ForwardBatch,
+        apply_hadamard_scale: bool = True,
     ):
         weights_raw = None
+        if _is_hcu:
+            query, _ = self.wq_b(q_lora)
+            query = rearrange(query, "l (h d) -> l h d", d=self.head_dim)
+            key, _ = self.wk(x)
+            if key.ndim == 2:
+                key = key.view(key.shape[0], -1, self.head_dim)
+
+            lightop_attention.fuse_layernorm_rotary_embedding(
+                positions,
+                query,
+                key,
+                self.head_dim,
+                self._indexer_cos_sin_cache,
+                False,
+                None,
+                None,
+                self.k_norm.weight,
+                getattr(self.k_norm, "bias", None),
+                None,
+                None,
+                self.k_norm.variance_epsilon,
+            )
+            query = rotate_activation(query, apply_scale=apply_hadamard_scale)
+            key = rotate_activation(key, apply_scale=apply_hadamard_scale)
+
+            if is_cp_v2_active(forward_batch):
+                key = get_cp_strategy().materialize_full_indexer_k_cache(
+                    key, forward_batch
+                )
+            elif (
+                forward_batch.attn_cp_metadata is not None
+                and self.dsa_enable_prefill_cp
+            ):
+                key = cp_all_gather_rerange_output(
+                    key.contiguous(),
+                    self.cp_size,
+                    forward_batch,
+                    torch.cuda.current_stream(),
+                )
+            return query, key, weights_raw
+
         if enable_dual_stream:
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
@@ -682,6 +864,20 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             return pool.get_broadcastable_index_k_with_scale_buffer(layer_id)
         return pool.get_index_k_with_scale_buffer(layer_id=layer_id)
 
+    def _get_hcu_paged_index_k_cache(
+        self, pool, layer_id: int
+    ) -> Tuple[torch.Tensor, bool]:
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
+        if use_bf16_index_cache:
+            return pool.get_index_k_buffer(layer_id=layer_id), True
+
+        kv_cache = self._get_index_k_read_buffer(pool, layer_id)
+        assert len(kv_cache.shape) == 2
+        return (
+            kv_cache.view(kv_cache.shape[0], pool.page_size, 1, self.head_dim + 4),
+            False,
+        )
+
     @staticmethod
     def _pad_heads_for_deep_gemm(q_fp8, weights):
         """Pad q and weights to 32 heads when num_heads < 32,
@@ -739,9 +935,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        page_size = get_token_to_kv_pool().page_size
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
         # NOTE(dark): blocksize = 64 is hardcoded in deep_gemm
-        if _is_hip:
+        if _is_hip and not _is_hcu:
             if _use_aiter_preshuffle:
                 assert (
                     page_size % 16 == 0
@@ -753,14 +950,12 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         else:
             assert page_size == 64, "only support page size 64"
         # NOTE(dark): this support extend/decode/decode+graph
-        if _is_hip and not _use_aiter_preshuffle:
+        if _is_hip and not _is_hcu and not _use_aiter_preshuffle:
             block_tables = metadata.get_page_table_1()
         else:
             block_tables = metadata.get_page_table_64()
 
         max_seq_len = block_tables.shape[1] * page_size
-        kv_cache_fp8 = self._get_index_k_read_buffer(get_token_to_kv_pool(), layer_id)
-
         blocksize = page_size
         forward_mode = effective_forward_mode(forward_batch)
         if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
@@ -814,15 +1009,33 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     seqlens_32_2d, blocksize, self.sm_count
                 )
 
-        assert len(kv_cache_fp8.shape) == 2
-        block_kv = page_size
-        num_heads_kv = 1
-        head_dim_with_sf = 132
-        kv_cache_fp8 = kv_cache_fp8.view(
-            kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
-        )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
+
+        if self.paged_mqa_logits_backend.is_lightop():
+            kv_cache, use_bf16_index_cache = self._get_hcu_paged_index_k_cache(
+                pool, layer_id
+            )
+            if use_bf16_index_cache:
+                active_weights = weights[:q_offset].to(torch.float32)
+            else:
+                active_weights = weights[:q_offset]
+            logits = _hcu_paged_mqa_logits(
+                q_fp8[:q_offset],
+                kv_cache,
+                active_weights,
+                seqlens_32,
+                block_tables,
+                schedule_metadata,
+                max_seq_len,
+            )
+        else:
+            kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
+            assert len(kv_cache_fp8.shape) == 2
+            block_kv = page_size
+            kv_cache_fp8 = kv_cache_fp8.view(
+                kv_cache_fp8.shape[0], block_kv, 1, self.head_dim + 4
+            )
 
         if self.paged_mqa_logits_backend.is_aiter():
             logits = aiter_paged_mqa_logits(
@@ -835,6 +1048,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 preshuffle=_use_aiter_preshuffle,
                 kv_block_size=block_kv,
             )
+        elif self.paged_mqa_logits_backend.is_lightop():
+            pass
         elif use_cute_dsl:
             logits = cutedsl_paged_mqa_logits(
                 q_fp8,
@@ -964,8 +1179,9 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         assert effective_forward_mode(forward_batch).is_extend_without_speculative()
 
-        page_size = get_token_to_kv_pool().page_size
-        if _is_hip:
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
+        if _is_hip and not _is_hcu:
             if _use_aiter_preshuffle:
                 assert (
                     page_size % 16 == 0
@@ -984,7 +1200,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         )
         weights = weights.squeeze(-1)
 
-        if _is_hip and not _use_aiter_preshuffle:
+        if _is_hip and not _is_hcu and not _use_aiter_preshuffle:
             block_tables = metadata.get_page_table_1()
         else:
             block_tables = metadata.get_page_table_64()
@@ -1012,26 +1228,41 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         indexer_seq_lens_cpu = metadata.get_indexer_seq_len_cpu()
         seq_len_sum = torch.sum(indexer_seq_lens_cpu).item()
         max_seq_len = torch.max(indexer_seq_lens_cpu).item()
-        k_fp8, k_scale = get_token_to_kv_pool().get_index_k_scale_buffer(
-            layer_id,
-            metadata.get_indexer_seq_len(),
-            block_tables,
-            seq_len_sum,
-            max_seq_len,
-        )
-        if _is_fp8_fnuz:
-            k_fp8 = k_fp8.view(torch.float8_e4m3fnuz)
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
+        if use_bf16_index_cache:
+            kv_bf16 = torch.cat(
+                [
+                    pool.get_index_k_continuous(
+                        layer_id,
+                        int(indexer_seq_lens_cpu[batch_idx].item()),
+                        block_tables[batch_idx],
+                    )
+                    for batch_idx in range(batch_size)
+                ],
+                dim=0,
+            )
+            k_offset = kv_bf16.shape[0]
         else:
-            k_fp8 = k_fp8.view(torch.float8_e4m3fn)
+            k_fp8, k_scale = pool.get_index_k_scale_buffer(
+                layer_id,
+                metadata.get_indexer_seq_len(),
+                block_tables,
+                seq_len_sum,
+                max_seq_len,
+            )
+            if _is_fp8_fnuz:
+                k_fp8 = k_fp8.view(torch.float8_e4m3fnuz)
+            else:
+                k_fp8 = k_fp8.view(torch.float8_e4m3fn)
 
-        k_scale = k_scale.view(torch.float32).squeeze(-1)
-        kv_fp8 = (k_fp8, k_scale)
+            k_scale = k_scale.view(torch.float32).squeeze(-1)
+            kv_fp8 = (k_fp8, k_scale)
+            k_offset = k_fp8.shape[0]
 
         # Check if we need to chunk to avoid OOM
         seq_lens_expanded = metadata.get_seqlens_expanded()
         token_to_batch_idx = metadata.get_token_to_batch_idx()
         q_offset = ks.shape[0]
-        k_offset = k_fp8.shape[0]
         need_chunk, logits_budget_bytes = self._should_chunk_mqa_logits(
             q_offset, k_offset, device_index
         )
@@ -1039,7 +1270,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if not need_chunk:
             assert q_fp8[:q_offset].shape[0] != 0
             with self._with_real_sm_count():
-                if _is_hip:
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8[:q_offset],
+                        kv_bf16,
+                        weights[:q_offset].to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    kv, scale = kv_fp8
+                    logits = _hcu_mqa_logits(
+                        q_fp8[:q_offset],
+                        kv,
+                        weights[:q_offset],
+                        ks,
+                        ke,
+                        kv_scale=scale,
+                    )
+                elif _is_hip:
                     from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 
                     kv, scale = kv_fp8
@@ -1098,7 +1348,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             end = min(start + max_rows, q_offset)
 
             with self._with_real_sm_count():
-                if _is_hip:
+                if use_bf16_index_cache:
+                    logits_chunk = _hcu_mqa_logits(
+                        q_fp8[start:end],
+                        kv_bf16,
+                        weights[start:end].to(torch.float32),
+                        ks[start:end],
+                        ke[start:end],
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    kv, scale = kv_fp8
+                    logits_chunk = _hcu_mqa_logits(
+                        q_fp8[start:end],
+                        kv,
+                        weights[start:end],
+                        ks[start:end],
+                        ke[start:end],
+                        kv_scale=scale,
+                    )
+                elif _is_hip:
                     from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 
                     kv, scale = kv_fp8
@@ -1254,12 +1523,15 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        page_size = get_token_to_kv_pool().page_size
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
         assert page_size == 64, "only support page size 64"
         assert len(weights.shape) == 3
         weights = weights.squeeze(-1)
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
         k_fp8_list = []
         k_scale_list = []
+        k_bf16_list = []
         ks_list = []
         ke_offset_list = []
         offset = 0
@@ -1283,23 +1555,27 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 end_seq_position += pre_chunk_offset
                 if offset == 0 and batch_idx != 0:
                     offset += forward_batch.extend_seq_lens_cpu[batch_idx - 1]
-                k_fp8 = get_token_to_kv_pool().get_index_k_continuous(
+                index_k = pool.get_index_k_continuous(
                     layer_id,
                     end_seq_position,
                     block_tables[batch_idx],
                 )
-                k_scale = get_token_to_kv_pool().get_index_k_scale_continuous(
-                    layer_id,
-                    end_seq_position,
-                    block_tables[batch_idx],
-                )
+                if not use_bf16_index_cache:
+                    k_scale = pool.get_index_k_scale_continuous(
+                        layer_id,
+                        end_seq_position,
+                        block_tables[batch_idx],
+                    )
 
                 extend_seq_len = end_seq_position - start_seq_position
                 ks = torch.full(
                     (extend_seq_len,), offset, dtype=torch.int32, device="cuda"
                 )
-                k_fp8_list.append(k_fp8)
-                k_scale_list.append(k_scale)
+                if use_bf16_index_cache:
+                    k_bf16_list.append(index_k)
+                else:
+                    k_fp8_list.append(index_k)
+                    k_scale_list.append(k_scale)
                 ks_list.append(ks)
                 ke_offset = torch.arange(
                     start_seq_position + 1,
@@ -1314,23 +1590,49 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 actual_seq_q_list.append(actual_seq_q)
                 batch_idx_list.append(batch_idx)
 
-            k_fp8 = torch.cat(k_fp8_list, dim=0).view(torch.float8_e4m3fn)
-            k_scale = torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
-            kv_fp8 = (k_fp8, k_scale)
             ks = torch.cat(ks_list, dim=0)
             ke_offset = torch.cat(ke_offset_list, dim=0)
             ke = ks + ke_offset
             actual_seq_q = torch.cat(actual_seq_q_list, dim=0)
             with self._with_real_sm_count():
-                q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(q_fp8, weights)
-                logits = deep_gemm.fp8_mqa_logits(
-                    q_padded,
-                    kv_fp8,
-                    w_padded,
-                    ks,
-                    ke,
-                    clean_logits=False,
-                )
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        torch.cat(k_bf16_list, dim=0),
+                        weights.to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    k_fp8 = torch.cat(k_fp8_list, dim=0).view(fp8_dtype)
+                    k_scale = (
+                        torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
+                    )
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        k_fp8,
+                        weights,
+                        ks,
+                        ke,
+                        kv_scale=k_scale,
+                    )
+                else:
+                    k_fp8 = torch.cat(k_fp8_list, dim=0).view(torch.float8_e4m3fn)
+                    k_scale = (
+                        torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
+                    )
+                    q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(
+                        q_fp8, weights
+                    )
+                    logits = deep_gemm.fp8_mqa_logits(
+                        q_padded,
+                        (k_fp8, k_scale),
+                        w_padded,
+                        ks,
+                        ke,
+                        clean_logits=False,
+                    )
             topk_result = metadata.topk_transform(
                 logits,
                 self.index_topk,
@@ -1345,20 +1647,11 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 - forward_batch.extend_seq_lens_cpu[0]
                 + kv_len
             )
-            k_fp8 = get_token_to_kv_pool().get_index_k_continuous(
+            index_k = pool.get_index_k_continuous(
                 layer_id,
                 kv_len,
                 block_tables[0],
             )
-            k_scale = get_token_to_kv_pool().get_index_k_scale_continuous(
-                layer_id,
-                kv_len,
-                block_tables[0],
-            )
-
-            k_fp8 = k_fp8.view(torch.float8_e4m3fn)
-            k_scale = k_scale.view(torch.float32).squeeze(-1)
-            kv_fp8 = (k_fp8, k_scale)
             ks = torch.full((actual_seq_q,), offset, dtype=torch.int32, device="cuda")
             ke_offset = torch.arange(
                 (kv_len - actual_seq_q) + 1,
@@ -1369,15 +1662,44 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             ke = ks + ke_offset
 
             with self._with_real_sm_count():
-                q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(q_fp8, weights)
-                logits = deep_gemm.fp8_mqa_logits(
-                    q_padded,
-                    kv_fp8,
-                    w_padded,
-                    ks,
-                    ke,
-                    clean_logits=False,
-                )
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        index_k,
+                        weights.to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                else:
+                    k_scale = pool.get_index_k_scale_continuous(
+                        layer_id,
+                        kv_len,
+                        block_tables[0],
+                    )
+                    k_fp8 = index_k.view(fp8_dtype if _is_hcu else torch.float8_e4m3fn)
+                    k_scale = k_scale.view(torch.float32).squeeze(-1)
+                    if _is_hcu:
+                        logits = _hcu_mqa_logits(
+                            q_fp8,
+                            k_fp8,
+                            weights,
+                            ks,
+                            ke,
+                            kv_scale=k_scale,
+                        )
+                    else:
+                        q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(
+                            q_fp8, weights
+                        )
+                        logits = deep_gemm.fp8_mqa_logits(
+                            q_padded,
+                            (k_fp8, k_scale),
+                            w_padded,
+                            ks,
+                            ke,
+                            clean_logits=False,
+                        )
             actual_seq_q = torch.tensor([actual_seq_q], dtype=torch.int32).to(
                 device="cuda", non_blocking=True
             )
@@ -1416,6 +1738,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
         if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
+            return
+
+        if _is_hcu:
+            if self._use_hcu_bf16_index_cache(pool):
+                pool.set_index_k_buffer(
+                    layer_id=layer_id,
+                    loc=out_cache_loc,
+                    index_k=key,
+                )
+                return
+
+            lightop_kvcache.fuse_act_quant_and_store_index_k_cache(
+                key,
+                pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+                out_cache_loc.contiguous(),
+                pool.page_size,
+                1e-5,
+                False,
+                not _is_fp8_fnuz,
+            )
             return
 
         if (
@@ -1500,9 +1842,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         layer_id: int,
         return_indices: bool = True,
     ) -> Optional[torch.Tensor]:
-        if _is_hip:
+        act_quant = None
+        if _is_hip and not _is_hcu:
             from sglang.kernels.ops.attention.dsa.tilelang_kernel import act_quant
-        elif not _is_npu:
+        elif not _is_npu and not _is_hcu:
             from sglang.kernels.ops.attention.dsa.triton_kernel import act_quant
 
         if TYPE_CHECKING:
@@ -1513,7 +1856,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         x_meta = x[0] if isinstance(x, tuple) else x
 
         in_piecewise_or_breakable_cuda_graph = (
-            _is_in_piecewise_or_breakable_cuda_graph()
+            not _is_hcu and _is_in_piecewise_or_breakable_cuda_graph()
         )
 
         # In piecewise/breakable CUDA graph mode, metadata is fetched inside
@@ -1568,7 +1911,51 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             self.weights_proj, "set_lora", False
         )
 
-        if (
+        if _is_hcu:
+            pool = get_token_to_kv_pool()
+            x_for_gate = self._get_gate_input_tensor(x)
+            if self._use_hcu_bf16_index_cache(pool):
+                q_fp8, key, _ = self._get_q_k_bf16(
+                    q_lora,
+                    x,
+                    positions,
+                    False,
+                    forward_batch=forward_batch,
+                )
+                self._store_index_k_cache(
+                    forward_batch=forward_batch,
+                    layer_id=layer_id,
+                    key=key,
+                )
+                if weights_proj_lora:
+                    weights = (
+                        self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
+                    ).unsqueeze(-1) * self.softmax_scale
+                else:
+                    weights = self._get_bf16_logits_head_gate(x_for_gate)
+            else:
+                query, key, _ = self._get_q_k_bf16(
+                    q_lora,
+                    x,
+                    positions,
+                    False,
+                    forward_batch=forward_batch,
+                    apply_hadamard_scale=False,
+                )
+                q_fp8_raw, q_scale, _ = self._hcu_fused_qk_quant_and_store(
+                    query,
+                    key,
+                    pool,
+                    layer_id,
+                    forward_batch.out_cache_loc,
+                )
+                q_fp8 = q_fp8_raw.view(fp8_dtype)
+                if weights_proj_lora:
+                    gate = self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
+                    weights = self._apply_q_scale_and_softmax_scale(gate, q_scale)
+                else:
+                    weights = self._get_logits_head_gate(x_for_gate, q_scale)
+        elif (
             self.use_dsa_indexer_fusion
             and not in_piecewise_or_breakable_cuda_graph
             and forward_batch.attn_cp_metadata is None

--- a/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
@@ -57,6 +57,28 @@ def can_fuse_flashmla_metadata(
     )
 
 
+def refresh_flashmla_metadata(
+    destination: DSAFlashMLAMetadata,
+    source: DSAFlashMLAMetadata,
+    sli,
+    *,
+    is_hcu: bool,
+) -> DSAFlashMLAMetadata:
+    """Return the metadata wrapper the next forward must retain.
+
+    Tensor metadata is refreshed in-place so captured data pointers stay
+    stable. HCU scheduler objects carry shape-bound mutable state, so callers
+    must retain the fresh source object instead of mutating a sliced temporary
+    wrapper that the forward never reads.
+    """
+
+    if is_hcu:
+        return source
+    destination_view = destination.slice(sli)
+    destination_view.copy_(source)
+    return destination_view
+
+
 def wrap_flashmla_metadata_result(
     result: tuple[Any, Optional[torch.Tensor]], *, is_hcu: bool
 ) -> DSAFlashMLAMetadata:

--- a/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable, Optional
+
+import torch
+
+
+def get_flashmla_op(name: str, *, is_hcu: bool) -> Callable[..., Any]:
+    module_name = "flash_mla.flash_mla_interface" if is_hcu else "sgl_kernel.flash_mla"
+    return getattr(import_module(module_name), name)
+
+
+@dataclass(frozen=True)
+class DSAFlashMLAMetadata:
+    """Metadata needed only by FlashMLA.
+
+    CUDA FlashMLA stores scheduler metadata in tensors. HCU FlashMLA stores it
+    in a mutable backend object and initializes the object's tensor fields on
+    the first kernel invocation.
+    """
+
+    flashmla_metadata: Any
+    num_splits: Optional[torch.Tensor]
+
+    def slice(self, sli) -> DSAFlashMLAMetadata:
+        return DSAFlashMLAMetadata(
+            flashmla_metadata=self.flashmla_metadata,
+            num_splits=(None if self.num_splits is None else self.num_splits[sli]),
+        )
+
+    def copy_(self, other: DSAFlashMLAMetadata) -> None:
+        if isinstance(self.flashmla_metadata, torch.Tensor) and isinstance(
+            other.flashmla_metadata, torch.Tensor
+        ):
+            self.flashmla_metadata.copy_(other.flashmla_metadata)
+        else:
+            object.__setattr__(self, "flashmla_metadata", other.flashmla_metadata)
+
+        if isinstance(self.num_splits, torch.Tensor) and isinstance(
+            other.num_splits, torch.Tensor
+        ):
+            self.num_splits.copy_(other.num_splits)
+        else:
+            object.__setattr__(self, "num_splits", other.num_splits)
+
+
+def can_fuse_flashmla_metadata(
+    *metadatas: Optional[DSAFlashMLAMetadata],
+) -> bool:
+    return all(
+        metadata is not None
+        and isinstance(metadata.flashmla_metadata, torch.Tensor)
+        and isinstance(metadata.num_splits, torch.Tensor)
+        for metadata in metadatas
+    )
+
+
+def wrap_flashmla_metadata_result(
+    result: tuple[Any, Optional[torch.Tensor]], *, is_hcu: bool
+) -> DSAFlashMLAMetadata:
+    flashmla_metadata, num_splits = result
+    if is_hcu:
+        num_splits = getattr(flashmla_metadata, "num_splits", num_splits)
+    return DSAFlashMLAMetadata(
+        flashmla_metadata=flashmla_metadata,
+        num_splits=num_splits,
+    )

--- a/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
+++ b/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 
 def effective_forward_mode(forward_batch):
     """Return the algorithmic mode before MLP-sync remaps it to EXTEND."""
@@ -10,3 +12,50 @@ def effective_forward_mode(forward_batch):
         if original_forward_mode is None
         else original_forward_mode
     )
+
+
+def get_flashmla_kv_valid_rows(forward_batch, num_rows: int) -> Optional[int]:
+    """Return the real prefix length when MLP-sync padded FlashMLA KV rows."""
+
+    forward_mode = effective_forward_mode(forward_batch)
+    planned_batch_size = getattr(forward_batch, "forward_metadata_planned_bs", None)
+    planned_num_tokens = getattr(
+        forward_batch, "forward_metadata_planned_num_tokens", None
+    )
+    original_batch_size = getattr(forward_batch, "_original_batch_size", None)
+    original_num_tokens = getattr(forward_batch, "_original_num_tokens", None)
+
+    has_planned_layout = (
+        planned_batch_size is not None or planned_num_tokens is not None
+    )
+    if has_planned_layout:
+        if not (
+            isinstance(planned_batch_size, int)
+            and isinstance(planned_num_tokens, int)
+            and planned_batch_size == original_batch_size
+        ):
+            return None
+        real_batch_size = planned_batch_size
+        real_num_tokens = planned_num_tokens
+    else:
+        real_batch_size = original_batch_size
+        real_num_tokens = original_num_tokens
+
+    if forward_mode.is_decode_or_idle():
+        spec_info = getattr(forward_batch, "spec_info", None)
+        if getattr(spec_info, "num_tokens_per_req", None) != 1:
+            return None
+        if isinstance(real_batch_size, int) and 0 <= real_batch_size < num_rows:
+            return real_batch_size
+        return None
+
+    if not (forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2()):
+        return None
+    if not (
+        isinstance(real_batch_size, int)
+        and real_batch_size >= 0
+        and isinstance(real_num_tokens, int)
+        and 0 <= real_num_tokens < num_rows
+    ):
+        return None
+    return real_num_tokens

--- a/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
+++ b/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def effective_forward_mode(forward_batch):
+    """Return the algorithmic mode before MLP-sync remaps it to EXTEND."""
+
+    original_forward_mode = getattr(forward_batch, "_original_forward_mode", None)
+    return (
+        forward_batch.forward_mode
+        if original_forward_mode is None
+        else original_forward_mode
+    )

--- a/python/sglang/srt/layers/attention/dsa/hcu_persistent_mqa.py
+++ b/python/sglang/srt/layers/attention/dsa/hcu_persistent_mqa.py
@@ -1,0 +1,367 @@
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime gate for the packaged gfx938 persistent paged-MQA fastpath."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+import torch
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+_EXTENSION_API_NAME = "paged_mqa_logits_length_masked"
+
+_selected_operation: Optional[Callable[..., torch.Tensor]] = None
+_preload_failure: Optional[str] = None
+_preloaded_hardware: Optional[tuple[str, int]] = None
+_logged_hits: set[tuple[int, int, int]] = set()
+_logged_misses: set[str] = set()
+
+
+def resolve_persistent_ctas(
+    configured_ctas: int, *, batch_size: int, max_context_len: int
+) -> int:
+    """Resolve graph-stable persistent grid size from capture-stable shapes."""
+
+    _validate_configured_ctas(configured_ctas)
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if max_context_len <= 0:
+        raise ValueError(f"max_context_len must be positive, got {max_context_len}")
+    if configured_ctas:
+        return configured_ctas
+
+    max_chunks = (max_context_len + 255) // 256
+    batch_aware_floor = max(128, (2048 + batch_size - 1) // batch_size)
+    return min(max_chunks, batch_aware_floor)
+
+
+def _validate_configured_ctas(configured_ctas: int) -> None:
+    if configured_ctas < 0 or configured_ctas > 4096:
+        raise ValueError(
+            "SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS must be 0 (auto) or in "
+            f"[1, 4096], got {configured_ctas}"
+        )
+
+
+def _input_gate_miss_reason(
+    *,
+    is_hcu: bool,
+    page_size: int,
+    q: torch.Tensor,
+    fused_kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    schedule_meta: Any,
+    max_context_len: int,
+) -> Optional[str]:
+    if not is_hcu:
+        return "device backend is not HCU"
+    if page_size != 64:
+        return f"page_size must be 64, got {page_size}"
+    if schedule_meta is not None:
+        return "schedule_meta must be None"
+    if max_context_len <= 0:
+        return f"max_context_len must be positive, got {max_context_len}"
+
+    if q.device.type != "cuda":
+        return f"q must be an HCU/HIP tensor, got device {q.device}"
+    if q.dtype != torch.float8_e4m3fn:
+        return f"q dtype must be float8_e4m3fn, got {q.dtype}"
+    if q.dim() != 4 or tuple(q.shape[1:]) != (1, 32, 128):
+        return f"q shape must be [batch, 1, 32, 128], got {tuple(q.shape)}"
+    if q.shape[0] <= 0:
+        return "q batch size must be positive"
+    if not q.is_contiguous():
+        return "q must be contiguous"
+
+    reference_device = q.device
+    for name, tensor in (
+        ("fused_kv_cache", fused_kv_cache),
+        ("weights", weights),
+        ("context_lens", context_lens),
+        ("block_table", block_table),
+    ):
+        if tensor.device != reference_device:
+            return f"{name} must be on {reference_device}, got {tensor.device}"
+
+    if fused_kv_cache.dtype != torch.uint8:
+        return f"fused_kv_cache dtype must be uint8, got {fused_kv_cache.dtype}"
+    if fused_kv_cache.dim() != 4 or tuple(fused_kv_cache.shape[1:]) != (
+        64,
+        1,
+        132,
+    ):
+        return (
+            "fused_kv_cache shape must be [num_blocks, 64, 1, 132], got "
+            f"{tuple(fused_kv_cache.shape)}"
+        )
+    if fused_kv_cache.shape[0] <= 0:
+        return "fused_kv_cache must contain at least one block"
+    if tuple(fused_kv_cache.stride()) != (8448, 132, 132, 1):
+        return (
+            "fused_kv_cache stride must be [8448, 132, 132, 1], got "
+            f"{tuple(fused_kv_cache.stride())}"
+        )
+
+    batch_size = q.shape[0]
+    if (
+        weights.dtype != torch.float32
+        or weights.dim() != 2
+        or tuple(weights.shape) != (batch_size, 32)
+        or not weights.is_contiguous()
+    ):
+        return (
+            "weights must be contiguous float32 [batch, 32], got "
+            f"dtype={weights.dtype}, shape={tuple(weights.shape)}, "
+            f"contiguous={weights.is_contiguous()}"
+        )
+    if (
+        context_lens.dtype != torch.int32
+        or context_lens.dim() != 1
+        or tuple(context_lens.shape) != (batch_size,)
+        or not context_lens.is_contiguous()
+    ):
+        return (
+            "context_lens must be contiguous int32 [batch], got "
+            f"dtype={context_lens.dtype}, shape={tuple(context_lens.shape)}, "
+            f"contiguous={context_lens.is_contiguous()}"
+        )
+    if (
+        block_table.dtype != torch.int32
+        or block_table.dim() != 2
+        or block_table.shape[0] != batch_size
+        or block_table.shape[1] <= 0
+        or block_table.stride(1) != 1
+    ):
+        return (
+            "block_table must be int32 [batch, pages] with stride(1)=1, got "
+            f"dtype={block_table.dtype}, shape={tuple(block_table.shape)}, "
+            f"stride={tuple(block_table.stride())}"
+        )
+    block_table_capacity = block_table.shape[1] * page_size
+    if max_context_len != block_table_capacity:
+        return (
+            f"max_context_len {max_context_len} must equal block-table capacity "
+            f"{block_table_capacity}"
+        )
+    return None
+
+
+def _hardware_gate_miss_reason(*, arch_name: str, num_cus: int) -> Optional[str]:
+    if not arch_name.startswith("gfx938"):
+        return f"GPU architecture must be gfx938, got {arch_name or 'unknown'}"
+    if num_cus != 64:
+        return f"gfx938 specialization requires 64 CUs, got {num_cus}"
+    return None
+
+
+def _consumer_gate_miss_reason(
+    *,
+    fuse_topk: bool,
+    force_unfused_topk: bool,
+    topk_transform_method_name: str,
+    index_topk: int,
+    score_context_lens: torch.Tensor,
+    topk_context_lens: torch.Tensor,
+) -> Optional[str]:
+    if not fuse_topk:
+        return "SGLANG_DSA_FUSE_TOPK must be enabled"
+    if topk_transform_method_name != "PAGED":
+        return (
+            "metadata.topk_transform_method must be PAGED, got "
+            f"{topk_transform_method_name or 'unknown'}"
+        )
+    if index_topk != 2048:
+        return f"index_topk must be 2048, got {index_topk}"
+    if score_context_lens is not topk_context_lens:
+        topk_consumer = (
+            "fast_topk_v2" if force_unfused_topk else "fast_topk_transform_fused"
+        )
+        return (
+            "MQA context_lens must be the exact tensor consumed by production "
+            f"{topk_consumer}"
+        )
+    return None
+
+
+def _select_package_operation(package_operation: Any) -> None:
+    global _selected_operation
+
+    if _selected_operation is not None:
+        return
+    if not callable(package_operation):
+        raise RuntimeError(
+            "installed LightOp package does not export callable "
+            f"{_EXTENSION_API_NAME}"
+        )
+    _selected_operation = package_operation
+    logger.info("Using packaged LightOp persistent paged-MQA operation")
+
+
+def _raise_unavailable(reason: str) -> None:
+    raise RuntimeError(f"HCU persistent paged-MQA fastpath unavailable: {reason}")
+
+
+def _log_consumer_fallback(reason: str) -> None:
+    if reason not in _logged_misses:
+        _logged_misses.add(reason)
+        logger.warning(
+            "HCU persistent paged-MQA fastpath missed; using production LightOp: %s",
+            reason,
+        )
+
+
+def preload_hcu_persistent_mqa(
+    *,
+    is_hcu: bool,
+    arch_name: str,
+    num_cus: int,
+    package_operation: Any = None,
+) -> None:
+    """Validate and select the packaged LightOp API before graph capture."""
+
+    global _preload_failure, _preloaded_hardware
+
+    if not envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH.get():
+        return
+
+    if _preload_failure is not None:
+        _raise_unavailable(_preload_failure)
+
+    if not is_hcu:
+        reason = "device backend is not HCU"
+    else:
+        reason = _hardware_gate_miss_reason(
+            arch_name=arch_name,
+            num_cus=num_cus,
+        )
+    if reason is not None:
+        _preload_failure = reason
+        _raise_unavailable(reason)
+
+    try:
+        _validate_configured_ctas(envs.SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS.get())
+        _select_package_operation(package_operation)
+        _preloaded_hardware = (arch_name, num_cus)
+    except (RuntimeError, ValueError) as error:
+        _preload_failure = str(error)
+        _raise_unavailable(_preload_failure)
+
+
+def _log_hit_once(*, q_rows: int, max_context_len: int, resolved_ctas: int) -> None:
+    hit_key = (q_rows, max_context_len, resolved_ctas)
+    if hit_key in _logged_hits:
+        return
+    _logged_hits.add(hit_key)
+    logger.info(
+        "HCU persistent paged-MQA fastpath HIT source=lightop-package q_rows=%d "
+        "max_context_len=%d resolved_ctas=%d; kernel writes only the valid "
+        "prefix and downstream production TopK must use the same context_lens",
+        q_rows,
+        max_context_len,
+        resolved_ctas,
+    )
+
+
+def paged_mqa_logits_length_masked(
+    q: torch.Tensor,
+    fused_kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    schedule_meta: Any,
+    max_context_len: int,
+    *,
+    is_hcu: bool,
+    page_size: int,
+    fuse_topk: bool,
+    force_unfused_topk: bool,
+    topk_transform_method_name: str,
+    index_topk: int,
+    topk_context_lens: torch.Tensor,
+) -> Optional[torch.Tensor]:
+    """Use the length-masked kernel only when producer and consumer agree."""
+
+    if not envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH.get():
+        return None
+
+    if _preload_failure is not None:
+        _raise_unavailable(_preload_failure)
+
+    reason = _input_gate_miss_reason(
+        is_hcu=is_hcu,
+        page_size=page_size,
+        q=q,
+        fused_kv_cache=fused_kv_cache,
+        weights=weights,
+        context_lens=context_lens,
+        block_table=block_table,
+        schedule_meta=schedule_meta,
+        max_context_len=max_context_len,
+    )
+    if reason is not None:
+        _raise_unavailable(reason)
+
+    reason = _consumer_gate_miss_reason(
+        fuse_topk=fuse_topk,
+        force_unfused_topk=force_unfused_topk,
+        topk_transform_method_name=topk_transform_method_name,
+        index_topk=index_topk,
+        score_context_lens=context_lens,
+        topk_context_lens=topk_context_lens,
+    )
+    if reason is not None:
+        # Forward modes may use different TopK metadata. A mismatch must use the
+        # regular kernel, which initializes all logits before that consumer.
+        _log_consumer_fallback(reason)
+        return None
+
+    operation = _selected_operation
+    if _preloaded_hardware is None or operation is None:
+        _raise_unavailable("packaged LightOp operation was not preloaded")
+
+    try:
+        resolved_ctas = resolve_persistent_ctas(
+            envs.SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS.get(),
+            batch_size=q.shape[0],
+            max_context_len=max_context_len,
+        )
+    except ValueError as error:
+        _raise_unavailable(str(error))
+
+    logits = operation(
+        q,
+        fused_kv_cache,
+        weights,
+        context_lens,
+        block_table,
+        schedule_meta,
+        max_context_len,
+        True,
+        4,
+        resolved_ctas,
+    )
+    _log_hit_once(
+        q_rows=q.shape[0],
+        max_context_len=max_context_len,
+        resolved_ctas=resolved_ctas,
+    )
+    return logits

--- a/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from enum import Enum
 
-from sglang.srt.utils import is_hip, is_sm100_supported
+from sglang.srt.utils import is_hcu, is_hip, is_sm100_supported
 
 
 class DSAPagedMQALogitsBackend(Enum):
     DEEPGEMM = "deepgemm"
     CUTEDSL = "cutedsl"
     AITER = "aiter"
+    LIGHTOP = "lightop"
 
     def is_deepgemm(self) -> bool:
         return self == DSAPagedMQALogitsBackend.DEEPGEMM
@@ -19,8 +20,21 @@ class DSAPagedMQALogitsBackend(Enum):
     def is_aiter(self) -> bool:
         return self == DSAPagedMQALogitsBackend.AITER
 
+    def is_lightop(self) -> bool:
+        return self == DSAPagedMQALogitsBackend.LIGHTOP
+
     @staticmethod
     def resolve(value: str) -> DSAPagedMQALogitsBackend:
+        # HCU reports itself as a HIP platform, but its DSA indexer uses the
+        # LightOp page-64 layout rather than AITER's ROCm layout.
+        if is_hcu():
+            if value not in ("auto", "lightop"):
+                raise ValueError(
+                    f"dsa_paged_mqa_logits_backend={value!r} is not supported on "
+                    "HCU; only 'lightop' is implemented."
+                )
+            return DSAPagedMQALogitsBackend.LIGHTOP
+
         if is_hip():
             if value not in ("auto", "aiter"):
                 raise ValueError(
@@ -33,6 +47,8 @@ class DSAPagedMQALogitsBackend(Enum):
             return DSAPagedMQALogitsBackend.DEEPGEMM
         if value == "aiter":
             raise ValueError("dsa_paged_mqa_logits_backend='aiter' requires ROCm.")
+        if value == "lightop":
+            raise ValueError("dsa_paged_mqa_logits_backend='lightop' requires HCU.")
         if value == "cutedsl":
             if not is_sm100_supported():
                 raise ValueError(

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -5,6 +5,9 @@ import torch
 import triton
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.dp_attention import DpPaddingMode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     is_in_breakable_cuda_graph,
@@ -143,12 +146,12 @@ def is_graph_dsa_split_op_surface(forward_batch: "ForwardBatch") -> bool:
     return (
         is_cuda()
         and (is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph())
-        and forward_batch.forward_mode.is_extend_without_speculative()
+        and effective_forward_mode(forward_batch).is_extend_without_speculative()
     )
 
 
 def can_dsa_prefill_cp_round_robin_split(forward_batch: "ForwardBatch"):
-    if not forward_batch.forward_mode.is_context_parallel_extend():
+    if not effective_forward_mode(forward_batch).is_context_parallel_extend():
         return False
     cp_size = get_parallel().attn_cp_size
     seq_len = sum(forward_batch.extend_seq_lens_cpu)
@@ -251,7 +254,7 @@ def can_dsa_cp_split(seq_len: int, cp_size: int, use_dsa: bool, forward_batch):
     if (
         cp_size <= 1
         or not use_dsa
-        or not forward_batch.forward_mode.is_context_parallel_extend()
+        or not effective_forward_mode(forward_batch).is_context_parallel_extend()
         or not is_dsa_enable_prefill_cp()
         or sum(forward_batch.extend_seq_lens_cpu) < cp_size
     ):
@@ -325,7 +328,7 @@ def dsa_use_prefill_cp(forward_batch, dsa_enable_prefill_cp=None):
     if (
         forward_batch.attn_cp_metadata is not None
         and dsa_enable_prefill_cp
-        and forward_batch.forward_mode.is_context_parallel_extend()
+        and effective_forward_mode(forward_batch).is_context_parallel_extend()
     ):
         return True
     else:

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -47,6 +47,12 @@ from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
     DSATopKBackend,
     TopkTransformMethod,
 )
+from sglang.srt.layers.attention.dsa.flashmla_backend import (
+    DSAFlashMLAMetadata,
+    can_fuse_flashmla_metadata,
+    get_flashmla_op,
+    wrap_flashmla_metadata_result,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -173,24 +179,6 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
         # view — we want (N_total, 1) regardless.
         seqlens_32 = seqlens_32.reshape(-1)
     return seqlens_32.contiguous().view(-1, 1)
-
-
-@dataclass(frozen=True)
-class DSAFlashMLAMetadata:
-    """Metadata only needed by FlashMLA"""
-
-    flashmla_metadata: torch.Tensor
-    num_splits: torch.Tensor
-
-    def slice(self, sli):
-        return DSAFlashMLAMetadata(
-            flashmla_metadata=self.flashmla_metadata,
-            num_splits=self.num_splits[sli],
-        )
-
-    def copy_(self, other: DSAFlashMLAMetadata):
-        self.flashmla_metadata.copy_(other.flashmla_metadata)
-        self.num_splits.copy_(other.num_splits)
 
 
 @dataclass(frozen=True)
@@ -1740,8 +1728,16 @@ class DeepseekSparseAttnBackend(
         # Track whether fused kernel succeeded
         fused_kernel_succeeded = False
 
-        # Use fused CUDA kernel for all copy operations
-        if not _is_hip:
+        # Use fused CUDA kernel for all copy operations. HCU FlashMLA keeps
+        # scheduler state in a backend object, which the tensor-only fused
+        # copy kernel cannot consume.
+        flashmla_metadata_can_fuse = precomputed.flashmla_metadata is None or (
+            can_fuse_flashmla_metadata(
+                precomputed.flashmla_metadata,
+                metadata.flashmla_metadata,
+            )
+        )
+        if not _is_hip and flashmla_metadata_can_fuse:
             try:
                 from sglang.kernels.ops.attention.fused_metadata_copy import (
                     fused_metadata_copy_cuda,
@@ -2407,16 +2403,21 @@ class DeepseekSparseAttnBackend(
         sm_scale: float,
         topk_length: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+        flash_mla_sparse_fwd = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=_is_hcu)
 
         # FlashMLA sparse kernel requires num_heads to be a multiple of 64 (Hopper) or 128 (Blackwell)
         # When using TP, num_heads might be smaller (e.g., 256//8=32)
         num_tokens, num_heads, head_dim = q_all.shape
 
-        # Determine required padding based on GPU architecture (use cached value)
-        required_padding = 128 if self.device_sm_major >= 10 else 64
-
-        need_padding = num_heads % required_padding != 0
+        # The CUDA kernels require Hopper/Blackwell head padding. HCU's
+        # external FlashMLA implementation accepts the native TP head count.
+        if _is_hcu:
+            required_padding = num_heads
+            need_padding = False
+        else:
+            # Determine required padding based on GPU architecture (use cached value)
+            required_padding = 128 if self.device_sm_major >= 10 else 64
+            need_padding = num_heads % required_padding != 0
 
         if need_padding:
             assert required_padding % num_heads == 0, (
@@ -2811,7 +2812,9 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata,
         page_table_1,
     ) -> torch.Tensor:
-        from sgl_kernel.flash_mla import flash_mla_with_kvcache
+        flash_mla_with_kvcache = get_flashmla_op(
+            "flash_mla_with_kvcache", is_hcu=_is_hcu
+        )
 
         cache_seqlens = metadata.dsa_cache_seqlens_int32
         assert metadata.flashmla_metadata is not None
@@ -3407,24 +3410,22 @@ class DeepseekSparseAttnBackend(
         )
 
     def _compute_flashmla_metadata(self, cache_seqlens: torch.Tensor, seq_len_q: int):
-        from sgl_kernel.flash_mla import get_mla_metadata
+        get_mla_metadata = get_flashmla_op("get_mla_metadata", is_hcu=_is_hcu)
 
         num_heads_q = self.flashmla_kv_num_q_heads
 
-        flashmla_metadata, num_splits = get_mla_metadata(
-            cache_seqlens=cache_seqlens,
-            # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`
-            #      but the name looks like need seq_len_q?
-            num_q_tokens_per_head_k=seq_len_q * num_heads_q // 1,
-            num_heads_k=1,
-            num_heads_q=num_heads_q,
-            is_fp8_kvcache=True,
-            topk=self.dsa_index_topk,
-        )
-
-        return DSAFlashMLAMetadata(
-            flashmla_metadata=flashmla_metadata,
-            num_splits=num_splits,
+        return wrap_flashmla_metadata_result(
+            get_mla_metadata(
+                cache_seqlens=cache_seqlens,
+                # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`
+                #      but the name looks like need seq_len_q?
+                num_q_tokens_per_head_k=seq_len_q * num_heads_q // 1,
+                num_heads_k=1,
+                num_heads_q=num_heads_q,
+                is_fp8_kvcache=True,
+                topk=self.dsa_index_topk,
+            ),
+            is_hcu=_is_hcu,
         )
 
 
@@ -3508,6 +3509,16 @@ class DeepseekSparseAttnMultiStepBackend:
                 for i in range(3):
                     self.attn_backends[i].set_dsa_prefill_impl(forward_batch=None)
 
+                # HCU FlashMLA metadata may be a backend object rather than a
+                # tensor. Fuse it only when every source/destination is a
+                # plain tensor; otherwise copy it with its backend wrapper.
+                fused_flashmla_metadata = can_fuse_flashmla_metadata(
+                    precomputed.flashmla_metadata,
+                    metadata0.flashmla_metadata,
+                    metadata1.flashmla_metadata,
+                    metadata2.flashmla_metadata,
+                )
+
                 # Prepare FlashMLA tensors if needed
                 flashmla_num_splits_src = None
                 flashmla_metadata_src = None
@@ -3518,7 +3529,7 @@ class DeepseekSparseAttnMultiStepBackend:
                 flashmla_metadata_dst1 = None
                 flashmla_metadata_dst2 = None
 
-                if precomputed.flashmla_metadata is not None:
+                if fused_flashmla_metadata:
                     flashmla_num_splits_src = precomputed.flashmla_metadata.num_splits
                     flashmla_metadata_src = (
                         precomputed.flashmla_metadata.flashmla_metadata
@@ -3591,6 +3602,17 @@ class DeepseekSparseAttnMultiStepBackend:
                     precomputed.max_len,
                     precomputed.seqlens_expanded_size,
                 )
+
+                if (
+                    precomputed.flashmla_metadata is not None
+                    and not fused_flashmla_metadata
+                ):
+                    size = precomputed.seqlens_expanded_size
+                    for metadata in (metadata0, metadata1, metadata2):
+                        flashmla_metadata = metadata.flashmla_metadata.slice(
+                            slice(0, size + 1)
+                        )
+                        flashmla_metadata.copy_(precomputed.flashmla_metadata)
 
                 # Copy remaining backends one by one (if > 3 backends)
                 for i in range(3, self.speculative_num_steps - 1):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -55,6 +55,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
 )
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
     effective_forward_mode,
+    get_flashmla_kv_valid_rows,
 )
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
@@ -2158,6 +2159,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                forward_batch=forward_batch,
             )
         elif dsa_impl == "fa3":
             return self._forward_fa3(
@@ -2313,6 +2315,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                forward_batch=forward_batch,
             )
         elif self.dsa_decode_impl == "tilelang":
             # Cat-skip (HIP-only): when caller passes q_rope=None on HIP, q_all
@@ -2811,6 +2814,7 @@ class DeepseekSparseAttnBackend(
         layer,
         metadata: DSAMetadata,
         page_table_1,
+        forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         flash_mla_with_kvcache = get_flashmla_op(
             "flash_mla_with_kvcache", is_hcu=_is_hcu
@@ -2844,24 +2848,49 @@ class DeepseekSparseAttnBackend(
             indices.shape[-1] == self.dsa_index_topk
         )  # requirement of FlashMLA decode kernel
 
-        o, _ = flash_mla_with_kvcache(
-            q=q_input,
-            k_cache=kv_cache,
-            cache_seqlens=cache_seqlens,
-            head_dim_v=v_head_dim,
-            tile_scheduler_metadata=metadata.flashmla_metadata.flashmla_metadata,
-            num_splits=metadata.flashmla_metadata.num_splits,
-            softmax_scale=sm_scale,
-            indices=indices,
-            # doc says it is not used, but if pass in None then error
-            block_table=torch.empty(
-                (q_all.shape[0], 0), dtype=torch.int32, device=q_all.device
-            ),
-            is_fp8_kvcache=True,
-        )
+        # MLP-sync can append synthetic speculative rows. HCU FlashMLA must
+        # only see the real prefix; downstream MLP-sync still needs the padded
+        # output shape, so restore it after the kernel returns.
+        num_total = q_input.shape[0]
+        num_valid = get_flashmla_kv_valid_rows(forward_batch, num_total)
+        needs_repad = _is_hcu and num_valid is not None
+        flashmla_metadata = metadata.flashmla_metadata
+        if needs_repad:
+            q_input = q_input[:num_valid]
+            indices = indices[:num_valid]
+            cache_seqlens = cache_seqlens[:num_valid]
+            if num_valid > 0:
+                flashmla_metadata = self._compute_flashmla_metadata(
+                    cache_seqlens=cache_seqlens,
+                    seq_len_q=1,
+                )
+
+        if needs_repad and num_valid == 0:
+            o = q_input.new_zeros((0, 1, target_q_heads, v_head_dim))
+        else:
+            o, _ = flash_mla_with_kvcache(
+                q=q_input,
+                k_cache=kv_cache,
+                cache_seqlens=cache_seqlens,
+                head_dim_v=v_head_dim,
+                tile_scheduler_metadata=flashmla_metadata.flashmla_metadata,
+                num_splits=flashmla_metadata.num_splits,
+                softmax_scale=sm_scale,
+                indices=indices,
+                # doc says it is not used, but if pass in None then error
+                block_table=torch.empty(
+                    (q_input.shape[0], 0), dtype=torch.int32, device=q_input.device
+                ),
+                is_fp8_kvcache=True,
+            )
+
+        if needs_repad:
+            full_o = o.new_zeros((num_total, *o.shape[1:]))
+            full_o[:num_valid] = o
+            o = full_o
 
         if target_q_heads != num_q_heads:
-            o = o[:, :, :num_q_heads, :]
+            o = o[:, :, :num_q_heads, :].contiguous()
 
         return o
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -51,6 +51,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     DSAFlashMLAMetadata,
     can_fuse_flashmla_metadata,
     get_flashmla_op,
+    refresh_flashmla_metadata,
     wrap_flashmla_metadata_result,
 )
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
@@ -1281,14 +1282,14 @@ class DeepseekSparseAttnBackend(
             seqlens_expanded = cache_seqlens_int32
             dsa_extend_seq_lens_list = [1] * bs
             if self.dsa_decode_impl == "flashmla_kv":
-                flashmla_metadata = self.decode_cuda_graph_metadata[
-                    "flashmla_metadata"
-                ].slice(slice(0, bs + 1))
-                flashmla_metadata.copy_(
+                flashmla_metadata = refresh_flashmla_metadata(
+                    self.decode_cuda_graph_metadata["flashmla_metadata"],
                     self._compute_flashmla_metadata(
                         cache_seqlens=dsa_cache_seqlens_int32,
                         seq_len_q=1,
-                    )
+                    ),
+                    slice(0, bs + 1),
+                    is_hcu=_is_hcu,
                 )
             else:
                 flashmla_metadata = None
@@ -1343,15 +1344,14 @@ class DeepseekSparseAttnBackend(
             dsa_extend_seq_lens_list = [1] * bs * self.speculative_num_draft_tokens
 
             if self.dsa_decode_impl == "flashmla_kv":
-                flashmla_metadata = self.decode_cuda_graph_metadata[
-                    "flashmla_metadata"
-                ].slice(slice(0, bs * self.speculative_num_draft_tokens + 1))
-
-                flashmla_metadata.copy_(
+                flashmla_metadata = refresh_flashmla_metadata(
+                    self.decode_cuda_graph_metadata["flashmla_metadata"],
                     self._compute_flashmla_metadata(
                         cache_seqlens=dsa_cache_seqlens_int32,
                         seq_len_q=1,
-                    )
+                    ),
+                    slice(0, bs * self.speculative_num_draft_tokens + 1),
+                    is_hcu=_is_hcu,
                 )
             else:
                 flashmla_metadata = None
@@ -1697,15 +1697,17 @@ class DeepseekSparseAttnBackend(
             assert metadata.real_page_table is metadata.page_table_1
 
         if self.dsa_decode_impl == "flashmla_kv":
-            flashmla_metadata = metadata.flashmla_metadata.slice(
-                slice(0, seqlens_expanded_size + 1)
-            )
-            flashmla_metadata.copy_(
+            flashmla_metadata = refresh_flashmla_metadata(
+                metadata.flashmla_metadata,
                 self._compute_flashmla_metadata(
                     cache_seqlens=dsa_cache_seqlens,
                     seq_len_q=1,
-                )
+                ),
+                slice(0, seqlens_expanded_size + 1),
+                is_hcu=_is_hcu,
             )
+            if _is_hcu:
+                object.__setattr__(metadata, "flashmla_metadata", flashmla_metadata)
 
         self.forward_metadata = metadata
 
@@ -1850,11 +1852,26 @@ class DeepseekSparseAttnBackend(
                     precomputed.real_page_table
                 )
 
-            # Copy FlashMLA metadata in fallback path
-            if precomputed.flashmla_metadata is not None:
-                size = precomputed.seqlens_expanded_size
-                flashmla_metadata = metadata.flashmla_metadata.slice(slice(0, size + 1))
-                flashmla_metadata.copy_(precomputed.flashmla_metadata)
+        if precomputed.flashmla_metadata is not None and (
+            _is_hcu or not fused_kernel_succeeded
+        ):
+            size = precomputed.seqlens_expanded_size
+            flashmla_source = (
+                self._compute_flashmla_metadata(
+                    cache_seqlens=precomputed.dsa_cache_seqlens,
+                    seq_len_q=1,
+                )
+                if _is_hcu
+                else precomputed.flashmla_metadata
+            )
+            flashmla_metadata = refresh_flashmla_metadata(
+                metadata.flashmla_metadata,
+                flashmla_source,
+                slice(0, size + 1),
+                is_hcu=_is_hcu,
+            )
+            if _is_hcu:
+                object.__setattr__(metadata, "flashmla_metadata", flashmla_metadata)
 
         # Refresh DeepGEMM paged MQA schedule metadata for the actual seqlens of
         # this replay (the captured graph holds stale data otherwise, which can
@@ -3636,11 +3653,31 @@ class DeepseekSparseAttnMultiStepBackend:
                     and not fused_flashmla_metadata
                 ):
                     size = precomputed.seqlens_expanded_size
-                    for metadata in (metadata0, metadata1, metadata2):
-                        flashmla_metadata = metadata.flashmla_metadata.slice(
-                            slice(0, size + 1)
+                    for backend, metadata in zip(
+                        self.attn_backends[:3],
+                        (metadata0, metadata1, metadata2),
+                        strict=True,
+                    ):
+                        flashmla_source = (
+                            backend._compute_flashmla_metadata(
+                                cache_seqlens=precomputed.dsa_cache_seqlens,
+                                seq_len_q=1,
+                            )
+                            if _is_hcu
+                            else precomputed.flashmla_metadata
                         )
-                        flashmla_metadata.copy_(precomputed.flashmla_metadata)
+                        flashmla_metadata = refresh_flashmla_metadata(
+                            metadata.flashmla_metadata,
+                            flashmla_source,
+                            slice(0, size + 1),
+                            is_hcu=_is_hcu,
+                        )
+                        if _is_hcu:
+                            object.__setattr__(
+                                metadata,
+                                "flashmla_metadata",
+                                flashmla_metadata,
+                            )
 
                 # Copy remaining backends one by one (if > 3 backends)
                 for i in range(3, self.speculative_num_steps - 1):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -53,6 +53,9 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     get_flashmla_op,
     wrap_flashmla_metadata_result,
 )
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -765,7 +768,7 @@ class DeepseekSparseAttnBackend(
             req_pool_indices=forward_batch.req_pool_indices,
             seq_lens=forward_batch.seq_lens,
             seq_lens_cpu=seq_lens_cpu,
-            forward_mode=forward_batch.forward_mode,
+            forward_mode=effective_forward_mode(forward_batch),
             spec_info=forward_batch.spec_info,
             out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
             actual_forward_mode=getattr(forward_batch, "actual_forward_mode", None),
@@ -775,8 +778,9 @@ class DeepseekSparseAttnBackend(
         """Init the metadata for a forward pass."""
         batch_size = forward_batch.batch_size
         device = forward_batch.seq_lens.device
+        forward_mode = effective_forward_mode(forward_batch)
 
-        if forward_batch.forward_mode.is_target_verify():
+        if forward_mode.is_target_verify():
             draft_token_num = self.speculative_num_draft_tokens
         else:
             draft_token_num = 0
@@ -805,16 +809,14 @@ class DeepseekSparseAttnBackend(
         dsa_impl_for_batch = (
             self.dsa_decode_impl
             if (
-                forward_batch.forward_mode.is_decode_or_idle()
-                or forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             )
             else self.dsa_prefill_impl
         )
         use_flashmla_kv = (not self.use_mha) and dsa_impl_for_batch == "flashmla_kv"
-        topk_transform_method = self.get_topk_transform_method(
-            forward_batch.forward_mode
-        )
+        topk_transform_method = self.get_topk_transform_method(forward_mode)
         # Batch indices selected when cp enabled: After splitting multiple sequences,
         # a certain cp rank may not have some of these sequences.
         # We use bs_idx_cpu to mark which sequences are finally selected by the current cp rank,
@@ -824,12 +826,12 @@ class DeepseekSparseAttnBackend(
         indexer_seq_lens_cpu = forward_batch.seq_lens_cpu
         indexer_seq_lens = forward_batch.seq_lens
 
-        if forward_batch.forward_mode.is_decode_or_idle():
+        if forward_mode.is_decode_or_idle():
             extend_seq_lens_cpu = [1] * batch_size
             max_seqlen_q = 1
             cu_seqlens_q = self.get_device_int32_arange(batch_size + 1)
             seqlens_expanded = cache_seqlens_int32
-        elif forward_batch.forward_mode.is_target_verify():
+        elif forward_mode.is_target_verify():
             max_seqlen_q = 1
             cu_seqlens_q = torch.arange(
                 0,
@@ -850,7 +852,7 @@ class DeepseekSparseAttnBackend(
             page_table = torch.repeat_interleave(
                 page_table, repeats=self.speculative_num_draft_tokens, dim=0
             )
-        elif forward_batch.forward_mode.is_draft_extend_v2():
+        elif forward_mode.is_draft_extend_v2():
             if forward_batch.extend_prefix_lens_cpu is None:
                 assert forward_batch.extend_prefix_lens is not None
                 forward_batch.extend_prefix_lens_cpu = (
@@ -883,7 +885,7 @@ class DeepseekSparseAttnBackend(
                 sum(extend_seq_lens_cpu),
                 self.speculative_num_draft_tokens,
             )
-            if forward_batch.forward_mode.is_draft_extend_v2():
+            if forward_mode.is_draft_extend_v2():
                 # DRAFT_EXTEND_V2: V2 worker pre-fills draft KV cache with ALL speculated
                 # tokens upfront. All requests extend by the same fixed
                 # (speculative_num_draft_tokens). Use scalar to avoid GPU sync.
@@ -897,7 +899,7 @@ class DeepseekSparseAttnBackend(
                 page_table = torch.repeat_interleave(
                     page_table, repeats=forward_batch.extend_seq_lens, dim=0
                 )
-        elif forward_batch.forward_mode.is_extend():
+        elif forward_mode.is_extend():
             assert (
                 forward_batch.extend_seq_lens_cpu is not None
                 and forward_batch.extend_seq_lens is not None
@@ -999,7 +1001,7 @@ class DeepseekSparseAttnBackend(
                     extend_seq_lens,
                 )
         else:
-            assert False, f"Unsupported {forward_batch.forward_mode = }"
+            assert False, f"Unsupported {forward_mode = }"
 
         indexer_k_start_end, token_to_batch_idx = self._cal_indexer_k_start_end(
             forward_batch, bs_idx_cpu
@@ -1018,12 +1020,12 @@ class DeepseekSparseAttnBackend(
         paged_mqa_schedule_metadata = None
         paged_mqa_ctx_lens_2d = None
         if is_cuda() and (
-            forward_batch.forward_mode.is_decode_or_idle()
-            or forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
+            forward_mode.is_decode_or_idle()
+            or forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
         ):
             paged_mqa_ctx_lens_2d = self._build_paged_mqa_schedule_2d_ctx_lens(
-                forward_batch.forward_mode,
+                forward_mode,
                 cache_seqlens_int32,
                 seqlens_expanded,
                 forward_batch.batch_size,
@@ -1076,7 +1078,7 @@ class DeepseekSparseAttnBackend(
         forward_batch: ForwardBatch,
         bs_idx: Optional[List[int]] = None,
     ):
-        if not forward_batch.forward_mode.is_extend_without_speculative():
+        if not effective_forward_mode(forward_batch).is_extend_without_speculative():
             return None, None
         if forward_batch.batch_size == 0 or (bs_idx is not None and len(bs_idx) == 0):
             empty_t = torch.empty(0, dtype=torch.int32, device=self.device)
@@ -1114,7 +1116,7 @@ class DeepseekSparseAttnBackend(
                 (extend_seq_len,), k_offset, dtype=torch.int32, device=self.device
             )
             kv_len = seq_len
-            if forward_batch.forward_mode.is_target_verify():
+            if effective_forward_mode(forward_batch).is_target_verify():
                 kv_len += self.speculative_num_draft_tokens
             seq_lens_expanded = torch.arange(
                 kv_len - extend_seq_len + 1,
@@ -1897,11 +1899,13 @@ class DeepseekSparseAttnBackend(
         metadata = self.forward_metadata
         assert causal, "DSA is causal only"
 
+        forward_mode = effective_forward_mode(forward_batch)
         dsa_impl = (
             self.dsa_decode_impl
             if (
-                forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             )
             else self.dsa_prefill_impl
         )
@@ -1921,7 +1925,7 @@ class DeepseekSparseAttnBackend(
                 cos_sin_cache,
                 is_neox,
                 llama_4_scaling,
-                is_prefill=True,
+                is_prefill=not forward_mode.is_decode_or_idle(),
             )
 
         if k is not None:
@@ -1970,9 +1974,7 @@ class DeepseekSparseAttnBackend(
             q_rope = q_all[:, :, layer.v_head_dim :]
 
         # NOTE(dark): here, we use page size = 1
-        topk_transform_method = self.get_topk_transform_method(
-            forward_batch.forward_mode
-        )
+        topk_transform_method = self.get_topk_transform_method(forward_mode)
 
         if self.use_fused_topk:
             if topk_indices is not None:
@@ -2003,8 +2005,8 @@ class DeepseekSparseAttnBackend(
                     page_size=1,
                     output_num_tokens=q_nope.shape[0],
                     page_table_is_expanded=(
-                        forward_batch.forward_mode.is_target_verify()
-                        or forward_batch.forward_mode.is_draft_extend_v2()
+                        forward_mode.is_target_verify()
+                        or forward_mode.is_draft_extend_v2()
                     ),
                     cu_seqlens_q=metadata.cu_seqlens_q,
                 )
@@ -2477,7 +2479,8 @@ class DeepseekSparseAttnBackend(
             return False
         # RAGGED routing requires exactly EXTEND (excludes decode/idle, MIXED,
         # target-verify and draft-extend, which use dsa_decode_impl anyway).
-        if forward_batch.forward_mode != ForwardMode.EXTEND:
+        forward_mode = effective_forward_mode(forward_batch)
+        if forward_mode != ForwardMode.EXTEND:
             return False
         # Per-batch dense fallback (il <= threshold) reads bf16 q directly.
         if self.use_mha:
@@ -2490,10 +2493,7 @@ class DeepseekSparseAttnBackend(
             return False
         if is_dsa_enable_prefill_cp():
             return False
-        if (
-            self.get_topk_transform_method(forward_batch.forward_mode)
-            != TopkTransformMethod.RAGGED
-        ):
+        if self.get_topk_transform_method(forward_mode) != TopkTransformMethod.RAGGED:
             return False
         # Mirror the helper's head-padding compatibility check.
         if num_heads % 64 != 0 and 64 % num_heads != 0:
@@ -3216,8 +3216,8 @@ class DeepseekSparseAttnBackend(
                 page_size=1,
                 output_num_tokens=q.shape[0],
                 page_table_is_expanded=(
-                    forward_batch.forward_mode.is_target_verify()
-                    or forward_batch.forward_mode.is_draft_extend_v2()
+                    effective_forward_mode(forward_batch).is_target_verify()
+                    or effective_forward_mode(forward_batch).is_draft_extend_v2()
                 ),
                 cu_seqlens_q=metadata.cu_seqlens_q,
             )
@@ -3326,7 +3326,8 @@ class DeepseekSparseAttnBackend(
             # guarantee correctness.
             self.use_mha = False
         elif (
-            forward_batch and forward_batch.forward_mode.is_extend_without_speculative()
+            forward_batch
+            and effective_forward_mode(forward_batch).is_extend_without_speculative()
         ):
             # Check if sequence meets criteria for MHA_ONE_SHOT
             assert forward_batch.seq_lens_cpu is not None
@@ -3356,7 +3357,7 @@ class DeepseekSparseAttnBackend(
                 if (
                     is_blackwell()
                     and forward_batch is not None
-                    and forward_batch.forward_mode == ForwardMode.EXTEND
+                    and effective_forward_mode(forward_batch) == ForwardMode.EXTEND
                 ):
                     total_kv_tokens = forward_batch.seq_lens_sum
                     total_q_tokens = forward_batch.extend_num_tokens
@@ -3394,15 +3395,13 @@ class DeepseekSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:
+        forward_mode = effective_forward_mode(forward_batch)
         force_unfused = not self.use_fused_topk or (
-            self.hisparse_coordinator is not None
-            and forward_batch.forward_mode.is_decode_or_idle()
+            self.hisparse_coordinator is not None and forward_mode.is_decode_or_idle()
         )
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,
-            topk_transform_method=self.get_topk_transform_method(
-                forward_batch.forward_mode
-            ),
+            topk_transform_method=self.get_topk_transform_method(forward_mode),
             topk_backend=self.dsa_topk_backend,
             paged_mqa_schedule_metadata=self.forward_metadata.paged_mqa_schedule_metadata,
             paged_mqa_ctx_lens_2d=self.forward_metadata.paged_mqa_ctx_lens_2d,

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -1178,11 +1178,13 @@ class DeepEPMoE(FusedMoE):
             q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant(
                 gateup_output,
                 fp8type=0,
+                expert_ids=m_indices,
             )
         else:
             q_a2_all, q_a2_scale = fuse_silu_mul_fp8_quant(
                 gateup_output,
                 fp8type=0,
+                expert_ids=m_indices,
                 limit=swiglu_limit,
             )
         del gateup_output

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -46,6 +46,14 @@ from sglang.srt.utils import W8a8GetCacheJSON
 W8A8_TRITONJSON = W8a8GetCacheJSON()
 
 
+def _use_kme_hipblaslt(device: torch.device) -> bool:
+    if device.type != "cuda":
+        return False
+    device_props = torch.cuda.get_device_properties(device)
+    gcn_arch = getattr(device_props, "gcnArchName", "").split(":")[0]
+    return gcn_arch == "gfx928"
+
+
 class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
 
     def __init__(
@@ -119,6 +127,9 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
     def process_weights_after_loading(self, layer) -> None:
         n = layer.weight.shape[0]
         k = layer.weight.shape[1]
+        use_kme_hipblaslt = self.w8a8_strategy == 3 and _use_kme_hipblaslt(
+            layer.weight.device
+        )
 
         if self.w8a8_strategy == 1:
             if [n, k] not in W8A8_TRITONJSON.weight_shapes:
@@ -142,9 +153,6 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
                             best_config=value,
                         )
         elif self.w8a8_strategy == 3:
-            # KME/gfx928 hipBLASLt swapped TN: pack W as col-major [K,N]
-            # stride (1,K). Do not apply the later CHANNEL .t() that would
-            # turn it into contiguous [N,K] for the legacy blaslt path.
             w = layer.weight.data  # [N, K]
             if self.strategy == QuantizationStrategy.TENSOR:
                 max_w_scale, w = requantize_with_max_scale(
@@ -161,9 +169,16 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
             else:
                 raise ValueError(f"Unknown quantization strategy {self.strategy}")
 
-            w_col = torch.empty_strided((k, n), (1, k), device=w.device, dtype=w.dtype)
-            w_col.copy_(w.t().contiguous())
-            layer.weight = Parameter(w_col, requires_grad=False)
+            if use_kme_hipblaslt:
+                # gfx928 KME swapped TN: col-major [K,N], stride (1,K).
+                packed_weight = torch.empty_strided(
+                    (k, n), (1, k), device=w.device, dtype=w.dtype
+                )
+                packed_weight.copy_(w.t().contiguous())
+            else:
+                # gfx936/gfx938 use legacy NT with contiguous [N,K].
+                packed_weight = w.contiguous()
+            layer.weight = Parameter(packed_weight, requires_grad=False)
 
             W8A8_TRITONJSON.gen_model_json()
 
@@ -190,8 +205,13 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
                 layer.input_zero_point = None
 
             if not self.input_symmetric:
-                # W is [K,N] col-major; AZP adj is sum over K -> [1,N]
-                azp_adj = layer.weight.sum(dim=0, keepdim=True, dtype=torch.int32)
+                # AZP adjustment is the reduction over K, normalized to [1,N].
+                if use_kme_hipblaslt:
+                    azp_adj = layer.weight.sum(dim=0, keepdim=True, dtype=torch.int32)
+                else:
+                    azp_adj = layer.weight.sum(
+                        dim=1, keepdim=False, dtype=torch.int32
+                    ).unsqueeze(0)
                 if self.is_static_input_scheme:
                     azp_adj = layer.input_zero_point * azp_adj
                 layer.azp_adj = Parameter(azp_adj, requires_grad=False)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -378,7 +378,13 @@ NSA_CHOICES = DSA_CHOICES  # deprecated alias
 
 DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
 
-DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter"]
+DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = [
+    "auto",
+    "deepgemm",
+    "cutedsl",
+    "aiter",
+    "lightop",
+]
 
 MAMBA_RADIX_CACHE_STRATEGY_CHOICES = [
     "auto",
@@ -1786,7 +1792,7 @@ class ServerArgs:
     dsa_paged_mqa_logits_backend: A[
         str,
         Arg(
-            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only).",
+            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm, LightOp on HCU), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only), 'lightop' (HCU only).",
             choices=DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES,
         ),
         NS("exec.kernel"),

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -220,7 +220,8 @@ HCU_DSA_PREFILL_BACKEND_CHOICES = {"flashmla_sparse", "flashmla_kv", "flashmla_a
 HCU_DSA_DECODE_BACKEND_CHOICES = {"flashmla_sparse", "flashmla_kv"}
 HCU_GENERIC_KV_CACHE_DTYPE_CHOICES = {"auto", "bf16", "bfloat16", "fp8_e5m2"}
 HCU_NATIVE_FP8_KV_CACHE_DTYPE_CHOICES = {
-    *HCU_GENERIC_KV_CACHE_DTYPE_CHOICES, "fp8_e4m3"
+    *HCU_GENERIC_KV_CACHE_DTYPE_CHOICES,
+    "fp8_e4m3",
 }
 HCU_DSA_KV_CACHE_DTYPE_CHOICES = {"auto", "bf16", "bfloat16", "fp8_e4m3"}
 HCU_DSV4_KV_CACHE_DTYPE_CHOICES = HCU_DSA_KV_CACHE_DTYPE_CHOICES
@@ -1826,10 +1827,14 @@ class ServerArgs:
         NS("exec.kernel"),
     ] = "auto"
     pack_paged_kv_to_varlen_min_kv_tokens: A[
-        int, "Minimum total KV tokens for the packed paged-KV auto policy.", NS("exec.kernel")
+        int,
+        Arg(help="Minimum total KV tokens for the packed paged-KV auto policy."),
+        NS("exec.kernel"),
     ] = 16384
     pack_paged_kv_to_varlen_min_q_tokens: A[
-        int, "Minimum query tokens for the packed paged-KV auto policy.", NS("exec.kernel")
+        int,
+        Arg(help="Minimum query tokens for the packed paged-KV auto policy."),
+        NS("exec.kernel"),
     ] = 8192
     mamba_backend: A[
         str,
@@ -2386,6 +2391,20 @@ class ServerArgs:
         "The algorithm to choose ranks for redundant experts in expert parallel.",
         NS("exec.moe"),
     ] = None
+    ep_static_dispatch_policy: A[
+        Literal["nearest", "locality_fair"],
+        Arg(
+            help=(
+                "Choose the replica-selection policy for static expert dispatch. "
+                "`nearest` preserves the legacy nearest-replica behavior. "
+                "`locality_fair` builds a deterministic source-rank-to-replica map "
+                "that preserves same-GPU, then same-node locality while balancing "
+                "static bindings among equally local replicas; it does not rebalance "
+                "live token traffic."
+            )
+        ),
+        NS("exec.moe"),
+    ] = "nearest"
     init_expert_location: A[str, "Initial location of EP experts.", NS("exec.moe")] = (
         "trivial"
     )
@@ -6878,6 +6897,12 @@ class ServerArgs:
         return required
 
     def _handle_eplb_and_dispatch(self):
+        if self.ep_static_dispatch_policy not in ("nearest", "locality_fair"):
+            raise ValueError(
+                "--ep-static-dispatch-policy must be one of "
+                "'nearest' or 'locality_fair'."
+            )
+
         if self.enable_eplb and (self.expert_distribution_recorder_mode is None):
             self.expert_distribution_recorder_mode = "stat"
             logger.warning(
@@ -6893,6 +6918,16 @@ class ServerArgs:
         ):
             self.ep_dispatch_algorithm = (
                 "dynamic" if needs_rank_invariant_dispatch else "static"
+            )
+
+        if (
+            self.ep_static_dispatch_policy != "nearest"
+            and self.ep_dispatch_algorithm != "static"
+        ):
+            raise ValueError(
+                "--ep-static-dispatch-policy locality_fair requires "
+                "--ep-dispatch-algorithm static. It configures a startup-time "
+                "source-rank-to-replica map, not dynamic token balancing."
             )
 
         # `dynamic` / `fake` switch to the row-index pick; `static` reads a

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -120,6 +120,7 @@ from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_cpu,
     is_cuda,
+    is_hcu,
     is_hip,
     is_musa,
     is_npu,
@@ -131,12 +132,18 @@ from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_musa = is_musa()
 _is_hip = is_hip()
 _is_xpu = is_xpu()
 
 
 logger = logging.getLogger(__name__)
+
+
+def _supports_cuda_graph_runner() -> bool:
+    """Whether this platform uses the CUDA-style EAGLE graph runners."""
+    return _is_cuda or _is_hcu or _is_musa
 
 
 class EagleDraftWorker(EagleDraftWorkerBase):
@@ -436,9 +443,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             TokenspeedMLABackend,
             FlashInferAttnBackend,
         ]
-        if _is_cuda or _is_musa:
-            # DSA is CUDA-only; import lazily so non-CUDA builds don't pull in
-            # deep_gemm and the rest of the sparse-attention stack at import time.
+        if _supports_cuda_graph_runner():
+            # Import lazily so unsupported platforms do not pull in the sparse
+            # attention stack at module import time.
             from sglang.srt.layers.attention.dsa_backend import (
                 DeepseekSparseAttnBackend,
             )
@@ -461,8 +468,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             tuple(graph_supported_backend_types),
         )
         supports_cuda_draft_extend_graph = (
-            _is_cuda or _is_musa
-        ) and graph_supported_backend
+            _supports_cuda_graph_runner() and graph_supported_backend
+        )
         # Capture extend
         # TODO: support draft extend cuda graph for more attention backends
         if (

--- a/test/registered/hcu/kernels/test_concat_mla_absorb_q_hcu.py
+++ b/test/registered/hcu/kernels/test_concat_mla_absorb_q_hcu.py
@@ -1,0 +1,40 @@
+import unittest
+
+import torch
+from sgl_kernel import concat_mla_absorb_q
+
+from sglang.test.ci.ci_register import register_hcu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_hcu_ci(est_time=30, suite="stage-b-test-1-hcu-small")
+
+
+class TestConcatMlaAbsorbQHcu(CustomTestCase):
+    def test_matches_torch_cat(self):
+        for dim_0, dim_1 in ((1, 1), (1, 5), (4, 16), (9, 7)):
+            with self.subTest(dim_0=dim_0, dim_1=dim_1):
+                q_nope = torch.randn(
+                    dim_0, dim_1, 512, device="cuda", dtype=torch.bfloat16
+                )
+                q_rope = torch.randn(
+                    dim_0, dim_1, 64, device="cuda", dtype=torch.bfloat16
+                )
+                expected = torch.cat((q_nope, q_rope), dim=-1)
+                actual = concat_mla_absorb_q(q_nope, q_rope)
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_supports_aligned_non_contiguous_rows(self):
+        q_nope_storage = torch.randn(3, 11, 520, device="cuda", dtype=torch.bfloat16)
+        q_rope_storage = torch.randn(3, 11, 72, device="cuda", dtype=torch.bfloat16)
+        q_nope = q_nope_storage[..., :512]
+        q_rope = q_rope_storage[..., :64]
+        self.assertFalse(q_nope.is_contiguous())
+        self.assertFalse(q_rope.is_contiguous())
+
+        actual = concat_mla_absorb_q(q_nope, q_rope)
+        expected = torch.cat((q_nope, q_rope), dim=-1)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/batch_overlap/test_sbo_deepep_normal_dispatch.py
+++ b/test/registered/unit/batch_overlap/test_sbo_deepep_normal_dispatch.py
@@ -1,0 +1,33 @@
+"""Regression test for DeepEP normal-mode SBO overlap arguments."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.batch_overlap.single_batch_overlap import SboFlags, compute_overlap_args
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestSboDeepEPNormalDispatch(CustomTestCase):
+    @patch.object(
+        SboFlags, "enable_combine_shared_two_stream_overlap", return_value=False
+    )
+    @patch.object(
+        SboFlags, "enable_combine_down_gemm_two_stream_overlap", return_value=True
+    )
+    def test_2d_dispatch_skips_secondary_overlap(self, _down_enabled, _shared_enabled):
+        dispatch_output = SimpleNamespace(hidden_states=torch.empty((4, 16)))
+
+        self.assertEqual(
+            compute_overlap_args(dispatch_output, alt_stream=None),
+            (None, None, {}),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -2,13 +2,15 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import torch
+
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.decode import (
     DecodePreallocQueue,
     DecodeTransferQueue,
     HiCacheRestoreResult,
 )
-from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.disaggregation.utils import DisaggregationMode, MetadataBuffers
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.managers.scheduler import Scheduler
@@ -30,6 +32,47 @@ class FakeReceiver:
 
 
 class TestDecodeQueueCleanup(CustomTestCase):
+    def test_fake_transfer_supplies_logical_dsa_seed_for_mtp(self):
+        buffers = MetadataBuffers(
+            size=1,
+            hidden_size=2,
+            hidden_states_dtype=torch.float32,
+            output_dsa_topk_indices_dim=3,
+        )
+        req = SimpleNamespace(
+            rid="fake-mtp-seed",
+            bootstrap_host=None,
+            bootstrap_room=7,
+            output_ids=[],
+            pd_rebootstrap_forced_output_id=None,
+            return_logprob=False,
+            return_sampling_mask=False,
+            time_stats=MagicMock(),
+        )
+        receiver = FakeReceiver()
+        decode_req = SimpleNamespace(
+            req=req,
+            kv_receiver=receiver,
+            metadata_buffer_index=0,
+            is_rebootstrap=False,
+        )
+
+        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+        queue.metadata_buffers = buffers
+        queue.spec_algorithm = MagicMock()
+        queue.spec_algorithm.is_none.return_value = False
+        queue.scheduler = SimpleNamespace(
+            server_args=SimpleNamespace(disaggregation_transfer_backend="fake")
+        )
+        queue._commit_hicache_local_restore_to_req = MagicMock()
+
+        queue._commit_transfer_to_req(decode_req)
+
+        self.assertEqual(req.output_dsa_topk_indices.tolist(), [0, 0, 0])
+        self.assertEqual(req.output_dsa_topk_indices.dtype, torch.int32)
+        self.assertTrue(receiver.clear_called)
+        self.assertIsNone(decode_req.kv_receiver)
+
     def test_paged_swa_retraction_resume_uses_physical_page_budget(self):
         page_size = 128
         fill_len = 574

--- a/test/registered/unit/eplb/test_compute_logical_to_rank_dispatch_physical_map.py
+++ b/test/registered/unit/eplb/test_compute_logical_to_rank_dispatch_physical_map.py
@@ -5,15 +5,19 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 
 import unittest
+from collections import Counter
+from random import Random
 
 import torch
 
 from sglang.srt.eplb.expert_location import (
+    _assign_locality_fair_experts,
     _compute_logical_to_all_physical_map,
     append_trivial_expert_slots,
     compute_logical_to_rank_dispatch_physical_map,
 )
 from sglang.srt.runtime_context import get_context
+from sglang.srt.server_args import ServerArgs
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -22,6 +26,7 @@ def _published(
     nnodes: int,
     moe_a2a_backend: str = "deepep",
     ep_join_mode=None,
+    ep_static_dispatch_policy: str = "nearest",
 ):
     """Scoped publish of the config the placement functions read.
 
@@ -33,6 +38,7 @@ def _published(
         nnodes=nnodes,
         moe_a2a_backend=moe_a2a_backend,
         ep_join_mode=ep_join_mode,
+        ep_static_dispatch_policy=ep_static_dispatch_policy,
     )
 
 
@@ -222,6 +228,143 @@ class TestComputeLogicalToRankDispatchPhysicalMap(CustomTestCase):
             )
 
         self.assertEqual(logical_to_physical[0, :16, 0].tolist(), list(range(64, 80)))
+
+
+class TestLocalityFairStaticDispatch(CustomTestCase):
+    """The policy builds static bindings; it does not inspect live token load."""
+
+    CANDIDATES = [0, 4, 12]
+    EP_SIZE = 8
+    NUM_LOCAL_GPU_EXPERTS = 2
+    NUM_GPUS_PER_NODE = 2
+    NUM_LOCAL_NODE_EXPERTS = 4
+
+    @classmethod
+    def _assign(cls, seed=42):
+        return _assign_locality_fair_experts(
+            candidate_physical_expert_ids=cls.CANDIDATES,
+            ep_size=cls.EP_SIZE,
+            num_local_gpu_physical_experts=cls.NUM_LOCAL_GPU_EXPERTS,
+            num_gpus_per_node=cls.NUM_GPUS_PER_NODE,
+            num_local_node_physical_experts=cls.NUM_LOCAL_NODE_EXPERTS,
+            r=Random(seed),
+        )
+
+    def test_same_gpu_then_same_node_then_remote(self):
+        assignments = self._assign()
+
+        # Physical experts 0, 4, and 12 are on source GPUs 0, 2, and 6.
+        self.assertEqual(assignments[0], 0)
+        self.assertEqual(assignments[2], 4)
+        self.assertEqual(assignments[6], 12)
+
+        # Their node peers retain node locality even though no replica is on
+        # those peers' own GPUs.
+        self.assertEqual(assignments[1], 0)
+        self.assertEqual(assignments[3], 4)
+        self.assertEqual(assignments[7], 12)
+
+        # Node 2 has no replica, so ranks 4 and 5 use the fair remote fallback.
+        self.assertIn(assignments[4], self.CANDIDATES)
+        self.assertIn(assignments[5], self.CANDIDATES)
+        counts = Counter(assignments)
+        self.assertLessEqual(max(counts.values()) - min(counts.values()), 1)
+
+    def test_same_seed_is_deterministic(self):
+        self.assertEqual(self._assign(seed=7), self._assign(seed=7))
+
+    def test_flat_topology_skips_same_node_affinity(self):
+        assignments = _assign_locality_fair_experts(
+            candidate_physical_expert_ids=[0, 4],
+            ep_size=4,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=None,
+            num_local_node_physical_experts=None,
+            r=Random(42),
+        )
+
+        self.assertEqual(assignments[0], 0)
+        self.assertEqual(assignments[2], 4)
+        self.assertEqual({assignments[1], assignments[3]}, {0, 4})
+
+    def test_policy_is_wired_through_static_dispatch_map(self):
+        logical_to_all_physical = torch.tensor([[[0, 4, 12]]], dtype=torch.int64)
+        with _published(
+            ep_size=self.EP_SIZE,
+            nnodes=4,
+            ep_static_dispatch_policy="locality_fair",
+        ):
+            actual = [
+                compute_logical_to_rank_dispatch_physical_map(
+                    logical_to_all_physical_map=logical_to_all_physical,
+                    ep_size=self.EP_SIZE,
+                    num_physical_experts=16,
+                    ep_rank=ep_rank,
+                    seed=42,
+                ).item()
+                for ep_rank in range(self.EP_SIZE)
+            ]
+
+        self.assertEqual(actual, self._assign(seed=42))
+
+    def test_server_args_rejects_non_static_opt_in(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep",
+            ep_dispatch_algorithm="dynamic",
+            ep_static_dispatch_policy="locality_fair",
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires.*static"):
+            server_args._handle_eplb_and_dispatch()
+
+    def test_server_args_accepts_static_opt_in(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep",
+            ep_dispatch_algorithm="static",
+            ep_static_dispatch_policy="locality_fair",
+        )
+
+        server_args._handle_eplb_and_dispatch()
+
+    def test_single_rank_topology(self):
+        assignment = _assign_locality_fair_experts(
+            candidate_physical_expert_ids=[0, 1],
+            ep_size=1,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=1,
+            num_local_node_physical_experts=2,
+            r=Random(42),
+        )
+        self.assertEqual(len(assignment), 1)
+        self.assertIn(assignment[0], [0, 1])
+
+    def test_invalid_topology_is_rejected(self):
+        valid = dict(
+            candidate_physical_expert_ids=[0],
+            ep_size=4,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=2,
+            num_local_node_physical_experts=4,
+            r=Random(42),
+        )
+        invalid_overrides = [
+            {"candidate_physical_expert_ids": []},
+            {"ep_size": 0},
+            {"num_local_gpu_physical_experts": 0},
+            {
+                "num_gpus_per_node": None,
+                "num_local_node_physical_experts": 4,
+            },
+            {"num_gpus_per_node": 3, "num_local_node_physical_experts": 6},
+            {"num_local_node_physical_experts": 5},
+            {"candidate_physical_expert_ids": [8]},
+        ]
+
+        for overrides in invalid_overrides:
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                _assign_locality_fair_experts(**(valid | overrides))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
@@ -251,7 +251,8 @@ class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
 
     def test_fused_qk_quant_store_keeps_lightop_scale_contract(self):
         indexer = object.__new__(Indexer)
-        indexer.hidden_size = 256
+        indexer.hidden_size = 6144
+        indexer.head_dim = 128
         indexer.softmax_scale = 0.125
         pool = SimpleNamespace(
             page_size=64,
@@ -281,7 +282,7 @@ class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
             )
 
         self.assertEqual(result, expected)
-        hadamard_scale = 256**-0.5
+        hadamard_scale = 128**-0.5
         lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.assert_called_once_with(
             sentinel.query,
             sentinel.key,

--- a/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
@@ -1,0 +1,301 @@
+"""Unit coverage for the HCU DSA indexer's LightOp contracts."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, sentinel
+
+import torch
+
+from sglang.srt.layers.attention.dsa import dsa_indexer as indexer_module
+from sglang.srt.layers.attention.dsa import paged_mqa_logits_backend as backend_module
+from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
+    DSAPagedMQALogitsBackend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestHCUDSAPagedMQABackend(CustomTestCase):
+    def test_hcu_resolves_before_generic_hip(self):
+        with (
+            patch.object(backend_module, "is_hcu", return_value=True),
+            patch.object(backend_module, "is_hip", return_value=True),
+        ):
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("auto"),
+                DSAPagedMQALogitsBackend.LIGHTOP,
+            )
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("lightop"),
+                DSAPagedMQALogitsBackend.LIGHTOP,
+            )
+            with self.assertRaisesRegex(ValueError, "only 'lightop'"):
+                DSAPagedMQALogitsBackend.resolve("aiter")
+
+    def test_non_hcu_hip_keeps_aiter(self):
+        with (
+            patch.object(backend_module, "is_hcu", return_value=False),
+            patch.object(backend_module, "is_hip", return_value=True),
+        ):
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("auto"),
+                DSAPagedMQALogitsBackend.AITER,
+            )
+
+
+class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
+    def test_qk_prepare_uses_lightop_fused_layernorm_rope(self):
+        indexer = object.__new__(Indexer)
+        indexer.wq_b = MagicMock(return_value=(sentinel.query_projection, None))
+        indexer.wk = MagicMock(return_value=(sentinel.key_projection, None))
+        indexer.head_dim = 128
+        indexer.k_norm = SimpleNamespace(
+            weight=sentinel.norm_weight,
+            bias=sentinel.norm_bias,
+            variance_epsilon=1e-6,
+        )
+        indexer.rotary_emb = SimpleNamespace(cos_sin_cache=sentinel.cos_sin_cache)
+        indexer.dsa_enable_prefill_cp = False
+        query = MagicMock()
+        key = MagicMock(ndim=3)
+        forward_batch = SimpleNamespace(attn_cp_metadata=None)
+        lightop_attention = MagicMock()
+
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(indexer_module, "rearrange", return_value=query),
+            patch.object(
+                indexer_module, "rotate_activation", side_effect=lambda x, **_: x
+            ),
+            patch.object(indexer_module, "is_cp_v2_active", return_value=False),
+            patch.object(
+                indexer_module,
+                "lightop_attention",
+                lightop_attention,
+                create=True,
+            ),
+        ):
+            got_query, got_key, weights_raw = indexer._get_q_k_bf16(
+                sentinel.q_lora,
+                sentinel.x,
+                sentinel.positions,
+                False,
+                forward_batch,
+            )
+
+        self.assertIs(got_query, query)
+        self.assertIs(got_key, key)
+        self.assertIsNone(weights_raw)
+        lightop_attention.fuse_layernorm_rotary_embedding.assert_called_once_with(
+            sentinel.positions,
+            query,
+            key,
+            128,
+            sentinel.cos_sin_cache,
+            False,
+            None,
+            None,
+            sentinel.norm_weight,
+            sentinel.norm_bias,
+            None,
+            None,
+            1e-6,
+        )
+
+    def test_paged_and_ragged_mqa_abis(self):
+        lightop_attention = MagicMock()
+        lightop_attention.paged_mqa_logits.return_value = sentinel.paged_logits
+        lightop_attention.mqa_logits.return_value = sentinel.ragged_logits
+        q = MagicMock()
+        q.unsqueeze.return_value = sentinel.q_next_n
+
+        with patch.object(
+            indexer_module,
+            "lightop_attention",
+            lightop_attention,
+            create=True,
+        ):
+            paged_result = indexer_module._hcu_paged_mqa_logits(
+                q,
+                sentinel.kv_cache,
+                sentinel.weights,
+                sentinel.seqlens,
+                sentinel.block_tables,
+                None,
+                4096,
+            )
+            ragged_result = indexer_module._hcu_mqa_logits(
+                sentinel.q,
+                sentinel.kv,
+                sentinel.weights,
+                sentinel.ks,
+                sentinel.ke,
+                sentinel.kv_scale,
+            )
+
+        self.assertIs(paged_result, sentinel.paged_logits)
+        lightop_attention.paged_mqa_logits.assert_called_once_with(
+            sentinel.q_next_n,
+            sentinel.kv_cache,
+            sentinel.weights,
+            sentinel.seqlens,
+            sentinel.block_tables,
+            None,
+            4096,
+            clean_logits=True,
+        )
+        self.assertIs(ragged_result, sentinel.ragged_logits)
+        lightop_attention.mqa_logits.assert_called_once_with(
+            sentinel.q,
+            sentinel.kv,
+            sentinel.weights,
+            sentinel.ks,
+            sentinel.ke,
+            kv_scale=sentinel.kv_scale,
+            clean_logit=True,
+        )
+
+    def test_paged_cache_layout_selects_bf16_or_fp8(self):
+        indexer = object.__new__(Indexer)
+        indexer.head_dim = 128
+        bf16_cache = torch.empty((2, 64, 1, 128), dtype=torch.bfloat16)
+        bf16_pool = SimpleNamespace(
+            use_fp8_index_k_cache=False,
+            get_index_k_buffer=MagicMock(return_value=bf16_cache),
+        )
+        fp8_raw = torch.empty((2, 64 * 132), dtype=torch.uint8)
+        fp8_pool = SimpleNamespace(
+            use_fp8_index_k_cache=True,
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=fp8_raw),
+        )
+
+        with patch.object(indexer_module, "_is_hcu", True):
+            got_bf16, is_bf16 = indexer._get_hcu_paged_index_k_cache(
+                bf16_pool, layer_id=3
+            )
+            got_fp8, is_fp8_bf16 = indexer._get_hcu_paged_index_k_cache(
+                fp8_pool, layer_id=3
+            )
+
+        self.assertIs(got_bf16, bf16_cache)
+        self.assertTrue(is_bf16)
+        self.assertEqual(got_fp8.shape, (2, 64, 1, 132))
+        self.assertFalse(is_fp8_bf16)
+        bf16_pool.get_index_k_buffer.assert_called_once_with(layer_id=3)
+        fp8_pool.get_index_k_with_scale_buffer.assert_called_once_with(layer_id=3)
+
+    def test_hcu_cache_store_uses_native_layout(self):
+        indexer = object.__new__(Indexer)
+        forward_batch = SimpleNamespace(out_cache_loc=MagicMock())
+        key = sentinel.key
+        bf16_pool = SimpleNamespace(
+            use_fp8_index_k_cache=False,
+            set_index_k_buffer=MagicMock(),
+        )
+        fp8_pool = SimpleNamespace(
+            use_fp8_index_k_cache=True,
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=sentinel.fp8_cache),
+        )
+        lightop_kvcache = MagicMock()
+
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+            patch.object(
+                indexer_module, "get_token_to_kv_pool", return_value=bf16_pool
+            ),
+        ):
+            indexer._store_index_k_cache(forward_batch, layer_id=4, key=key)
+
+        bf16_pool.set_index_k_buffer.assert_called_once_with(
+            layer_id=4,
+            loc=forward_batch.out_cache_loc,
+            index_k=key,
+        )
+        lightop_kvcache.fuse_act_quant_and_store_index_k_cache.assert_not_called()
+
+        contiguous_loc = sentinel.contiguous_loc
+        forward_batch.out_cache_loc.contiguous.return_value = contiguous_loc
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(indexer_module, "_is_fp8_fnuz", False),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+            patch.object(indexer_module, "get_token_to_kv_pool", return_value=fp8_pool),
+        ):
+            indexer._store_index_k_cache(forward_batch, layer_id=4, key=key)
+
+        lightop_kvcache.fuse_act_quant_and_store_index_k_cache.assert_called_once_with(
+            key,
+            sentinel.fp8_cache,
+            contiguous_loc,
+            64,
+            1e-5,
+            False,
+            True,
+        )
+
+    def test_fused_qk_quant_store_keeps_lightop_scale_contract(self):
+        indexer = object.__new__(Indexer)
+        indexer.hidden_size = 256
+        indexer.softmax_scale = 0.125
+        pool = SimpleNamespace(
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=sentinel.fp8_cache),
+        )
+        out_cache_loc = MagicMock()
+        out_cache_loc.contiguous.return_value = sentinel.contiguous_loc
+        expected = (sentinel.q_fp8, sentinel.q_scale, None)
+        lightop_kvcache = MagicMock()
+        lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.return_value = expected
+
+        with (
+            patch.object(indexer_module, "_is_fp8_fnuz", False),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+        ):
+            result = indexer._hcu_fused_qk_quant_and_store(
+                sentinel.query,
+                sentinel.key,
+                pool,
+                layer_id=5,
+                out_cache_loc=out_cache_loc,
+            )
+
+        self.assertEqual(result, expected)
+        hadamard_scale = 256**-0.5
+        lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.assert_called_once_with(
+            sentinel.query,
+            sentinel.key,
+            sentinel.fp8_cache,
+            sentinel.contiguous_loc,
+            64,
+            None,
+            hadamard_scale * 0.125,
+            hadamard_scale,
+            1e-5,
+            False,
+            True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/dsa/test_hcu_persistent_mqa.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_persistent_mqa.py
@@ -1,0 +1,258 @@
+"""Unit coverage for the HCU persistent paged-MQA safety gates."""
+
+import unittest
+from unittest.mock import MagicMock, patch, sentinel
+
+import torch
+
+from sglang.srt.layers.attention.dsa import hcu_persistent_mqa
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _mock_tensor(*, dtype, shape, stride, device=torch.device("cuda:0")):
+    tensor = MagicMock()
+    tensor.dtype = dtype
+    tensor.device = device
+    tensor.shape = shape
+    tensor.dim.return_value = len(shape)
+    tensor.stride.return_value = stride
+    tensor.stride.side_effect = lambda dim=None: stride if dim is None else stride[dim]
+    tensor.is_contiguous.return_value = True
+    return tensor
+
+
+class TestHCUPersistentMQAGates(CustomTestCase):
+    def setUp(self):
+        self.saved_operation = hcu_persistent_mqa._selected_operation
+        self.saved_failure = hcu_persistent_mqa._preload_failure
+        self.saved_hardware = hcu_persistent_mqa._preloaded_hardware
+        hcu_persistent_mqa._selected_operation = None
+        hcu_persistent_mqa._preload_failure = None
+        hcu_persistent_mqa._preloaded_hardware = None
+        hcu_persistent_mqa._logged_hits.clear()
+        hcu_persistent_mqa._logged_misses.clear()
+
+    def tearDown(self):
+        hcu_persistent_mqa._selected_operation = self.saved_operation
+        hcu_persistent_mqa._preload_failure = self.saved_failure
+        hcu_persistent_mqa._preloaded_hardware = self.saved_hardware
+        hcu_persistent_mqa._logged_hits.clear()
+        hcu_persistent_mqa._logged_misses.clear()
+
+    def test_auto_ctas_are_graph_stable_and_bounded(self):
+        self.assertEqual(
+            hcu_persistent_mqa.resolve_persistent_ctas(
+                0, batch_size=8, max_context_len=65536
+            ),
+            256,
+        )
+        self.assertEqual(
+            hcu_persistent_mqa.resolve_persistent_ctas(
+                96, batch_size=8, max_context_len=65536
+            ),
+            96,
+        )
+        with self.assertRaisesRegex(ValueError, r"\[1, 4096\]"):
+            hcu_persistent_mqa.resolve_persistent_ctas(
+                4097, batch_size=8, max_context_len=65536
+            )
+
+    def test_hardware_gate_is_exactly_gfx938_with_64_cus(self):
+        self.assertIsNone(
+            hcu_persistent_mqa._hardware_gate_miss_reason(
+                arch_name="gfx938:sramecc+", num_cus=64
+            )
+        )
+        self.assertIn(
+            "gfx938",
+            hcu_persistent_mqa._hardware_gate_miss_reason(
+                arch_name="gfx936", num_cus=64
+            ),
+        )
+        self.assertIn(
+            "64 CUs",
+            hcu_persistent_mqa._hardware_gate_miss_reason(
+                arch_name="gfx938", num_cus=60
+            ),
+        )
+
+    def test_input_gate_accepts_only_native_fp8_page64_layout(self):
+        batch_size = 2
+        q = _mock_tensor(
+            dtype=torch.float8_e4m3fn,
+            shape=(batch_size, 1, 32, 128),
+            stride=(4096, 4096, 128, 1),
+        )
+        kv_cache = _mock_tensor(
+            dtype=torch.uint8,
+            shape=(4, 64, 1, 132),
+            stride=(8448, 132, 132, 1),
+        )
+        weights = _mock_tensor(
+            dtype=torch.float32,
+            shape=(batch_size, 32),
+            stride=(32, 1),
+        )
+        context_lens = _mock_tensor(
+            dtype=torch.int32,
+            shape=(batch_size,),
+            stride=(1,),
+        )
+        block_table = _mock_tensor(
+            dtype=torch.int32,
+            shape=(batch_size, 4),
+            stride=(4, 1),
+        )
+
+        kwargs = dict(
+            is_hcu=True,
+            page_size=64,
+            q=q,
+            fused_kv_cache=kv_cache,
+            weights=weights,
+            context_lens=context_lens,
+            block_table=block_table,
+            schedule_meta=None,
+            max_context_len=256,
+        )
+        self.assertIsNone(hcu_persistent_mqa._input_gate_miss_reason(**kwargs))
+
+        kv_cache.stride.side_effect = lambda dim=None: (
+            (1, 1, 1, 1) if dim is None else 1
+        )
+        self.assertIn(
+            "packed stride",
+            hcu_persistent_mqa._input_gate_miss_reason(**kwargs),
+        )
+
+    def test_consumer_requires_the_exact_context_length_tensor(self):
+        context_lens = sentinel.context_lens
+        common = dict(
+            fuse_topk=True,
+            force_unfused_topk=False,
+            topk_transform_method_name="PAGED",
+            index_topk=2048,
+            score_context_lens=context_lens,
+        )
+        self.assertIsNone(
+            hcu_persistent_mqa._consumer_gate_miss_reason(
+                **common,
+                topk_context_lens=context_lens,
+            )
+        )
+        self.assertIn(
+            "exact tensor",
+            hcu_persistent_mqa._consumer_gate_miss_reason(
+                **common,
+                topk_context_lens=sentinel.other_context_lens,
+            ),
+        )
+
+    def test_consumer_mismatch_falls_back_without_calling_package(self):
+        operation = MagicMock()
+        hcu_persistent_mqa._selected_operation = operation
+        hcu_persistent_mqa._preloaded_hardware = ("gfx938", 64)
+
+        with (
+            patch.object(
+                hcu_persistent_mqa.envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH,
+                "get",
+                return_value=True,
+            ),
+            patch.object(
+                hcu_persistent_mqa,
+                "_input_gate_miss_reason",
+                return_value=None,
+            ),
+            patch.object(
+                hcu_persistent_mqa,
+                "_consumer_gate_miss_reason",
+                return_value="context_lens mismatch",
+            ),
+        ):
+            result = hcu_persistent_mqa.paged_mqa_logits_length_masked(
+                sentinel.q,
+                sentinel.kv_cache,
+                sentinel.weights,
+                sentinel.context_lens,
+                sentinel.block_table,
+                None,
+                65536,
+                is_hcu=True,
+                page_size=64,
+                fuse_topk=True,
+                force_unfused_topk=False,
+                topk_transform_method_name="PAGED",
+                index_topk=2048,
+                topk_context_lens=sentinel.other_context_lens,
+            )
+
+        self.assertIsNone(result)
+        operation.assert_not_called()
+
+    def test_eligible_call_uses_packaged_operation(self):
+        q = MagicMock()
+        q.shape = (8, 1, 32, 128)
+        operation = MagicMock(return_value=sentinel.logits)
+        hcu_persistent_mqa._selected_operation = operation
+        hcu_persistent_mqa._preloaded_hardware = ("gfx938", 64)
+
+        with (
+            patch.object(
+                hcu_persistent_mqa.envs.SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH,
+                "get",
+                return_value=True,
+            ),
+            patch.object(
+                hcu_persistent_mqa.envs.SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS,
+                "get",
+                return_value=0,
+            ),
+            patch.object(
+                hcu_persistent_mqa,
+                "_input_gate_miss_reason",
+                return_value=None,
+            ),
+            patch.object(
+                hcu_persistent_mqa,
+                "_consumer_gate_miss_reason",
+                return_value=None,
+            ),
+        ):
+            result = hcu_persistent_mqa.paged_mqa_logits_length_masked(
+                q,
+                sentinel.kv_cache,
+                sentinel.weights,
+                sentinel.context_lens,
+                sentinel.block_table,
+                None,
+                65536,
+                is_hcu=True,
+                page_size=64,
+                fuse_topk=True,
+                force_unfused_topk=False,
+                topk_transform_method_name="PAGED",
+                index_topk=2048,
+                topk_context_lens=sentinel.context_lens,
+            )
+
+        self.assertIs(result, sentinel.logits)
+        operation.assert_called_once_with(
+            q,
+            sentinel.kv_cache,
+            sentinel.weights,
+            sentinel.context_lens,
+            sentinel.block_table,
+            None,
+            65536,
+            True,
+            4,
+            256,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
+++ b/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
@@ -1,0 +1,92 @@
+"""Unit tests for platform-specific DSA FlashMLA routing and metadata."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa.flashmla_backend import (
+    DSAFlashMLAMetadata,
+    can_fuse_flashmla_metadata,
+    get_flashmla_op,
+    wrap_flashmla_metadata_result,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSAFlashMLABackend(CustomTestCase):
+    def test_loader_routes_hcu_to_external_interface(self):
+        expected_op = MagicMock()
+        module = SimpleNamespace(flash_mla_sparse_fwd=expected_op)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa.flashmla_backend.import_module",
+            return_value=module,
+        ) as import_mock:
+            actual_op = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=True)
+
+        self.assertIs(actual_op, expected_op)
+        import_mock.assert_called_once_with("flash_mla.flash_mla_interface")
+
+    def test_loader_keeps_non_hcu_on_sgl_kernel(self):
+        expected_op = MagicMock()
+        module = SimpleNamespace(get_mla_metadata=expected_op)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa.flashmla_backend.import_module",
+            return_value=module,
+        ) as import_mock:
+            actual_op = get_flashmla_op("get_mla_metadata", is_hcu=False)
+
+        self.assertIs(actual_op, expected_op)
+        import_mock.assert_called_once_with("sgl_kernel.flash_mla")
+
+    def test_hcu_metadata_object_is_wrapped_and_copied(self):
+        backend_num_splits = torch.tensor([3], dtype=torch.int32)
+        backend_metadata = SimpleNamespace(num_splits=backend_num_splits)
+        source = wrap_flashmla_metadata_result((backend_metadata, None), is_hcu=True)
+
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=SimpleNamespace(num_splits=None),
+            num_splits=None,
+        )
+        destination.copy_(source)
+
+        self.assertIs(destination.flashmla_metadata, backend_metadata)
+        self.assertIs(destination.num_splits, backend_num_splits)
+        self.assertFalse(can_fuse_flashmla_metadata(source, destination))
+
+    def test_metadata_slice_accepts_uninitialized_hcu_scheduler(self):
+        backend_metadata = SimpleNamespace(num_splits=None)
+        metadata = wrap_flashmla_metadata_result((backend_metadata, None), is_hcu=True)
+
+        sliced = metadata.slice(slice(0, 2))
+
+        self.assertIs(sliced.flashmla_metadata, backend_metadata)
+        self.assertIsNone(sliced.num_splits)
+
+    def test_tensor_metadata_remains_fused_copy_eligible(self):
+        source = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.tensor([1, 2], dtype=torch.int32),
+            num_splits=torch.tensor([3, 4], dtype=torch.int32),
+        )
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.zeros(2, dtype=torch.int32),
+            num_splits=torch.zeros(2, dtype=torch.int32),
+        )
+
+        destination.copy_(source)
+
+        self.assertTrue(
+            torch.equal(destination.flashmla_metadata, source.flashmla_metadata)
+        )
+        self.assertTrue(torch.equal(destination.num_splits, source.num_splits))
+        self.assertTrue(can_fuse_flashmla_metadata(source, destination))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
+++ b/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     DSAFlashMLAMetadata,
     can_fuse_flashmla_metadata,
     get_flashmla_op,
+    refresh_flashmla_metadata,
     wrap_flashmla_metadata_result,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -86,6 +87,76 @@ class TestDSAFlashMLABackend(CustomTestCase):
         )
         self.assertTrue(torch.equal(destination.num_splits, source.num_splits))
         self.assertTrue(can_fuse_flashmla_metadata(source, destination))
+
+    def test_hcu_refresh_returns_fresh_scheduler_object(self):
+        captured_scheduler = SimpleNamespace(
+            have_initialized=True,
+            config="batch-6",
+            tile_scheduler_metadata=object(),
+            num_splits=object(),
+        )
+        fresh_scheduler = SimpleNamespace(
+            have_initialized=False,
+            config=None,
+            tile_scheduler_metadata=None,
+            num_splits=None,
+        )
+        destination = DSAFlashMLAMetadata(captured_scheduler, None)
+        source = DSAFlashMLAMetadata(fresh_scheduler, None)
+
+        refreshed = refresh_flashmla_metadata(
+            destination,
+            source,
+            slice(0, 6),
+            is_hcu=True,
+        )
+
+        self.assertIs(refreshed, source)
+        self.assertIs(refreshed.flashmla_metadata, fresh_scheduler)
+        self.assertIs(destination.flashmla_metadata, captured_scheduler)
+
+    def test_tensor_refresh_keeps_destination_storage(self):
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.zeros(2, dtype=torch.int32),
+            num_splits=torch.zeros(3, dtype=torch.int32),
+        )
+        source = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.tensor([1, 2], dtype=torch.int32),
+            num_splits=torch.tensor([3, 4], dtype=torch.int32),
+        )
+        destination_metadata = destination.flashmla_metadata
+        destination_splits = destination.num_splits
+
+        refreshed = refresh_flashmla_metadata(
+            destination,
+            source,
+            slice(0, 2),
+            is_hcu=False,
+        )
+
+        self.assertIs(refreshed.flashmla_metadata, destination_metadata)
+        self.assertEqual(refreshed.num_splits.data_ptr(), destination_splits.data_ptr())
+        self.assertTrue(
+            torch.equal(refreshed.flashmla_metadata, source.flashmla_metadata)
+        )
+        self.assertTrue(torch.equal(refreshed.num_splits, source.num_splits))
+
+    def test_hcu_refresh_does_not_share_schedulers_across_steps(self):
+        destination = DSAFlashMLAMetadata(SimpleNamespace(), None)
+        first = DSAFlashMLAMetadata(SimpleNamespace(have_initialized=False), None)
+        second = DSAFlashMLAMetadata(SimpleNamespace(have_initialized=False), None)
+
+        first_refreshed = refresh_flashmla_metadata(
+            destination, first, slice(0, 6), is_hcu=True
+        )
+        second_refreshed = refresh_flashmla_metadata(
+            destination, second, slice(0, 6), is_hcu=True
+        )
+
+        self.assertIsNot(
+            first_refreshed.flashmla_metadata,
+            second_refreshed.flashmla_metadata,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
+++ b/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
@@ -5,11 +5,26 @@ from types import SimpleNamespace
 
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
     effective_forward_mode,
+    get_flashmla_kv_valid_rows,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _Mode:
+    def __init__(self, kind):
+        self.kind = kind
+
+    def is_decode_or_idle(self):
+        return self.kind in ("decode", "idle")
+
+    def is_target_verify(self):
+        return self.kind == "target_verify"
+
+    def is_draft_extend_v2(self):
+        return self.kind == "draft_extend_v2"
 
 
 class TestDSAForwardBatchUtils(CustomTestCase):
@@ -37,6 +52,67 @@ class TestDSAForwardBatchUtils(CustomTestCase):
         forward_batch = SimpleNamespace(forward_mode=current_mode)
 
         self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+    def test_target_verify_uses_planned_five_of_six_rows(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=1,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_draft_extend_v2_uses_original_layout_without_preplan(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("draft_extend_v2"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=None,
+            forward_metadata_planned_num_tokens=None,
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_decode_uses_request_rows_instead_of_transient_token_rows(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("decode"),
+            _original_batch_size=5,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=5,
+            forward_metadata_planned_num_tokens=25,
+            spec_info=SimpleNamespace(num_tokens_per_req=1),
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_inconsistent_plan_does_not_trim(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=2,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertIsNone(get_flashmla_kv_valid_rows(forward_batch, 6))
+
+    def test_unpadded_rows_do_not_trigger_repad(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=1,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertIsNone(get_flashmla_kv_valid_rows(forward_batch, 5))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
+++ b/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
@@ -1,0 +1,43 @@
+"""Unit tests for DSA forward-batch layout helpers."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDSAForwardBatchUtils(CustomTestCase):
+    def test_effective_mode_uses_original_mode_during_mlp_sync(self):
+        current_mode = object()
+        original_mode = object()
+        forward_batch = SimpleNamespace(
+            forward_mode=current_mode,
+            _original_forward_mode=original_mode,
+        )
+
+        self.assertIs(effective_forward_mode(forward_batch), original_mode)
+
+    def test_effective_mode_handles_explicit_none(self):
+        current_mode = object()
+        forward_batch = SimpleNamespace(
+            forward_mode=current_mode,
+            _original_forward_mode=None,
+        )
+
+        self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+    def test_effective_mode_handles_missing_original_field(self):
+        current_mode = object()
+        forward_batch = SimpleNamespace(forward_mode=current_mode)
+
+        self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_w8a8_int8_hcu_layout.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_w8a8_int8_hcu_layout.py
@@ -1,0 +1,94 @@
+"""HCU W8A8 method-3 weight-layout regression tests."""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+from compressed_tensors.quantization import QuantizationStrategy
+from torch.nn import Parameter
+
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    compressed_tensors_w8a8_int8 as w8a8_int8,
+)
+from sglang.test.ci.ci_register import register_hcu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_hcu_ci(est_time=5, suite="stage-b-test-1-hcu-small")
+
+
+class TestCompressedTensorsW8A8Int8HCULayout(CustomTestCase):
+    @staticmethod
+    def _make_scheme():
+        with mock.patch.dict(os.environ, {"W8A8_SUPPORT_METHODS": "3"}):
+            return w8a8_int8.CompressedTensorsW8A8Int8(
+                strategy=QuantizationStrategy.CHANNEL,
+                is_static_input_scheme=False,
+                input_symmetric=False,
+            )
+
+    @staticmethod
+    def _make_layer(weight: torch.Tensor):
+        layer = torch.nn.Module()
+        layer.weight = Parameter(weight.clone(), requires_grad=False)
+        layer.weight_scale = Parameter(
+            torch.ones((weight.shape[0], 1), dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.logical_widths = [weight.shape[0]]
+        return layer
+
+    def test_only_gfx928_selects_kme(self):
+        cuda_device = SimpleNamespace(type="cuda")
+        cases = {
+            "gfx928:sramecc+:xnack-": True,
+            "gfx936:sramecc+:xnack-": False,
+            "gfx938:sramecc+:xnack-": False,
+            "sm_90": False,
+        }
+
+        for arch, expected in cases.items():
+            with self.subTest(arch=arch), mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(gcnArchName=arch),
+            ):
+                self.assertEqual(w8a8_int8._use_kme_hipblaslt(cuda_device), expected)
+
+        with mock.patch.object(torch.cuda, "get_device_properties") as get_props:
+            self.assertFalse(w8a8_int8._use_kme_hipblaslt(SimpleNamespace(type="cpu")))
+            get_props.assert_not_called()
+
+    def test_method3_layout_and_azp_reduction_match(self):
+        weight = torch.tensor(
+            [[1, 2, 3, 4], [5, -1, 0, 2], [-3, 7, 1, -2]],
+            dtype=torch.int8,
+        )
+        expected_azp = weight.sum(dim=1, keepdim=False, dtype=torch.int32).unsqueeze(0)
+
+        for use_kme in (True, False):
+            with self.subTest(use_kme=use_kme):
+                layer = self._make_layer(weight)
+                scheme = self._make_scheme()
+
+                with mock.patch.object(
+                    w8a8_int8, "_use_kme_hipblaslt", return_value=use_kme
+                ), mock.patch.object(w8a8_int8.W8A8_TRITONJSON, "gen_model_json"):
+                    scheme.process_weights_after_loading(layer)
+
+                if use_kme:
+                    self.assertEqual(layer.weight.shape, (4, 3))
+                    self.assertEqual(layer.weight.stride(), (1, 4))
+                    self.assertTrue(torch.equal(layer.weight, weight.t()))
+                else:
+                    self.assertEqual(layer.weight.shape, (3, 4))
+                    self.assertTrue(layer.weight.is_contiguous())
+                    self.assertTrue(torch.equal(layer.weight, weight))
+
+                self.assertEqual(layer.azp_adj.shape, (1, 3))
+                self.assertTrue(torch.equal(layer.azp_adj, expected_azp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_eagle_worker_v2_graph_support.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_graph_support.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch
+
+import sglang.srt.speculative.eagle_worker_v2 as eagle_worker_v2
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestEagleWorkerV2GraphSupport(CustomTestCase):
+    def test_hcu_uses_cuda_style_graph_runner(self):
+        with (
+            patch.object(eagle_worker_v2, "_is_cuda", False),
+            patch.object(eagle_worker_v2, "_is_hcu", True),
+            patch.object(eagle_worker_v2, "_is_musa", False),
+        ):
+            self.assertTrue(eagle_worker_v2._supports_cuda_graph_runner())
+
+    def test_plain_hip_does_not_use_cuda_style_graph_runner(self):
+        with (
+            patch.object(eagle_worker_v2, "_is_cuda", False),
+            patch.object(eagle_worker_v2, "_is_hcu", False),
+            patch.object(eagle_worker_v2, "_is_musa", False),
+        ):
+            self.assertFalse(eagle_worker_v2._supports_cuda_graph_runner())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

### PD 与 MTP

- **fake prefill 的 MTP index sharing**：fake PD 没有真实 Prefill 端写入 DSA TopK metadata，因此缺少 MTP index sharing 的初始 seed。本 PR 仅在 fake transfer 且启用 speculative decoding 时构造 shape、dtype 正确的全零 DSA seed，后续继续复用 main 已有的 decode-local remap；真实 PD 请求仍使用 Prefill 端产生的 seed。

- **HCU DSA MTP draft-extend CUDA Graph**：将 HCU DSA backend 纳入 EAGLE CUDA-style draft-extend graph 支持范围。满足现有 backend、batch size、speculative step 和 graph shape 条件时参与 capture/replay；仍可通过 `SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH=1` 关闭。

### HCU DSA、FlashMLA 与 MQA logits

- **HCU FlashMLA backend 选择**：修复 DSA 重构后 HCU 误用 `sgl_kernel.flash_mla` 的问题。HCU 改为调用 `flash_mla.flash_mla_interface`，并使用原始 TP head 数；非 HCU 平台继续使用原有 `sgl_kernel.flash_mla` 和 head padding 规则。该改动无新增开关，仅在现有 DSA 配置选择 FlashMLA 时生效。

- **IFB/MTP effective forward mode**：IFB 的 MLP-sync padding 会临时将 decode、target verify 或 draft extend 标记为 `EXTEND`，使 DSA backend、indexer 和 metadata 选错执行分支。本 PR 统一读取 padding 前的真实算法模式。

- **IFB/MTP FlashMLA padded rows**：HCU FlashMLA kernel 只接收真实 token/request rows，并同步裁剪 q、indices 和 cache sequence lengths，再按有效行重新生成 metadata；零有效行跳过 kernel。kernel 返回后将输出补回 MLP-sync 所需的物理行数，避免 synthetic rows 中的 `-1` indices 或零长度 metadata 进入 FlashMLA。无法可靠判断 padding 来源时保留原路径。

- **HCU FlashMLA metadata replay**：CUDA FlashMLA 使用可原地复制的 Tensor metadata，而 HCU 使用与 shape 绑定的 mutable scheduler object。本 PR 在 graph capture/replay、precomputed metadata 和 multi-step replay 中重新生成并保存对应 HCU object，避免多个 step 复用旧调度状态；CUDA 的 Tensor/fused-copy 路径保持不变。

- **HCU LightOp DSA indexer**：`--dsa-paged-mqa-logits-backend` 及其默认值 `auto` 已存在于 main；本 PR 新增 `lightop` backend，并增加 HCU 专用解析规则。HCU 使用 `auto` 时选择 LightOp，也可显式指定 `lightop`；CUDA 和普通 ROCm 平台保留 main 原有的 DeepGEMM/AITER 选择。该路径恢复 page size 64 的 paged MQA logits、ragged/CP MQA logits、BF16/native FP8 index cache 读写、fused LayerNorm/RoPE 以及 q/k quant-store，避免 HCU 因同时被识别为 HIP 而误走 AITER。

- **DSA indexer 归一化**：fused Hadamard 路径按 q/k 的实际 `head_dim` 归一化，不再使用模型 `hidden_size`，避免 indexer logits 缩放错误。

- **persistent paged MQA logits 快速路径**：默认关闭，建议使用以下配置显式开启：

  ```bash
  export SGLANG_DSA_HCU_PERSISTENT_MQA_FASTPATH=1
  export SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS=0
  ```

  `SGLANG_DSA_HCU_PERSISTENT_MQA_CTAS=0` 是默认值，表示根据 batch size 和 max context length 自动选择 CTA 数，并不是必须固定为 0；也可以设置 `1–4096` 的固定 CTA 数。

  当前 fast path 的命中条件如下：

  | 条件 | 当前要求 |
  |---|---|
  | LightOp ABI | 已安装的 LightOp 必须导出可调用的 `paged_mqa_logits_length_masked` |
  | KV cache | page size 为 `64`，使用 native FP8 packed cache，layout 为 `[num_blocks, 64, 1, 132]` |
  | Query | contiguous `float8_e4m3fn`，shape 为 `[batch, 1, 32, 128]` |
  | Weights | contiguous FP32，shape 为 `[batch, 32]` |
  | Metadata | `schedule_meta=None`，int32 context lengths/block table，且 block-table capacity 等于 max context length |
  | TopK consumer | `SGLANG_DSA_FUSE_TOPK=1`、transform method 为 `PAGED`、`index_topk=2048`，并且 MQA 与生产 TopK 使用同一个 context-length Tensor |

  显式启用后，如果硬件、LightOp ABI 或输入 layout 不满足上述 contract，会直接报错，避免误跑不兼容 kernel；仅 TopK consumer 条件不匹配时安全回退普通 LightOp paged MQA logits。

- **MQA logits memory budget**：ragged MQA 大 logits 矩阵的动态 chunk 已存在于 main，本 PR 不重复实现。现有 `SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION` 默认值为 `0.2`，继续根据空闲显存与 serving memory headroom 决定是否分块；不引入旧 NSA 分支固定 1 GiB 的预算实现。

### DeepEP、MoE 与 expert dispatch

- **FP8 activation quantization padded rows**：将 expert row mapping 传给 fused SiLU+FP8 quantization，使 GroupGEMM 对齐产生的 padded rows 不参与有效量化和后续 expert 计算。

- **DeepEP prefill secondary overlap**：DeepEP normal prefill 返回二维 contiguous hidden states，而第二阶段 down-GEMM/combine overlap 只支持 low-latency decode 的三维 masked layout。遇到非三维输入时跳过这个不兼容的第二阶段，已完成的 shared-expert/dispatch overlap 不受影响。

- **locality-fair static dispatch**：为有冗余 expert replica 的 static dispatch 增加确定性的 source-rank-to-replica 映射，优先 same GPU、其次 same node，并在同等 locality 的副本间均衡静态绑定。它不是按实时 token/queue 负载动态均衡。

- **启用方式**：`--ep-dispatch-algorithm static --ep-static-dispatch-policy locality_fair`。默认仍为 `nearest`，并且需要能够将 token 路由到单一 rank 的 MoE A2A backend。

### HCU W8A8 与 MLA kernel

- **HCU W8A8 hipBLASLt 权重 layout**：当 `W8A8_SUPPORT_METHODS=3` 时，仅 gfx928 KME 使用 swapped-TN 的 col-major `[K, N]`；gfx936/gfx938 使用 legacy NT 所需的 contiguous `[N, K]`，并按照实际 K 维修正 asymmetric zero-point reduction。其他 W8A8 strategy 不受影响。

- **HCU MLA query concat AOT kernel**：用于拼接 BF16 `q_nope[..., 512]` 和 `q_rope[..., 64]`。通过 `SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q=1` 显式启用，默认关闭；shape、dtype、stride 或 device 不满足 kernel 条件时自动回退 `torch.cat`，CUDA 原有 JIT 路径保持不变。

## 动机 / 关联

- 关联 Issue：无

- 关联需求/客户：补齐 GLM5.2 在 HCU 上的 DSA、MTP、IFB、DeepEP、W8A8 和相关 kernel 支持。

- 目标分支：main

## 贡献者

- @yangql1：DeepEP FP8 padded rows、DeepEP prefill secondary overlap、HCU MLA query concat kernel。

## 影响面

- [x] 主要影响 HCU/DCU 路径，非 HCU 平台保留原实现

- [x] 通用模块中的改动均由平台判断、输入条件或显式开关保护

- [x] 涉及 attention、speculative decoding、MoE、quant 与 kernel

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->