### PR TITLE
[diffusion][MiniMax-H3] Add HCU runtime support and fix CacheDiT residual aliasing

### DIFF
--- a/python/sglang/__init__.py
+++ b/python/sglang/__init__.py
@@ -14,6 +14,18 @@ redirect_third_party_caches()
 import platform as _platform
 import sys as _sys
 
+try:
+    import torch as _torch
+
+    if _torch.version.hip is not None and hasattr(_torch.backends, "cuda"):
+        _torch.backends.cuda.enable_flash_sdp(False)
+        _torch.backends.cuda.enable_mem_efficient_sdp(False)
+        _torch.backends.cuda.enable_cudnn_sdp(False)
+        _torch.backends.cuda.enable_math_sdp(True)
+    del _torch
+except Exception:
+    pass
+
 if _sys.platform == "darwin" and _platform.machine() == "arm64":
     try:
         import torch as _torch

--- a/python/sglang/kernels/ops/diffusion/triton/indexed_modulation.py
+++ b/python/sglang/kernels/ops/diffusion/triton/indexed_modulation.py
@@ -53,6 +53,7 @@ def _indexed_gate_bf16_kernel(
     other_ptr,
     indices_ptr,
     hidden_size,
+    stride_output_row,
     stride_x_row,
     stride_gate_row,
     stride_other_row,
@@ -76,7 +77,7 @@ def _indexed_gate_bf16_kernel(
 
     gated = round_bf16_to_fp32(gate * other)
     tl.store(
-        output_ptr + row * stride_x_row + columns,
+        output_ptr + row * stride_output_row + columns,
         x + gated,
         mask=mask,
     )
@@ -109,7 +110,8 @@ def indexed_scale_shift_bf16_(
     return x
 
 
-def indexed_gate_bf16_(
+def _indexed_gate_bf16(
+    output: torch.Tensor,
     x: torch.Tensor,
     gate: torch.Tensor,
     other: torch.Tensor,
@@ -117,15 +119,16 @@ def indexed_gate_bf16_(
 ) -> torch.Tensor:
     rows, hidden_size = x.shape
     if rows == 0:
-        return x
+        return output
     block_n = triton.next_power_of_2(hidden_size)
     _indexed_gate_bf16_kernel[(rows,)](
-        x,
+        output,
         x,
         gate,
         other,
         indices,
         hidden_size,
+        output.stride(0),
         x.stride(0),
         gate.stride(0),
         other.stride(0),
@@ -133,4 +136,22 @@ def indexed_gate_bf16_(
         BLOCK_N=block_n,
         num_warps=8,
     )
-    return x
+    return output
+
+
+def indexed_gate_bf16_(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    return _indexed_gate_bf16(x, x, gate, other, indices)
+
+
+def indexed_gate_bf16(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    return _indexed_gate_bf16(torch.empty_like(x), x, gate, other, indices)

--- a/python/sglang/kernels/ops/layernorm/norm.py
+++ b/python/sglang/kernels/ops/layernorm/norm.py
@@ -12,6 +12,7 @@ from sglang.kernels.jit.utils import (
     load_jit,
     make_cpp_args,
 )
+from sglang.srt.utils import is_hcu
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -99,6 +100,10 @@ def _jit_qknorm_across_heads_module(dtype: torch.dtype) -> Module:
 @torch.compiler.assume_constant_result
 @cache_once
 def can_use_fused_inplace_qknorm(head_dim: int, dtype: torch.dtype) -> bool:
+    # The JIT QK-Norm kernel emits CUDA-oriented source and includes CUDA headers.
+    # On HCU/HIP, keep the regular RMSNorm fallback instead of compiling it.
+    if is_hcu():
+        return False
     if head_dim not in [64, 128, 256, 512, 1024]:
         logger.warning(f"Unsupported head_dim={head_dim} for JIT QK-Norm kernel")
         return False

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/sdpa.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/sdpa.py
@@ -64,6 +64,8 @@ class SDPAImpl(AttentionImpl):
         self.allow_cudnn_sdp = bool(extra_impl_args.get("allow_cudnn_sdp", False))
 
     def _sdpa_context(self, query: torch.Tensor):
+        if query.device.type == "cuda" and torch.version.hip is not None:
+            return sdpa_kernel(SDPBackend.MATH)
         if self.allow_cudnn_sdp and query.device.type == "cuda":
             return sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
         return nullcontext()

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -77,6 +77,15 @@ _PYTORCH_DEFAULT_CUDA_SDP_BACKENDS = [
     SDPBackend.MATH,
 ]
 
+
+def _sdpa_context_for_device(query: torch.Tensor, allow_cudnn_sdp: bool):
+    if query.device.type == "cuda" and torch.version.hip is not None:
+        return sdpa_kernel(SDPBackend.MATH)
+    if allow_cudnn_sdp and query.device.type == "cuda":
+        return sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
+    return nullcontext()
+
+
 import sglang.multimodal_gen.envs as envs
 
 if envs.SGLANG_DIFFUSION_RING_ATTN_OVERLAP:
@@ -632,11 +641,7 @@ class LocalAttention(nn.Module):
                 k_ = k_.repeat_interleave(repeat_factor, dim=1)
                 v_ = v_.repeat_interleave(repeat_factor, dim=1)
 
-            sdpa_context = (
-                sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
-                if self.allow_cudnn_sdp and q_.device.type == "cuda"
-                else nullcontext()
-            )
+            sdpa_context = _sdpa_context_for_device(q_, self.allow_cudnn_sdp)
             attn_kwargs = {
                 "attn_mask": mask,
                 "dropout_p": 0.0,
@@ -959,11 +964,7 @@ class USPAttention(nn.Module):
                 k_ = k.transpose(1, 2)
                 v_ = v.transpose(1, 2)
                 mask = _prepare_sdpa_mask(attn_mask, dtype=q_.dtype, device=q_.device)
-                sdpa_context = (
-                    sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
-                    if self.allow_cudnn_sdp and q_.device.type == "cuda"
-                    else nullcontext()
-                )
+                sdpa_context = _sdpa_context_for_device(q_, self.allow_cudnn_sdp)
                 with sdpa_context:
                     return torch.nn.functional.scaled_dot_product_attention(
                         q_,
@@ -1131,11 +1132,7 @@ class USPAttention(nn.Module):
             k_ = k.transpose(1, 2)
             v_ = v.transpose(1, 2)
             mask = _prepare_sdpa_mask(gathered_mask, dtype=q_.dtype, device=q_.device)
-            sdpa_context = (
-                sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
-                if self.allow_cudnn_sdp and q_.device.type == "cuda"
-                else nullcontext()
-            )
+            sdpa_context = _sdpa_context_for_device(q_, self.allow_cudnn_sdp)
             with sdpa_context:
                 out = torch.nn.functional.scaled_dot_product_attention(
                     q_,
@@ -1418,11 +1415,7 @@ class USPAttention(nn.Module):
             k_ = k_.repeat_interleave(repeat_factor, dim=1)
             v_ = v_.repeat_interleave(repeat_factor, dim=1)
 
-        sdpa_context = (
-            sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
-            if self.allow_cudnn_sdp and q_.device.type == "cuda"
-            else nullcontext()
-        )
+        sdpa_context = _sdpa_context_for_device(q_, self.allow_cudnn_sdp)
         with sdpa_context:
             out = torch.nn.functional.scaled_dot_product_attention(
                 q_,

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -65,6 +65,7 @@ from sglang.multimodal_gen.runtime.platforms import (
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
 )
+from sglang.srt.utils import is_hcu
 
 _ARCH_DEFAULTS = MiniMaxH3DiTArchConfig()
 _BF16_DTYPE = torch.bfloat16
@@ -277,6 +278,7 @@ def _apply_qk_norm(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if (
         q.is_cuda
+        and not is_hcu()
         and q.dtype == _BF16_DTYPE
         and q.dtype == k.dtype == q_norm.weight.dtype == k_norm.weight.dtype
         and q.stride(-1) == k.stride(-1) == 1

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -21,6 +21,7 @@ from sglang.kernels.ops.diffusion.qknorm_rope import (
     fused_inplace_qknorm_rope,
 )
 from sglang.kernels.ops.diffusion.triton.indexed_modulation import (
+    indexed_gate_bf16,
     indexed_gate_bf16_,
     indexed_scale_shift_bf16_,
 )
@@ -240,8 +241,9 @@ def _modulate_gate(
     indices: torch.Tensor,
     *,
     dtype: torch.dtype,
+    allow_inplace: bool = True,
 ) -> torch.Tensor:
-    """Apply indexed gated residual, reusing disposable CUDA BF16 input."""
+    """Apply an indexed gated residual, optionally reusing the input buffer."""
     # Apply the per-index gated residual: x + gate[idx] * other.
     if (
         x.is_cuda
@@ -252,7 +254,9 @@ def _modulate_gate(
         and x.is_contiguous()
         and other.is_contiguous()
     ):
-        return indexed_gate_bf16_(x, gate, other, indices)
+        if allow_inplace:
+            return indexed_gate_bf16_(x, gate, other, indices)
+        return indexed_gate_bf16(x, gate, other, indices)
     return (x + gate.index_select(0, indices) * other).to(dtype)
 
 
@@ -901,6 +905,7 @@ class MiniMaxH3DiTBlock(nn.Module):
             expand_ratio=6,
             modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
         )
+        self.preserve_input_for_cache_dit = False
 
     def forward(
         self,
@@ -927,6 +932,9 @@ class MiniMaxH3DiTBlock(nn.Module):
             adaln_params = self.adaln_proj(adaln_input)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = adaln_params
 
+        # Cache-DiT retains the inputs to its Fn and Mn block ranges. Only the
+        # first gated residual writes to that tensor; the second one operates on
+        # a block-local buffer.
         residual = x
         h = self.norm1(x)
         h = _modulate_scale_shift(
@@ -941,7 +949,14 @@ class MiniMaxH3DiTBlock(nn.Module):
             ulysses_active=ulysses_active,
             ring_active=ring_active,
         )
-        x = _modulate_gate(residual, gate_msa, h, combined_indices, dtype=_BF16_DTYPE)
+        x = _modulate_gate(
+            residual,
+            gate_msa,
+            h,
+            combined_indices,
+            dtype=_BF16_DTYPE,
+            allow_inplace=not self.preserve_input_for_cache_dit,
+        )
 
         residual = x
         h = self.norm2(x)
@@ -949,6 +964,8 @@ class MiniMaxH3DiTBlock(nn.Module):
             h, shift_mlp, scale_mlp, combined_indices, dtype=_BF16_DTYPE
         )
         h = self.mlp(h)
+        # `residual` is block-local here, so this remains in-place even while
+        # Cache-DiT is attached.
         return _modulate_gate(
             residual, gate_mlp, h, combined_indices, dtype=_BF16_DTYPE
         )
@@ -1184,6 +1201,12 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         )
         self._resolved_attention_backend: AttentionBackendEnum | None = None
         self._mark_missing_params_required()
+
+    def set_cache_dit_input_preservation(self, enabled: bool) -> None:
+        """Prevent Cache-DiT's retained block-stack input from being overwritten."""
+
+        for block in self.blocks:
+            block.preserve_input_for_cache_dit = enabled
 
     def _resolve_attention_backend_once(self) -> None:
         if self._resolved_attention_backend is not None:

--- a/python/sglang/multimodal_gen/runtime/models/encoders/qwen3.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/qwen3.py
@@ -1,8 +1,10 @@
 from collections.abc import Iterable
+from contextlib import nullcontext
 from typing import Any
 
 import torch
 from torch import nn
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from sglang.multimodal_gen.configs.models.encoders import BaseEncoderOutput
 from sglang.multimodal_gen.configs.models.encoders.qwen3 import Qwen3TextConfig
@@ -25,6 +27,12 @@ from sglang.multimodal_gen.runtime.loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.multimodal_gen.runtime.models.encoders.base import TextEncoder
+
+
+def _rocm_sdpa_context(tensor: torch.Tensor):
+    if tensor.device.type == "cuda" and torch.version.hip is not None:
+        return sdpa_kernel(SDPBackend.MATH)
+    return nullcontext()
 
 
 class Qwen3MLP(nn.Module):
@@ -229,14 +237,15 @@ class Qwen3Attention(nn.Module):
                 repeat_factor = self.num_heads // self.num_kv_heads
                 real_k = real_k.repeat_interleave(repeat_factor, dim=1)
                 real_v = real_v.repeat_interleave(repeat_factor, dim=1)
-            pad_output = torch.nn.functional.scaled_dot_product_attention(
-                pad_q,
-                real_k,
-                real_v,
-                dropout_p=0.0,
-                is_causal=False,
-                scale=self.scaling,
-            ).transpose(1, 2)
+            with _rocm_sdpa_context(pad_q):
+                pad_output = torch.nn.functional.scaled_dot_product_attention(
+                    pad_q,
+                    real_k,
+                    real_v,
+                    dropout_p=0.0,
+                    is_causal=False,
+                    scale=self.scaling,
+                ).transpose(1, 2)
             outputs.append(torch.cat([real_output, pad_output], dim=1))
 
         return torch.cat(outputs, dim=0)

--- a/python/sglang/multimodal_gen/runtime/models/encoders/qwen3vl.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/qwen3vl.py
@@ -49,6 +49,62 @@ from transformers.activations import ACT2FN
 
 logger = logging.getLogger(__name__)
 
+
+def _is_rocm_tensor(tensor: torch.Tensor) -> bool:
+    return tensor.device.type == "cuda" and torch.version.hip is not None
+
+
+def _repeat_kv_for_gqa(
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    num_query_heads: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_kv_heads = key_states.shape[1]
+    if num_query_heads == num_kv_heads:
+        return key_states, value_states
+    if num_query_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"num_query_heads={num_query_heads} must be divisible by "
+            f"num_kv_heads={num_kv_heads}"
+        )
+    repeat_factor = num_query_heads // num_kv_heads
+    return (
+        key_states.repeat_interleave(repeat_factor, dim=1),
+        value_states.repeat_interleave(repeat_factor, dim=1),
+    )
+
+
+def _rocm_math_attention(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    *,
+    softmax_scale: float,
+    causal: bool,
+) -> torch.Tensor:
+    query_states = query_states.transpose(1, 2)
+    key_states = key_states.transpose(1, 2)
+    value_states = value_states.transpose(1, 2)
+    key_states, value_states = _repeat_kv_for_gqa(
+        key_states, value_states, query_states.shape[1]
+    )
+
+    attn_weights = torch.matmul(
+        query_states.to(torch.float32),
+        key_states.to(torch.float32).transpose(-2, -1),
+    )
+    attn_weights.mul_(softmax_scale)
+    if causal:
+        q_len = query_states.shape[-2]
+        k_len = key_states.shape[-2]
+        causal_mask = torch.ones(
+            (q_len, k_len), dtype=torch.bool, device=query_states.device
+        ).triu(diagonal=1 + k_len - q_len)
+        attn_weights.masked_fill_(causal_mask, torch.finfo(attn_weights.dtype).min)
+    attn_weights = torch.softmax(attn_weights, dim=-1).to(value_states.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+    return attn_output.transpose(1, 2)
+
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.models.qwen3_vl.configuration_qwen3_vl import (
     Qwen3VLTextConfig,
@@ -336,7 +392,18 @@ class Qwen3VLTextAttention(nn.Module):
         query_states = query_states.transpose(1, 2)
         key_states = key_states.transpose(1, 2)
         value_states = value_states.transpose(1, 2)
-        attn_output = self.attn(query_states, key_states, value_states)
+        if _is_rocm_tensor(query_states):
+            # Avoid PyTorch flash SDP on ROCm/HIP for MiniMax-H3 text encoding.
+            # The flash path can segfault during 8-card startup/request handling.
+            attn_output = _rocm_math_attention(
+                query_states,
+                key_states,
+                value_states,
+                softmax_scale=self.scaling,
+                causal=self.is_causal,
+            )
+        else:
+            attn_output = self.attn(query_states, key_states, value_states)
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         if not isinstance(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/reference_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/reference_encoding.py
@@ -6,10 +6,8 @@ Encoding recipes for user-provided reference materials:
 - image reference: independent 2048px short-edge resize with upscale enabled,
   LANCZOS, and nearest-32 dimensions, then the SAME keyframe tokenizer recipe
   as fl2va (seed-42 sampled encode, normalize, [1,2,2] patchify);
-- audio reference: the audio material chain (pure
-  audio is losslessly normalized
-  to stereo; video soundtracks are extracted as 44.1 kHz stereo), then a
-  single resample to 32 kHz,
+- audio reference: the audio material chain uses ffmpeg to decode directly to
+  model-required 32 kHz stereo PCM,
   audio VAE posterior MEAN (encoder -> optional pre_block -> mean_proj; no
   sampling), canonical [2, T, 32], normalize with loader-injected audio stats,
   channel-major rows.
@@ -17,7 +15,6 @@ Encoding recipes for user-provided reference materials:
 
 from __future__ import annotations
 
-import functools
 import math
 from typing import Any
 
@@ -203,11 +200,10 @@ def _load_waveform(
 ) -> tuple[torch.Tensor, int]:
     """Apply the audio material chain.
 
-    Pure-audio references preserve their source rate while normalizing to
-    stereo. Video-bearing references first extract 44.1 kHz stereo PCM. The
-    audio VAE boundary then performs the single 32 kHz resample below. ffmpeg
-    writes bounded interleaved float PCM directly to stdout, avoiding a
-    temporary lossless file plus a second decode.
+    ffmpeg writes bounded interleaved float PCM directly to stdout and
+    normalizes every reference to the Audio VAE contract: 32 kHz stereo.
+    This avoids torchaudio, whose binary extension may not match the HCU torch
+    runtime in deployment containers.
     """
 
     import subprocess
@@ -225,12 +221,11 @@ def _load_waveform(
     if material_chain == "audio":
         if source_sample_rate is None or int(source_sample_rate) <= 0:
             raise ValueError("reference audio sample rate must be positive")
-        source_rate = int(source_sample_rate)
     elif material_chain in {
         "video.reference_preserve",
         "video_audio.reference_preserve",
     }:
-        source_rate = 44100
+        pass
     else:
         raise ValueError(
             f"unsupported MiniMax H3 audio material chain {material_chain!r}"
@@ -251,9 +246,9 @@ def _load_waveform(
         "-vn",
         "-ac",
         str(MINIMAX_H3_AUDIO_CHANNELS),
+        "-ar",
+        str(MINIMAX_H3_AUDIO_SAMPLE_RATE),
     ]
-    if material_chain != "audio":
-        command += ["-ar", str(source_rate)]
     if max_duration_seconds is not None:
         command += ["-t", f"{max_duration_seconds:.9g}"]
     command += ["-f", "f32le", "pipe:1"]
@@ -272,14 +267,7 @@ def _load_waveform(
         .reshape(-1, MINIMAX_H3_AUDIO_CHANNELS)
         .T.copy()
     )
-    return waveform, source_rate
-
-
-@functools.lru_cache(maxsize=8)
-def _audio_resampler(source_rate: int):
-    import torchaudio
-
-    return torchaudio.transforms.Resample(source_rate, MINIMAX_H3_AUDIO_SAMPLE_RATE)
+    return waveform, MINIMAX_H3_AUDIO_SAMPLE_RATE
 
 
 @torch.inference_mode()
@@ -310,7 +298,10 @@ def minimax_h3_encode_reference_audio_rows(
     if waveform.numel() == 0:
         raise ValueError(f"reference audio is empty: {audio_path}")
     if int(source_rate) != MINIMAX_H3_AUDIO_SAMPLE_RATE:
-        waveform = _audio_resampler(int(source_rate))(waveform)
+        raise RuntimeError(
+            "MiniMax H3 reference audio must be decoded to "
+            f"{MINIMAX_H3_AUDIO_SAMPLE_RATE} Hz, got {source_rate}"
+        )
     waveform = waveform.to(device)
 
     with _AudioVAEDeterminismContext():

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -5,12 +5,15 @@ single-branch execution, and payload validation.
 
 from __future__ import annotations
 
+import json
+import os
 from collections.abc import Mapping
 from contextlib import contextmanager
 from functools import partial
 from typing import Any
 
 import torch
+import torch.distributed as dist
 
 from sglang.multimodal_gen.runtime.cache.cache_dit_integration import (
     CacheDitConfig,
@@ -46,6 +49,17 @@ _REF2VA_VIDEO_CHAINS = {
     "video.reference_preserve",
     "video_audio.reference_preserve",
 }
+
+_MINIMAX_H3_CACHE_DIT_STATS_ENV = "SGLANG_MINIMAX_H3_CACHE_DIT_STATS"
+
+
+def _minimax_h3_cache_dit_stats_enabled() -> bool:
+    return os.getenv(_MINIMAX_H3_CACHE_DIT_STATS_ENV, "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def minimax_h3_condition_noise_aug(sampling: Any) -> tuple[float, float]:
@@ -399,6 +413,36 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
             or super()._cache_dit_requested()
         )
 
+    def _maybe_log_cache_dit_stats(self) -> None:
+        """Log detailed Cache-DiT statistics for H3 on global rank zero."""
+
+        if not _minimax_h3_cache_dit_stats_enabled():
+            return
+        if not getattr(self, "_cache_dit_enabled", False):
+            return
+
+        is_rank_zero = not (
+            dist.is_available() and dist.is_initialized() and dist.get_rank() != 0
+        )
+
+        try:
+            import cache_dit
+
+            summary = cache_dit.summary(
+                self.transformer,
+                details=True,
+                logging=False,
+            )
+            if is_rank_zero:
+                logger.info(
+                    "H3_CACHE_DIT_RUNTIME_SUMMARY=%s",
+                    json.dumps(summary, ensure_ascii=False, default=str),
+                )
+        except Exception:
+            # Statistics are diagnostic-only and must not fail generation.
+            if is_rank_zero:
+                logger.exception("Failed to collect MiniMax-H3 Cache-DiT statistics")
+
     def _maybe_enable_cache_dit(
         self, num_inference_steps: int | tuple[int, int], batch: Req
     ) -> None:
@@ -417,16 +461,70 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
         # a time. Combined with `quality` in the dynamic-batch signature, this
         # makes the process-wide hook transition safe at this batch boundary.
         if self._cache_dit_enabled and current_mode != desired_mode:
+            # Keep preservation enabled until Cache-DiT has released every
+            # retained input reference.
             self.transformer = disable_cache_on_transformer(self.transformer)
             self._cache_dit_enabled = False
             self._cached_num_steps = None
             self._minimax_h3_cache_mode = None
+            self._set_cache_dit_input_preservation(False)
 
         if desired_mode is None:
             return
-        super()._maybe_enable_cache_dit(num_inference_steps, batch)
+
+        # Arm before mounting because Cache-DiT replaces `blocks` with its
+        # wrapper and the real H3 blocks are only directly reachable here.
+        was_enabled = self._cache_dit_enabled
+        if not was_enabled:
+            self._set_cache_dit_input_preservation(True)
+        try:
+            super()._maybe_enable_cache_dit(num_inference_steps, batch)
+        except Exception:
+            if not was_enabled:
+                self._disarm_after_failed_mount()
+            raise
+
         if self._cache_dit_enabled:
             self._minimax_h3_cache_mode = desired_mode
+        elif not was_enabled:
+            self._set_cache_dit_input_preservation(False)
+
+    def _disarm_after_failed_mount(self) -> None:
+        """Restore the in-place path after confirming a failed mount is gone."""
+
+        try:
+            self.transformer = disable_cache_on_transformer(self.transformer)
+        except Exception:
+            logger.warning(
+                "Could not unmount Cache-DiT after a failed mount; leaving "
+                "MiniMax-H3 input preservation on",
+                exc_info=True,
+            )
+            return
+        self._cache_dit_enabled = False
+        self._cached_num_steps = None
+        self._minimax_h3_cache_mode = None
+        self._set_cache_dit_input_preservation(False)
+
+    def _set_cache_dit_input_preservation(self, enabled: bool) -> None:
+        """Toggle the H3 block input-preservation path through wrappers."""
+
+        model = self.transformer
+        for _ in range(4):
+            if hasattr(model, "set_cache_dit_input_preservation"):
+                break
+            inner = getattr(model, "_orig_mod", None) or getattr(model, "module", None)
+            if inner is None:
+                break
+            model = inner
+        setter = getattr(model, "set_cache_dit_input_preservation", None)
+        if not callable(setter):
+            raise TypeError(
+                "MiniMax-H3 Cache-DiT requires set_cache_dit_input_preservation() "
+                f"on the transformer, but {type(self.transformer).__name__} does "
+                "not expose it"
+            )
+        setter(enabled)
 
     def _cache_dit_scm_masks(
         self, primary_num_steps: int, secondary_num_steps: int | None = None
@@ -610,6 +708,7 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
             video_rows=video_rows,
             audio_rows=audio_rows,
         )
+        self._maybe_log_cache_dit_stats()
 
     @contextmanager
     def _profile_denoising_step(self, step_index: int, *, batch: Req):

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py
@@ -25,8 +25,10 @@ from sglang.multimodal_gen.runtime.loader.utils import get_param_names_mapping
 from sglang.multimodal_gen.runtime.models.dits.minimax_h3 import (
     MINIMAX_H3_FP32_BUFFER_NAMES,
     MINIMAX_H3_FP32_PARAM_NAMES,
+    MiniMaxH3DiTBlock,
     MiniMaxH3DiTModel,
     _copy_grouped_qkv_tp_shard,
+    _modulate_gate,
     _reorder_grouped_qkv_to_qkv,
 )
 from sglang.multimodal_gen.test.single_test_file.component_accuracy.utils import (
@@ -97,6 +99,94 @@ def test_native_weight_names_and_grouped_qkv_reorder():
             assert torch.equal(
                 param.view(torch.int16), expected_shard.view(torch.int16)
             )
+
+
+class _KwargIdentity(torch.nn.Module):
+    def forward(self, x, **_kwargs):
+        return x
+
+
+def test_cache_dit_preservation_only_makes_first_gate_out_of_place():
+    block = MiniMaxH3DiTBlock.__new__(MiniMaxH3DiTBlock)
+    torch.nn.Module.__init__(block)
+    block.norm1 = torch.nn.Identity()
+    block.norm2 = torch.nn.Identity()
+    block.attn = _KwargIdentity()
+    block.mlp = torch.nn.Identity()
+    gate_modes = []
+
+    def fake_gate(residual, _gate, _other, _indices, *, dtype, allow_inplace=True):
+        gate_modes.append(allow_inplace)
+        return residual.to(dtype)
+
+    def run(preserve):
+        block.preserve_input_for_cache_dit = preserve
+        gate_modes.clear()
+        block(
+            torch.zeros(2, 4),
+            adaln_input=torch.zeros(1, 4),
+            combined_indices=torch.zeros(2, dtype=torch.long),
+            rope_cache=None,
+            cu_seqlens=torch.tensor([0, 2], dtype=torch.int32),
+            max_seqlen=2,
+            adaln_params=tuple(torch.zeros(1, 4) for _ in range(6)),
+        )
+        return list(gate_modes)
+
+    with (
+        patch(
+            "sglang.multimodal_gen.runtime.models.dits.minimax_h3._modulate_scale_shift",
+            side_effect=lambda value, *_args, **_kwargs: value,
+        ),
+        patch(
+            "sglang.multimodal_gen.runtime.models.dits.minimax_h3._modulate_gate",
+            side_effect=fake_gate,
+        ),
+    ):
+        assert run(preserve=False) == [True, True]
+        assert run(preserve=True) == [False, True]
+
+
+def test_cache_dit_input_preservation_toggles_every_block():
+    model = MiniMaxH3DiTModel.__new__(MiniMaxH3DiTModel)
+    torch.nn.Module.__init__(model)
+    model.blocks = torch.nn.ModuleList([torch.nn.Identity() for _ in range(5)])
+
+    model.set_cache_dit_input_preservation(True)
+    assert all(block.preserve_input_for_cache_dit for block in model.blocks)
+
+    model.set_cache_dit_input_preservation(False)
+    assert not any(block.preserve_input_for_cache_dit for block in model.blocks)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_cache_dit_out_of_place_gate_preserves_cuda_input():
+    x = torch.randn(4, 16, device="cuda", dtype=torch.bfloat16)
+    original = x.clone()
+    gate = torch.randn(2, 16, device="cuda", dtype=torch.bfloat16)
+    other = torch.randn_like(x)
+    indices = torch.tensor([0, 1, 0, 1], device="cuda", dtype=torch.long)
+    expected = _modulate_gate(
+        x.clone(),
+        gate,
+        other,
+        indices,
+        dtype=torch.bfloat16,
+        allow_inplace=True,
+    )
+
+    output = _modulate_gate(
+        x,
+        gate,
+        other,
+        indices,
+        dtype=torch.bfloat16,
+        allow_inplace=False,
+    )
+
+    assert output.data_ptr() != x.data_ptr()
+    torch.testing.assert_close(x, original, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
 
 
 def test_tp_and_ulysses_admission_uses_tp_local_shapes():

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_media.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_media.py
@@ -106,7 +106,7 @@ def test_audio_decode_is_bounded_float_pcm_without_temp_files(monkeypatch):
     )
 
     ffmpeg = next(command for command in commands if command[0] == "ffmpeg")
-    assert source_rate == 44100
+    assert source_rate == 32000
     torch.testing.assert_close(
         waveform,
         torch.tensor([[0, 2, 4, 6], [1, 3, 5, 7]], dtype=torch.float32),
@@ -114,4 +114,6 @@ def test_audio_decode_is_bounded_float_pcm_without_temp_files(monkeypatch):
     assert ffmpeg[ffmpeg.index("-t") + 1] == "3.5"
     assert ffmpeg[ffmpeg.index("-ss") + 1] == "2.25"
     assert ffmpeg.index("-ss") < ffmpeg.index("-i")
+    assert ffmpeg[ffmpeg.index("-ar") + 1] == "32000"
+    assert ffmpeg[ffmpeg.index("-ac") + 1] == "2"
     assert ffmpeg[-3:] == ["-f", "f32le", "pipe:1"]


### PR DESCRIPTION
一、修改动机

这个 PR 包含两项关联工作：第一项是让 MiniMax-H3 能够在 HCU/HIP 环境中运行；第二项是修复 MiniMax-H3 开启 CacheDiT 后残差统计失效的问题。

HCU 适配前，相关执行路径中包含多处 CUDA 专用假设，例如 CUDA 专用 fused QK-Norm JIT kernel、不适合 HCU 的 SDPA 后端选择、Qwen3/Qwen3-VL 中不稳定的 ROCm Attention 路径，以及可能与 HCU PyTorch 二进制不匹配的 torchaudio 依赖。

完成 HCU 适配后，CacheDiT 虽然能够挂载，但没有真正产生缓存命中。CacheDiT 会按引用保留 Fn 和 Mn 区域的输入 Tensor，并在后续 denoising step 中用这些输入计算 residual difference。MiniMax-H3 的 fused BF16 gated residual kernel 会原地更新输入 x，等价计算为 x = x + gate[indices] × other。由于 CacheDiT 保存的旧输入和当前 x 指向同一块显存，旧输入也会被覆盖，最终导致 residual difference 变为 NaN，缓存判断失效。

修复前典型日志：residual_diffs={'4': nan, '5': nan, '6': nan}；cached_steps=[]

两个 commit 放在同一个 PR 中，是因为第二个 CacheDiT 修复建立在第一个 MiniMax-H3 HCU 适配版本之上，并且是在同一 HCU 运行时中完成验证。

二、具体修改

2.1 MiniMax-H3 HCU Runtime 适配

Commit：c2efc92b3882a659929a59dca5dd076ee7388396

• HCU 上禁用 CUDA 专用的 fused QK-Norm JIT kernel，保留普通 RMSNorm fallback。
• 为多模态 Attention 选择 HCU 兼容的 SDPA 行为。
• 为 Qwen3 和 Qwen3-VL Encoder 增加 ROCm/HIP 安全路径。
• Qwen3-VL Text Encoder 避开当时不稳定的 ROCm Flash SDPA 路径。
• Reference Audio 通过 ffmpeg 直接解码为模型需要的 32 kHz 双声道 PCM。
• 避免依赖可能与 HCU PyTorch 二进制不兼容的 torchaudio。
• 同步调整 MiniMax-H3 Reference Encoding 和相关单元测试。

2.2 修复 MiniMax-H3 CacheDiT Residual Aliasing

Commit：c39171a7bceb9195f08d0acc20925387cba0b280

该实现参考官方上游 SGLang PR #33827 的输入保护思路，重点是在 CacheDiT 挂载期间保护它所保留的 block 输入。

• 保留原有原地 kernel indexed_gate_bf16_，同时新增非原地版本 indexed_gate_bf16。
• 为 _modulate_gate 增加 allow_inplace 参数。
• 未开启 CacheDiT 时继续使用原地 kernel，维持原来的快速路径。
• 开启 CacheDiT 时，每个 DiT block 的第一个 gated residual 使用非原地 kernel，避免覆盖 CacheDiT 保存的输入。
• 每个 block 的第二个 gated residual 继续使用原地 kernel，因为它操作的是 block 内部临时 Tensor，不是 CacheDiT 保存的输入。
• 在 CacheDiT 挂载前开启输入保护；CacheDiT 关闭或初始化失败后恢复原地路径。
• 支持 Transformer 被 compile 或 module wrapper 包装后的开关查找。
• 新增可选的 MiniMax-H3 CacheDiT 统计日志。

统计开关：SGLANG_MINIMAX_H3_CACHE_DIT_STATS=1
统计内容：cache_dit.summary(transformer, details=True)

三、正确性验证

3.1 CacheDiT 残差统计

修复前：cached_steps=[]；residual_diffs={'4': nan, '5': nan, '6': nan}

测试参数：Fn_compute_blocks=1；Bn_compute_blocks=0；residual_diff_threshold=0.24；max_continuous_cached_steps=3；max_warmup_steps=4

修复后：50-step FL2VA 请求实际执行 49 次 denoising iteration；缓存命中 34/49；residual difference 均为有限值；无 NaN。

3.2 输出文件验证

ffprobe：视频时长 5.207 秒；文件大小 2,094,131 bytes；输出文件有效。

3.3 Kernel 一致性

新增单元测试验证非原地 gated residual 的输出与原地实现完全一致，比较条件为 rtol=0、atol=0；同时验证原始输入 Tensor 未被修改，且输出与输入不共享同一数据指针。

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->