### PR TITLE
[feat] 适配main分支的moe接口

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2888,6 +2888,10 @@ def get_moe_tensor_parallel_rank():
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
+    from sglang.srt.layers.moe.mega_moe import destroy_mega_moe_symm_buffers
+
+    destroy_mega_moe_symm_buffers()
+
     dwdp_mgr = get_global_dwdp_manager()
     if dwdp_mgr is not None:
         dwdp_mgr.cleanup()

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -17,6 +17,7 @@ from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
 from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.unified_mem_hooks import unified_mla_hooks
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
@@ -50,10 +51,20 @@ if TYPE_CHECKING:
 
 from sgl_kernel import merge_state_v2
 
-from sglang.kernels.ops.attention.flash_attention import (
-    flash_attn_varlen_func,
-    flash_attn_with_kvcache,
-)
+if is_hcu():
+    from sglang.srt.layers.attention.flashattention_interface import (
+        flash_attn_varlen_func,
+        flash_attn_with_kvcache,
+        vllm_flash_attn_varlen_func,
+        vllm_flash_attn_with_kvcache,
+    )
+else:
+    from sglang.kernels.ops.attention.flash_attention import (
+        flash_attn_varlen_func,
+        flash_attn_with_kvcache,
+    )
+
+_kv_layout_hcu_fa = is_hcu() and envs.SGLANG_KV_LAYOUT_HCU_FA.get()
 
 
 def _should_disable_scheduler_metadata_precompute() -> bool:
@@ -263,7 +274,16 @@ class FlashAttentionBackend(AttentionBackend):
         self.fa_impl_ver = fa_impl_ver
         device_capability = get_device_capability()
         if is_hcu():
+            # HCU uses the flash-attn compatibility wrappers. The imports in the
+            # FA3/FA4 branches below are function-local, so relying on the
+            # module-level names here leaves these two locals unbound.
+            from sglang.srt.layers.attention.flashattention_interface import (
+                flash_attn_varlen_func,
+                flash_attn_with_kvcache,
+            )
+
             self._get_scheduler_metadata = None
+            self._get_fa_runtime_policy = None
         elif self.fa_impl_ver == 3:
             from sgl_kernel.flash_attn import (
                 flash_attn_varlen_func,
@@ -1383,12 +1403,20 @@ class FlashAttentionBackend(AttentionBackend):
             # Do multi-head attention
             key_cache, value_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
 
-            key_cache = key_cache.view(
-                -1, self.page_size, layer.tp_k_head_num, layer.head_dim
-            )
-            value_cache = value_cache.view(
-                -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
-            )
+            if _kv_layout_hcu_fa:
+                key_cache = key_cache.view(
+                    -1, layer.tp_k_head_num, self.page_size, layer.head_dim
+                )
+                value_cache = value_cache.view(
+                    -1, layer.tp_v_head_num, layer.v_head_dim, self.page_size
+                )
+            else:
+                key_cache = key_cache.view(
+                    -1, self.page_size, layer.tp_k_head_num, layer.head_dim
+                )
+                value_cache = value_cache.view(
+                    -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+                )
             if layer.is_cross_attention:
                 page_table = metadata.encoder_page_table
                 cache_seqlens = metadata.encoder_lens_int32
@@ -1492,6 +1520,47 @@ class FlashAttentionBackend(AttentionBackend):
                     causal=causal,
                     window_size=window_size,
                     softcap=layer.logit_cap,
+                    num_splits=self.num_splits,
+                    out=_fa_out,
+                    **kwargs,
+                )
+            elif _kv_layout_hcu_fa and max_seqlen_q > 1:
+                result = vllm_flash_attn_varlen_func(
+                    q=q.contiguous().view(
+                        -1, layer.tp_q_head_num, layer.head_dim
+                    ),
+                    k=key_cache,
+                    v=value_cache,
+                    cu_seqlens_q=cu_seqlens_q,
+                    max_seqlen_q=max_seqlen_q,
+                    seqused_k=cache_seqlens,
+                    max_seqlen_k=metadata.max_seq_len_k,
+                    softmax_scale=layer.scaling,
+                    causal=False if use_cascade_attn else causal,
+                    window_size=window_size,
+                    block_table=page_table,
+                    fa_version=2,
+                    q_descale=fa_k_descale,
+                    k_descale=fa_k_descale,
+                    v_descale=fa_v_descale,
+                    out=_fa_out,
+                )
+            elif _kv_layout_hcu_fa:
+                result = vllm_flash_attn_with_kvcache(
+                    q=q.contiguous()
+                    .view(-1, layer.tp_q_head_num, layer.head_dim)
+                    .unsqueeze(1),
+                    k_cache=key_cache,
+                    v_cache=value_cache,
+                    page_table=page_table,
+                    cache_seqlens=cache_seqlens,
+                    cu_seqlens_q=cu_seqlens_q,
+                    max_seqlen_q=max_seqlen_q,
+                    softmax_scale=layer.scaling,
+                    causal=False if use_cascade_attn else causal,
+                    window_size=window_size,
+                    softcap=layer.logit_cap,
+                    return_softmax_lse=use_cascade_attn,
                     num_splits=self.num_splits,
                     out=_fa_out,
                     **kwargs,
@@ -1888,16 +1957,24 @@ class FlashAttentionBackend(AttentionBackend):
             # Do multi-head attention
 
             key_cache, value_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
-            key_cache = key_cache.view(
-                -1, self.page_size, layer.tp_k_head_num, layer.head_dim
-            )
-            value_cache = value_cache.view(
-                -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
-            )
+            if _kv_layout_hcu_fa:
+                key_cache = key_cache.view(
+                    -1, layer.tp_k_head_num, self.page_size, layer.head_dim
+                )
+                value_cache = value_cache.view(
+                    -1, layer.tp_v_head_num, layer.v_head_dim, self.page_size
+                )
+            else:
+                key_cache = key_cache.view(
+                    -1, self.page_size, layer.tp_k_head_num, layer.head_dim
+                )
+                value_cache = value_cache.view(
+                    -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+                )
 
             if layer.is_cross_attention:
                 # Always use non-chunked logic for cross-attention
-                if self._decode_uses_static_max_seqlen_k:
+                if self._decode_uses_static_max_seqlen_k and not is_hcu():
                     kwargs["max_seqlen_k"] = metadata.encoder_max_seq_len_k
                 o = flash_attn_with_kvcache(
                     q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
@@ -1918,7 +1995,7 @@ class FlashAttentionBackend(AttentionBackend):
                 )
             elif use_local_attn:
                 # Use chunked (local) attention batching for self-attention
-                if self._decode_uses_static_max_seqlen_k:
+                if self._decode_uses_static_max_seqlen_k and not is_hcu():
                     kwargs["max_seqlen_k"] = local_attn_metadata.local_max_seq_len
                 o = flash_attn_with_kvcache(
                     q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
@@ -1975,8 +2052,16 @@ class FlashAttentionBackend(AttentionBackend):
                     sched_meta = metadata.scheduler_metadata
                 if self._decode_uses_static_max_seqlen_k:
                     kwargs["max_seqlen_k"] = metadata.max_seq_len_k
-                result = flash_attn_with_kvcache(
-                    q=q_reshaped,
+                decode_attn_func = flash_attn_with_kvcache
+                decode_q = q_reshaped
+                if is_hcu():
+                    # The HCU paged FP8 KV layout is consumed by the vLLM
+                    # compatibility kernel rather than the fp16/bf16-only
+                    # flash-attn kvcache entry point.
+                    decode_attn_func = vllm_flash_attn_with_kvcache
+                    decode_q = q_reshaped.unsqueeze(1)
+                result = decode_attn_func(
+                    q=decode_q,
                     k_cache=key_cache,
                     v_cache=value_cache,
                     page_table=page_table,

--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -79,22 +79,25 @@ def flash_attn_with_kvcache(
     return_softmax_lse=False,
     sinks=None,
     ver=3,
+    out=None,
 ):
     k_cache = k_cache.to(q.dtype) if not is_nmz_fp8(k_cache.dtype) else k_cache
     v_cache = v_cache.to(q.dtype) if not is_nmz_fp8(k_cache.dtype) else v_cache
-    return flash_attn_with_kvcache_interface(
-            q=q.contiguous().view(-1, max_seqlen_q, q.shape[-2], q.shape[-1]),
-            k_cache=k_cache,
-            v_cache=v_cache,
-            block_table=page_table,
-            cache_seqlens=cache_seqlens,
-            softmax_scale=softmax_scale,
-            causal=causal,
-            window_size=window_size,
-            softcap=softcap,
-            return_softmax_lse=return_softmax_lse,
-            num_splits=num_splits,
-        )
+    result = flash_attn_with_kvcache_interface(
+        q=q.contiguous().view(-1, max_seqlen_q, q.shape[-2], q.shape[-1]),
+        k_cache=k_cache,
+        v_cache=v_cache,
+        block_table=page_table,
+        cache_seqlens=cache_seqlens,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        softcap=softcap,
+        return_softmax_lse=return_softmax_lse,
+        num_splits=num_splits,
+    )
+    return _apply_flash_attn_varlen_out(result, out, return_softmax_lse)
+
 
 def vllm_flash_attn_with_kvcache(
     q,
@@ -130,9 +133,10 @@ def vllm_flash_attn_with_kvcache(
     return_softmax_lse=False,
     sinks=None,
     ver=3,
+    out=None,
 ):
     if _is_hcu and _use_triton_vllm_fa:
-        return triton_vllm_flash_attn_with_kvcache(
+        result = triton_vllm_flash_attn_with_kvcache(
             q=q,
             k_cache=k_cache,
             v_cache=v_cache,
@@ -147,8 +151,8 @@ def vllm_flash_attn_with_kvcache(
             softcap=softcap,
             return_softmax_lse=return_softmax_lse,
         )
-    
-    return vllm_flash_attn_with_kvcache_interface(
+    else:
+        result = vllm_flash_attn_with_kvcache_interface(
             q=q,
             k_cache=k_cache,
             v_cache=v_cache,
@@ -162,6 +166,8 @@ def vllm_flash_attn_with_kvcache(
             return_softmax_lse=return_softmax_lse,
             num_splits=num_splits,
         )
+    return _apply_flash_attn_varlen_out(result, out, return_softmax_lse)
+
 
 def _apply_flash_attn_varlen_out(result, out, return_softmax_lse):
     if out is None:
@@ -171,6 +177,12 @@ def _apply_flash_attn_varlen_out(result, out, return_softmax_lse):
         out.copy_(attn_out)
         return (out, lse, *rest)
     out.copy_(result)
+
+    # if return_softmax_lse:
+    #     attn_out, lse, *rest = result
+    #     out.copy_(attn_out.view_as(out))
+    #     return (out, lse, *rest)
+    # out.copy_(result.view_as(out))
     return out
 
 
@@ -262,9 +274,10 @@ def vllm_flash_attn_varlen_func(
     q_descale,
     k_descale,
     v_descale,
+    out=None,
 ):
     if _is_hcu and _use_triton_vllm_fa:
-        return triton_vllm_flash_attn_varlen_func(
+        result = triton_vllm_flash_attn_varlen_func(
             q=q,
             k=k,
             v=v,
@@ -281,21 +294,22 @@ def vllm_flash_attn_varlen_func(
             k_descale=k_descale,
             v_descale=v_descale,
         )
-
-    return vllm_flash_attn_varlen_func_interface(
-        q=q,
-        k=k,
-        v=v,
-        cu_seqlens_q=cu_seqlens_q,
-        max_seqlen_q=max_seqlen_q,
-        seqused_k=seqused_k,
-        max_seqlen_k=max_seqlen_k,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        window_size=window_size,
-        block_table=block_table,
-        fa_version=fa_version,
-        q_descale=q_descale,
-        k_descale=k_descale,
-        v_descale=v_descale,
-    )
+    else:
+        result = vllm_flash_attn_varlen_func_interface(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlen_q=max_seqlen_q,
+            seqused_k=seqused_k,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            block_table=block_table,
+            fa_version=fa_version,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
+        )
+    return _apply_flash_attn_varlen_out(result, out, False)

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -66,6 +66,9 @@ _MEGA_MOE_HCU_BACKEND_NORMAL = "normal"
 _MEGA_MOE_HCU_NORMAL_LL_TOKEN_THRESHOLD_ENV = "MEGAMOE_HCU_NORMAL_LL_TOKEN_THRESHOLD"
 _MEGA_MOE_HCU_NORMAL_LL_TOKEN_THRESHOLD = 496
 _MEGA_MOE_HCU_K3_TAIL_REDUCE_ENV = "K3_USE_ASM_TAIL_REDUCE"
+_MEGA_MOE_QUANT_MODE_FP8 = "fp8"
+_MEGA_MOE_QUANT_MODE_INT8 = "int8"
+_MEGA_MOE_HCU_WEIGHT_LAYOUT_NORMAL = "normal"
 
 logger = logging.getLogger(__name__)
 
@@ -272,6 +275,7 @@ def _get_mega_moe_symm_buffer(
     intermediate_hidden: int,
     *,
     runtime: str,
+    quant_mode: str = _MEGA_MOE_QUANT_MODE_FP8,
     cuda_graph_max_tokens_per_rank: Optional[int] = None,
 ) -> SymmBuffer:
     if _IS_HCU and runtime == _HCU_MEGA_MOE_RUNTIME_MEGAMOE:
@@ -289,6 +293,7 @@ def _get_mega_moe_symm_buffer(
 
     key = (
         package_key,
+        quant_mode,
         id(group),
         num_max_tokens_per_rank,
         cuda_graph_max_tokens_per_rank,
@@ -300,6 +305,8 @@ def _get_mega_moe_symm_buffer(
     buf = _MEGA_MOE_SYMM_BUFFER.get(key)
     if buf is None:
         kwargs = {}
+        if package_key == _HCU_MEGA_MOE_RUNTIME_MEGAMOE:
+            kwargs["quant_mode"] = quant_mode
         if cuda_graph_max_tokens_per_rank is not None:
             kwargs["cuda_graph_max_tokens_per_rank"] = cuda_graph_max_tokens_per_rank
         buf = factory(
@@ -317,7 +324,11 @@ def _get_mega_moe_symm_buffer(
     return buf
 
 
-def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bool:
+def should_use_mega_moe(
+    moe: DeepseekV2MoE,
+    hidden_states: torch.Tensor,
+    forward_batch: Optional[ForwardBatch] = None,
+) -> bool:
     if not get_moe_a2a_backend().is_megamoe():
         return False
     if not getattr(moe.experts, "_mega_moe_weights_built", False):
@@ -331,6 +342,21 @@ def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bo
                 f"built={built_runtime!r}, current={runtime!r}. Restart the "
                 "server after changing SGLANG_HCU_MEGA_MOE_RUNTIME."
             )
+        if (
+            runtime == _HCU_MEGA_MOE_RUNTIME_MEGAMOE
+            and getattr(moe.experts, "_mega_moe_quant_mode", _MEGA_MOE_QUANT_MODE_FP8)
+            == _MEGA_MOE_QUANT_MODE_INT8
+        ):
+            if getattr(moe.experts, "_mega_moe_hcu_weight_layout", None) != (
+                _MEGA_MOE_HCU_WEIGHT_LAYOUT_NORMAL
+            ):
+                return False
+            if get_is_capture_mode():
+                raise RuntimeError(
+                    "The standalone HCU INT8 MegaMoE path requires eager "
+                    "execution and cannot run inside CUDA/HIP graph capture."
+                )
+            return True
     elif _device_sm == 90:
         if not is_sm90_fp8_mega_moe_available(moe.experts):
             return False
@@ -347,9 +373,9 @@ def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bo
 
 
 def forward_mega_moe(
-    moe: "DeepseekV2MoE",
+    moe: DeepseekV2MoE,
     hidden_states: torch.Tensor,
-    forward_batch: Optional["ForwardBatch"] = None,
+    forward_batch: Optional[ForwardBatch] = None,
     input_ids_global: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     num_tokens = hidden_states.shape[0]
@@ -384,9 +410,9 @@ def forward_mega_moe(
 
 
 def _run_mega_routed(
-    moe: "DeepseekV2MoE",
+    moe: DeepseekV2MoE,
     hidden_states: torch.Tensor,
-    forward_batch: Optional["ForwardBatch"],
+    forward_batch: Optional[ForwardBatch],
     input_ids_global: Optional[torch.Tensor],
     num_tokens: int,
 ) -> torch.Tensor:
@@ -433,6 +459,7 @@ def _run_mega_routed(
     )
 
     runtime = get_hcu_mega_moe_runtime() if _IS_HCU else _HCU_MEGA_MOE_RUNTIME_DEEP_GEMM
+    quant_mode = getattr(moe.experts, "_mega_moe_quant_mode", _MEGA_MOE_QUANT_MODE_FP8)
     cuda_graph_max_tokens_per_rank = (
         _get_hcu_cuda_graph_max_tokens_per_rank(
             num_max_tokens_per_rank,
@@ -440,6 +467,7 @@ def _run_mega_routed(
         )
         if _IS_HCU
         and runtime == _HCU_MEGA_MOE_RUNTIME_MEGAMOE
+        and quant_mode == _MEGA_MOE_QUANT_MODE_FP8
         and get_is_capture_mode()
         else None
     )
@@ -451,21 +479,34 @@ def _run_mega_routed(
         hidden=hidden_size,
         intermediate_hidden=intermediate_size,
         runtime=runtime,
+        quant_mode=quant_mode,
         cuda_graph_max_tokens_per_rank=cuda_graph_max_tokens_per_rank,
     )
 
     if _IS_HCU:
         if runtime == _HCU_MEGA_MOE_RUNTIME_MEGAMOE:
-            y = _run_standalone_hcu_w8a8_mega_moe(
-                hidden_states=hidden_states,
-                topk_ids=topk_ids,
-                topk_weights=topk_weights,
-                moe=moe,
-                buf=buf,
-                num_tokens=num_tokens,
-                hidden_size=hidden_size,
-                dispatch_num_tokens=dispatch_num_tokens,
-            )
+            if quant_mode == _MEGA_MOE_QUANT_MODE_INT8:
+                y = _run_standalone_hcu_w8a8_int8_mega_moe(
+                    hidden_states=hidden_states,
+                    topk_ids=topk_ids,
+                    topk_weights=topk_weights,
+                    moe=moe,
+                    buf=buf,
+                    num_tokens=num_tokens,
+                    hidden_size=hidden_size,
+                    dispatch_num_tokens=dispatch_num_tokens,
+                )
+            else:
+                y = _run_standalone_hcu_w8a8_mega_moe(
+                    hidden_states=hidden_states,
+                    topk_ids=topk_ids,
+                    topk_weights=topk_weights,
+                    moe=moe,
+                    buf=buf,
+                    num_tokens=num_tokens,
+                    hidden_size=hidden_size,
+                    dispatch_num_tokens=dispatch_num_tokens,
+                )
         else:
             y = _run_deep_gemm_hcu_w8a8_mega_moe(
                 hidden_states=hidden_states,
@@ -559,7 +600,7 @@ def _run_deep_gemm_hcu_w8a8_mega_moe(
     hidden_states: torch.Tensor,
     topk_ids: Optional[torch.Tensor],
     topk_weights: Optional[torch.Tensor],
-    moe: "DeepseekV2MoE",
+    moe: DeepseekV2MoE,
     buf,
     num_tokens: int,
     hidden_size: int,
@@ -598,7 +639,7 @@ def _run_standalone_hcu_w8a8_mega_moe(
     hidden_states: torch.Tensor,
     topk_ids: Optional[torch.Tensor],
     topk_weights: Optional[torch.Tensor],
-    moe: "DeepseekV2MoE",
+    moe: DeepseekV2MoE,
     buf,
     num_tokens: int,
     hidden_size: int,
@@ -654,6 +695,72 @@ def _run_standalone_hcu_w8a8_mega_moe(
     return y[:num_tokens]
 
 
+def _run_standalone_hcu_w8a8_int8_mega_moe(
+    *,
+    hidden_states: torch.Tensor,
+    topk_ids: Optional[torch.Tensor],
+    topk_weights: Optional[torch.Tensor],
+    moe: DeepseekV2MoE,
+    buf,
+    num_tokens: int,
+    hidden_size: int,
+    dispatch_num_tokens: int,
+) -> torch.Tensor:
+    import megamoe
+
+    if get_is_capture_mode():
+        raise RuntimeError(
+            "The standalone HCU INT8 MegaMoE path requires eager execution"
+        )
+    if num_tokens == 0 and dispatch_num_tokens == 0:
+        return torch.empty(
+            (0, hidden_size),
+            dtype=torch.bfloat16,
+            device=hidden_states.device,
+        )
+
+    if num_tokens > 0:
+        topk_ids = (
+            topk_ids.to(torch.int64).contiguous()
+            if topk_ids.dtype not in (torch.int32, torch.int64)
+            else topk_ids.contiguous()
+        )
+        topk_weights = topk_weights.to(buf.topk_weights.dtype).contiguous()
+        megamoe.mega_moe_pre_dispatch_int8(
+            hidden_states.contiguous(),
+            topk_ids,
+            topk_weights,
+            buf.x,
+            buf.x_sf,
+            buf.topk_idx,
+            buf.topk_weights,
+            num_tokens=num_tokens,
+        )
+
+    y = torch.empty(
+        (num_tokens, hidden_size),
+        dtype=torch.bfloat16,
+        device=hidden_states.device,
+    )
+    megamoe.int8_w8a8_mega_moe(
+        y,
+        moe.experts.mega_l1_weights,
+        moe.experts.mega_l2_weights,
+        buf,
+        cumulative_local_expert_recv_stats=getattr(
+            moe.experts, "mega_moe_recv_stats", None
+        ),
+        recipe=(1, 1, 32),
+        activation="swiglu",
+        activation_clamp=getattr(moe.config, "swiglu_limit", None),
+        fast_math=True,
+        megamoe_backend=_MEGA_MOE_HCU_BACKEND_NORMAL,
+        graph=False,
+        capacity_num_tokens=dispatch_num_tokens,
+    )
+    return y
+
+
 def _interleave_mega_moe_gate_up(t: torch.Tensor, gran: int = 8) -> torch.Tensor:
     # Match DeepGEMM's L1 gate/up layout:
     # [gate: 0..7, up: 0..7, gate: 8..15, up: 8..15, ...].
@@ -683,7 +790,6 @@ def _transpose_mega_moe_sf_for_utccp(sf: torch.Tensor) -> torch.Tensor:
         .reshape(num_groups, mn, packed_sf_k)
     )
     return torch.empty_like(sf).copy_(result)
-
 
 
 def build_mega_moe_experts_weights(experts) -> None:
@@ -729,7 +835,9 @@ def build_mega_moe_experts_weights(experts) -> None:
         # the deep-ep path consumes the non-transposed interleaved scale and a
         # swizzle-aware activation kernel. L2 weight is untouched by the mega
         # transform, so the existing `w2_weight.data` is shared directly.
-        w13_interleaved, w13_sf_interleaved = _interleave_mega_moe_l1_weights((w13, w13_sf))
+        w13_interleaved, w13_sf_interleaved = _interleave_mega_moe_l1_weights(
+            (w13, w13_sf)
+        )
         w13_sf_utccp = _transpose_mega_moe_sf_for_utccp(w13_sf_interleaved)
         w2_sf_utccp = _transpose_mega_moe_sf_for_utccp(w2_sf)
 
@@ -867,4 +975,92 @@ def build_hcu_w8a8_mega_moe_experts_weights(experts) -> None:
 
     experts._mega_moe_hcu_runtime = runtime
     experts._mega_moe_hcu_w8a8_weights = True
+    experts._mega_moe_quant_mode = _MEGA_MOE_QUANT_MODE_FP8
     experts._mega_moe_weights_built = True
+
+
+def build_hcu_w8a8_int8_mega_moe_experts_weights(experts) -> None:
+    runtime = get_hcu_mega_moe_runtime()
+    if runtime != _HCU_MEGA_MOE_RUNTIME_MEGAMOE:
+        raise ValueError(
+            "HCU INT8 MegaMoE weights require SGLANG_HCU_MEGA_MOE_RUNTIME=megamoe"
+        )
+    if getattr(experts, "_mega_moe_weights_built", False):
+        built_runtime = getattr(experts, "_mega_moe_hcu_runtime", runtime)
+        built_quant_mode = getattr(
+            experts, "_mega_moe_quant_mode", _MEGA_MOE_QUANT_MODE_INT8
+        )
+        if built_runtime != runtime or built_quant_mode != _MEGA_MOE_QUANT_MODE_INT8:
+            raise RuntimeError(
+                "HCU MegaMoE expert weights were already built for an "
+                "incompatible runtime or quantization mode: "
+                f"runtime={built_runtime!r}, quant_mode={built_quant_mode!r}"
+            )
+        return
+
+    w13 = experts.w13_weight.data
+    w2 = experts.w2_weight.data
+    if w13.dim() != 3 or w2.dim() != 3:
+        raise ValueError(
+            "HCU INT8 MegaMoE requires grouped 3D expert weights; "
+            f"got w13={tuple(w13.shape)}, w2={tuple(w2.shape)}"
+        )
+    if w13.dtype != torch.int8 or w2.dtype != torch.int8:
+        raise ValueError("HCU INT8 MegaMoE requires signed INT8 expert weights")
+
+    num_local_experts, l1_rows, hidden_size = w13.shape
+    num_w2_experts, l2_rows, intermediate_size = w2.shape
+    if num_local_experts != num_w2_experts:
+        raise ValueError(
+            "HCU INT8 MegaMoE w13/w2 local expert count mismatch; "
+            f"got w13={tuple(w13.shape)}, w2={tuple(w2.shape)}"
+        )
+    if l2_rows != hidden_size or l1_rows != 2 * intermediate_size:
+        raise ValueError(
+            "HCU INT8 MegaMoE requires w13=[E,2I,H] and w2=[E,H,I]; "
+            f"got w13={tuple(w13.shape)}, w2={tuple(w2.shape)}"
+        )
+
+    device = w13.device
+    w13_scale = _hcu_channelwise_scale(experts, ("w13_weight_scale",), l1_rows, "w13")
+    w2_scale = _hcu_channelwise_scale(experts, ("w2_weight_scale",), l2_rows, "w2")
+    if w13_scale.device != device or w2_scale.device != device:
+        raise ValueError(
+            "HCU INT8 MegaMoE weights and channelwise scales must be on the same device"
+        )
+    for name, scale in (("w13_weight_scale", w13_scale), ("w2_weight_scale", w2_scale)):
+        if not torch.all(torch.isfinite(scale) & (scale > 0)).item():
+            raise ValueError(f"HCU INT8 MegaMoE {name} must be finite and positive")
+
+    import megamoe
+
+    l1_weights, l2_weights = megamoe.transform_int8_weights_for_mega_moe_normal(
+        (w13.contiguous(), w13_scale),
+        (w2.contiguous(), w2_scale),
+    )
+    for weights in (l1_weights, l2_weights):
+        packed_weight, scale = weights[_MEGA_MOE_HCU_WEIGHT_LAYOUT_NORMAL]
+        if packed_weight.device != device or scale.device != device:
+            raise RuntimeError(
+                "HCU INT8 MegaMoE weight repack must remain on the model device"
+            )
+
+    experts.w13_weight.data = torch.empty((0,), dtype=torch.int8, device=device)
+    experts.w2_weight.data = torch.empty((0,), dtype=torch.int8, device=device)
+
+    experts.mega_l1_weights = l1_weights
+    experts.mega_l2_weights = l2_weights
+    experts._mega_moe_hcu_runtime = runtime
+    experts._mega_moe_hcu_w8a8_weights = True
+    experts._mega_moe_quant_mode = _MEGA_MOE_QUANT_MODE_INT8
+    experts._mega_moe_hcu_weight_layout = _MEGA_MOE_HCU_WEIGHT_LAYOUT_NORMAL
+    experts._mega_moe_weights_built = True
+
+
+def destroy_mega_moe_symm_buffers() -> None:
+    buffers = list(dict.fromkeys(_MEGA_MOE_SYMM_BUFFER.values()))
+    for buffer in buffers:
+        destroy = getattr(buffer, "destroy", None)
+        if destroy is not None:
+            destroy()
+    _MEGA_MOE_SYMM_BUFFER.clear()

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -667,6 +667,7 @@ def pre_permute_standard_to_aiter(
     return AiterRunnerInput(
         hidden_states=hidden_states,
         topk_weights=topk_weights,
+        topk_ids=topk_ids,
         quant_type=quant_info.quant_type,
     )
 

--- a/python/sglang/srt/layers/moe/moe_runner/lightop.py
+++ b/python/sglang/srt/layers/moe/moe_runner/lightop.py
@@ -114,34 +114,95 @@ class LightOpMoeQuantInfo(MoeQuantInfo):
     w2_scale: torch.Tensor
     a13_scale: Optional[torch.Tensor] = None
     a2_scale: Optional[torch.Tensor] = None
+    use_fp8_w8a8: bool = False
+    use_int8_w8a8: bool = True
+    origin_w13_shape: Optional[torch.Size] = None
+    origin_w2_shape: Optional[torch.Size] = None
 
 
-def get_lightop_marlin_weight(weight: torch.Tensor) -> torch.Tensor:
+def _is_moe_prefill_or_normal() -> bool:
+    from sglang.srt.runtime_context import get_server_args
+
+    server_args = get_server_args()
+    return (
+        server_args.disaggregation_mode == "prefill"
+        or server_args.deepep_mode == "normal"
+    )
+
+
+def get_lightop_marlin_weight(
+    weight: torch.Tensor, *, use_fp8_w8a8: bool = False
+) -> torch.Tensor:
     if get_moe_a2a_backend().is_deepep():
+        if use_fp8_w8a8 and _is_moe_prefill_or_normal():
+            from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import (
+                weight8bit_nt_kpack2_marlin,
+            )
+
+            return weight8bit_nt_kpack2_marlin(weight)
         return weight8bit_nt_kpack2_marlin1(weight)
+
+    if use_fp8_w8a8:
+        from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import (
+            w8a8_2_marlin_weight,
+        )
+
+        return w8a8_2_marlin_weight(weight)
     return get_w8a8_int8_marlin_weights(weight)
 
 
-def process_weights_after_loading_lightop(layer: torch.nn.Module) -> None:
+def process_weights_after_loading_lightop(
+    layer: torch.nn.Module, *, use_fp8_w8a8: bool = False
+) -> None:
+    origin_w13_shape = layer.w13_weight.shape
+    origin_w2_shape = layer.w2_weight.shape
+    if use_fp8_w8a8:
+        if (
+            layer.w13_weight.dim() != 3
+            or layer.w2_weight.dim() != 3
+            or layer.w13_weight.size(0) != layer.w2_weight.size(0)
+        ):
+            raise RuntimeError("Unexpected MoE weight shapes")
+        two_n, hidden_size = layer.w13_weight.shape[1:]
+        if layer.w2_weight.size(1) != hidden_size:
+            raise RuntimeError("Unexpected MoE w2 layout")
+        intermediate_size = layer.w2_weight.size(2)
+        if two_n != 2 * intermediate_size:
+            raise RuntimeError("Unexpected MoE hidden dims")
+        if (
+            hidden_size % 32 != 0
+            or intermediate_size % 16 != 0
+            or two_n % 32 != 0
+        ):
+            raise RuntimeError("Marlin packing requires alignment")
+
     w13_weight = torch.stack(
         [
-            get_lightop_marlin_weight(layer.w13_weight[i])
+            get_lightop_marlin_weight(
+                layer.w13_weight[i], use_fp8_w8a8=use_fp8_w8a8
+            )
             for i in range(layer.w13_weight.shape[0])
         ],
         dim=0,
     )
     w2_weight = torch.stack(
         [
-            get_lightop_marlin_weight(layer.w2_weight[i])
+            get_lightop_marlin_weight(
+                layer.w2_weight[i], use_fp8_w8a8=use_fp8_w8a8
+            )
             for i in range(layer.w2_weight.shape[0])
         ],
         dim=0,
     )
     layer.w13_weight = Parameter(w13_weight, requires_grad=False)
     layer.w2_weight = Parameter(w2_weight, requires_grad=False)
+    layer._lightop_origin_w13_shape = origin_w13_shape
+    layer._lightop_origin_w2_shape = origin_w2_shape
 
 
-def get_lightop_quant_info(layer: torch.nn.Module) -> LightOpMoeQuantInfo:
+def get_lightop_quant_info(
+    layer: torch.nn.Module, *, use_fp8_w8a8: bool = False
+) -> LightOpMoeQuantInfo:
     return LightOpMoeQuantInfo(
         w13_weight=layer.w13_weight,
         w2_weight=layer.w2_weight,
@@ -149,6 +210,10 @@ def get_lightop_quant_info(layer: torch.nn.Module) -> LightOpMoeQuantInfo:
         w2_scale=layer.w2_weight_scale,
         a13_scale=layer.w13_input_scale,
         a2_scale=layer.w2_input_scale,
+        use_fp8_w8a8=use_fp8_w8a8,
+        use_int8_w8a8=not use_fp8_w8a8,
+        origin_w13_shape=getattr(layer, "_lightop_origin_w13_shape", None),
+        origin_w2_shape=getattr(layer, "_lightop_origin_w2_shape", None),
     )
 
 
@@ -168,25 +233,52 @@ class LightOpRunnerCore(MoeRunnerCore):
             else 1.0
         )
 
-        output = torch.ops.sglang.fused_experts_impl_int8_marlin(
-            runner_input.hidden_states,
-            quant_info.w13_weight,
-            quant_info.w2_weight,
-            topk_weights=runner_input.topk_weights,
-            topk_ids=runner_input.topk_ids,
-            inplace=self.config.inplace,
-            activation=self.config.activation,
-            apply_router_weight_on_input=self.config.apply_router_weight_on_input,
-            use_int8_w8a8=True,
-            per_channel_quant=True,
-            global_num_experts=self.config.num_experts,
-            w1_scale=quant_info.w13_scale,
-            w2_scale=quant_info.w2_scale,
-            a1_scale=quant_info.a13_scale,
-            a2_scale=quant_info.a2_scale,
-            use_nn_moe=False,
-            routed_scaling_factor=float(routed_scaling_factor),
-        )
+        if quant_info.use_fp8_w8a8:
+            if (
+                quant_info.origin_w13_shape is None
+                or quant_info.origin_w2_shape is None
+            ):
+                raise RuntimeError("Missing original FP8 MoE weight shapes")
+
+            from sglang.srt.layers.moe.fused_moe_triton.fused_moe import (
+                fused_moe_fp8_w8a8,
+            )
+
+            output = fused_moe_fp8_w8a8(
+                hidden_states=runner_input.hidden_states,
+                w1=quant_info.w13_weight,
+                w2=quant_info.w2_weight,
+                w1_scale=quant_info.w13_scale,
+                w2_scale=quant_info.w2_scale,
+                topk_weights=runner_input.topk_weights,
+                topk_ids=runner_input.topk_ids,
+                global_num_experts=self.config.num_experts,
+                inplace=self.config.inplace,
+                origin_w1_shape=quant_info.origin_w13_shape,
+                origin_w2_shape=quant_info.origin_w2_shape,
+                routed_scaling_factor=routed_scaling_factor,
+            )
+        else:
+            output = torch.ops.sglang.fused_experts_impl_int8_marlin(
+                runner_input.hidden_states,
+                quant_info.w13_weight,
+                quant_info.w2_weight,
+                topk_weights=runner_input.topk_weights,
+                topk_ids=runner_input.topk_ids,
+                inplace=self.config.inplace,
+                activation=self.config.activation,
+                apply_router_weight_on_input=self.config.apply_router_weight_on_input,
+                use_fp8_w8a8=False,
+                use_int8_w8a8=quant_info.use_int8_w8a8,
+                per_channel_quant=True,
+                global_num_experts=self.config.num_experts,
+                w1_scale=quant_info.w13_scale,
+                w2_scale=quant_info.w2_scale,
+                a1_scale=quant_info.a13_scale,
+                a2_scale=quant_info.a2_scale,
+                use_nn_moe=False,
+                routed_scaling_factor=float(routed_scaling_factor),
+            )
         return LightOpRunnerOutput(hidden_states=output)
 
     @property

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
@@ -34,7 +34,7 @@ if _is_cuda or _is_hip or _is_xpu or _is_musa:
     from sglang.kernels.ops.moe import moe_align_block_size as sgl_moe_align_block_size
 
 if _is_hcu:
-    from lightop import op
+    from lightop import moe as op
 
 if _is_cuda:
     from sglang.kernels.ops.moe.moe_align_small_numel import (

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -177,6 +177,9 @@ class MoeRunnerBackend(Enum):
     def is_aiter(self):
         return self == MoeRunnerBackend.AITER
 
+    def is_lightop(self):
+        return self == MoeRunnerBackend.LIGHTOP
+
 
 class DeepEPMode(Enum):
 

--- a/python/sglang/srt/layers/quantization/w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_fp8.py
@@ -45,7 +45,6 @@ from sglang.srt.layers.quantization.fp8_utils import (
     input_to_float8,
     normalize_e4m3fn_to_e4m3fnuz,
 )
-from sglang.srt.runtime_context import get_server_args
 from sglang.srt.utils import get_bool_env_var, is_hcu, set_weight_attrs
 
 if TYPE_CHECKING:
@@ -57,24 +56,6 @@ if TYPE_CHECKING:
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_hcu = is_hcu()
 _use_fp8_w8a8_moe = get_bool_env_var("SGLANG_USE_FP8_W8A8_MOE")
-
-
-def _is_moe_prefill_or_normal() -> bool:
-    server_args = get_server_args()
-    return (
-        server_args.disaggregation_mode == "prefill"
-        or server_args.deepep_mode == "normal"
-    )
-
-
-try:
-    from lightop.moe import (  # noqa: F401
-        fused_experts_impl_w4a8_marlin,
-    )
-except Exception:
-    print(
-        "INFO: Please install lightop if you want to infer the quantitative model of moe.\n"
-    )
 
 
 class W8A8Fp8Config(QuantizationConfig):
@@ -250,7 +231,6 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
 
     def __init__(self, quant_config: W8A8Fp8Config):
         self.quant_config = quant_config
-        self.use_deepep = get_moe_a2a_backend().is_deepep()
 
     def create_weights(
         self,
@@ -332,88 +312,21 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
             build_hcu_w8a8_mega_moe_experts_weights(layer)
             return
 
-        if _is_hcu and _use_fp8_w8a8_moe:
-            w1 = layer.w13_weight
-            w2 = layer.w2_weight
-            w1_shape = w1.shape
-            w2_shape = w2.shape
-            if w1.is_cuda and w2.is_cuda:
-                if w1.dim() != 3 or w2.dim() != 3 or w1.size(0) != w2.size(0):
-                    raise RuntimeError("Unexpected MoE weight shapes")
-                twoN, K = w1.size(1), w1.size(2)
-                if w2.size(1) != K:
-                    raise RuntimeError("Unexpected MoE w2 layout")
-                N = w2.size(2)
-                if twoN != 2 * N:
-                    raise RuntimeError("Unexpected MoE hidden dims")
-                if K % 16 != 0 or K % 32 != 0 or N % 16 != 0 or twoN % 32 != 0:
-                    raise RuntimeError("Marlin packing requires alignment")
+        if _is_hcu and self.runner.runner_backend.is_lightop():
+            from sglang.srt.layers.moe.moe_runner.lightop import (
+                process_weights_after_loading_lightop,
+            )
 
-                from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import (
-                    w8a8_2_marlin_weight,
-                    weight8bit_nt_kpack2_marlin,
-                    weight8bit_nt_kpack2_marlin1,
-                )
-
-                def _pack_per_expert(weight: torch.Tensor) -> torch.Tensor:
-                    num_experts = weight.shape[0]
-                    for i in range(num_experts):
-                        new_expert = w8a8_2_marlin_weight(weight[i]).contiguous()
-                        weight.data[i].view(-1).copy_(new_expert.view(-1))
-                    weight = weight.reshape((-1,) + new_expert.shape)
-
-                    return weight
-
-                def _pack_per_expert_deepep(weight: torch.Tensor) -> torch.Tensor:
-                    num_experts = weight.shape[0]
-                    for i in range(num_experts):
-                        if _is_moe_prefill_or_normal():
-                            new_expert = weight8bit_nt_kpack2_marlin(
-                                weight[i]
-                            ).contiguous()
-                        else:
-                            new_expert = weight8bit_nt_kpack2_marlin1(
-                                weight[i]
-                            ).contiguous()
-                        weight.data[i].view(-1).copy_(new_expert.view(-1))
-                    weight = weight.reshape((-1,) + new_expert.shape)
-                    return weight
-
-                with torch.no_grad():
-                    if self.use_deepep:
-                        w1_packed = _pack_per_expert_deepep(w1)
-                        w2_packed = _pack_per_expert_deepep(w2)
-                    else:
-                        w1_packed = _pack_per_expert(w1)
-                        w2_packed = _pack_per_expert(w2)
-
-                    new_w1 = Parameter(w1_packed, requires_grad=False)
-                    new_w2 = Parameter(w2_packed, requires_grad=False)
-
-                    if hasattr(w1, "__dict__"):
-                        for k, v in w1.__dict__.items():
-                            setattr(new_w1, k, v)
-                    if hasattr(w2, "__dict__"):
-                        for k, v in w2.__dict__.items():
-                            setattr(new_w2, k, v)
-
-                    setattr(new_w1, "_w8a8_fp8_packed", True)
-                    setattr(new_w1, "w1_shape", w1_shape)
-                    setattr(new_w2, "_w8a8_fp8_packed", True)
-                    setattr(new_w2, "w2_shape", w2_shape)
-
-                    layer.w13_weight = new_w1
-                    layer.w2_weight = new_w2
-                    layer._w8a8_fp8_packed = True
+            process_weights_after_loading_lightop(layer, use_fp8_w8a8=True)
         else:
             layer.w13_weight = Parameter(layer.w13_weight, requires_grad=False)
             layer.w2_weight = Parameter(layer.w2_weight, requires_grad=False)
-            layer.w13_weight_scale = Parameter(
-                layer.w13_weight_scale.data, requires_grad=False
-            )
-            layer.w2_weight_scale = Parameter(
-                layer.w2_weight_scale.data, requires_grad=False
-            )
+        layer.w13_weight_scale = Parameter(
+            layer.w13_weight_scale.data, requires_grad=False
+        )
+        layer.w2_weight_scale = Parameter(
+            layer.w2_weight_scale.data, requires_grad=False
+        )
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
@@ -425,6 +338,8 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
 
         if moe_runner_backend.is_aiter() and _is_hcu:
             self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
+        elif moe_runner_backend.is_lightop() and _is_hcu:
+            self.runner = MoeRunner(MoeRunnerBackend.LIGHTOP, moe_runner_config)
         elif moe_runner_backend.is_triton():
             self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
         else:
@@ -450,10 +365,6 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
         i_q: Optional[torch.Tensor] = None,
         i_s: Optional[torch.Tensor] = None,
     ) -> CombineInput:
-        x = dispatch_output.hidden_states
-        topk_output = dispatch_output.topk_output
-        moe_runner_config = self.moe_runner_config
-
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
         if _is_hcu and self.runner.runner_backend.is_aiter():
@@ -469,48 +380,19 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
                 )
             return combine_input
 
-        if _is_hcu and _use_fp8_w8a8_moe:
-            if getattr(layer.w13_weight, "_w8a8_fp8_packed", False) or getattr(
-                layer.w2_weight, "_w8a8_fp8_packed", False
-            ):
-                topk_weights, topk_ids, _ = topk_output
-                use_prequant_input = i_q is not None and i_s is not None
-                if moe_runner_config.apply_router_weight_on_input:
-                    assert (
-                        topk_weights.dim() == 2
-                    ), "`topk_weights` should be (num_tokens, topk)"
-                    _, tk = topk_weights.shape
-                    assert (
-                        tk == 1
-                    ), "HCU marlin path: apply_router_weight_on_input requires topk=1"
-                    x = x * topk_weights.to(x.dtype)
-                    topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
-                    # Router-weighted input no longer matches precomputed rms-quant activations.
-                    use_prequant_input = False
-                from sglang.srt.layers.moe.fused_moe_triton.fused_moe import (
-                    fused_moe_fp8_w8a8,
-                )
+        if _is_hcu and self.runner.runner_backend.is_lightop():
+            from sglang.srt.layers.moe.moe_runner.lightop import (
+                get_lightop_quant_info,
+            )
 
-                origin_w1_shape = getattr(layer.w13_weight, "w1_shape", None)
-                origin_w2_shape = getattr(layer.w2_weight, "w2_shape", None)
-                output = fused_moe_fp8_w8a8(
-                    hidden_states=x,
-                    w1=layer.w13_weight,
-                    w2=layer.w2_weight,
-                    w1_scale=layer.w13_weight_scale,
-                    w2_scale=layer.w2_weight_scale,
-                    topk_weights=topk_weights,
-                    topk_ids=topk_ids,
-                    global_num_experts=self.moe_runner_config.num_experts,
-                    inplace=True,
-                    origin_w1_shape=origin_w1_shape,
-                    origin_w2_shape=origin_w2_shape,
-                    routed_scaling_factor=moe_runner_config.routed_scaling_factor,
-                    bias=bias,
-                    hidden_states_fp8_input=i_q if use_prequant_input else None,
-                    hidden_states_scale_fp8_input=i_s if use_prequant_input else None,
+            quant_info = get_lightop_quant_info(layer, use_fp8_w8a8=True)
+            combine_input = self.runner.run(dispatch_output, quant_info)
+            if bias is not None:
+                return StandardCombineInput(
+                    hidden_states=combine_input.hidden_states + bias
                 )
-                return StandardCombineInput(hidden_states=output)
+            return combine_input
+
         quant_info = TritonMoeQuantInfo(
             w13_weight=layer.w13_weight,
             w2_weight=layer.w2_weight,

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, cast
 import torch
 from torch.nn.parameter import Parameter
 
-from sglang.kernels.ops.quantization.int8_kernel import per_token_quant_int8
+
 from sglang.srt.layers.amx_utils import (
     CPUQuantMethod,
     _amx_process_weight_after_loading,
@@ -41,6 +41,7 @@ from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
+    get_bool_env_var,
     is_cuda,
     is_hcu,
     is_host_cpu_arm64,
@@ -59,9 +60,12 @@ _is_hcu = is_hcu()
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_cpu_arm64 = is_host_cpu_arm64()
+_use_lightop = get_bool_env_var("SGLANG_USE_LIGHTOP")
 
-if _is_hcu:
+if _is_hcu and _use_lightop:
     from lightop.quant import per_token_quant_int8
+else:
+    from sglang.kernels.ops.quantization.int8_kernel import per_token_quant_int8
 
 if _is_cuda:
     from sgl_kernel import int8_scaled_mm  # noqa: F401 -- registers the custom op
@@ -243,6 +247,7 @@ class W8A8Int8LinearMethod(LinearMethodBase):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
+        input_quant_args: Optional[List[torch.Tensor]] = None,
     ):
         if use_intel_amx_backend(layer) or _is_cpu_arm64:
             return torch.ops.sgl_kernel.int8_scaled_mm_with_quant(
@@ -253,7 +258,11 @@ class W8A8Int8LinearMethod(LinearMethodBase):
                 x.dtype,
                 True,  # is_vnni
             )
-        x_q, x_scale = per_token_quant_int8(x)
+        if input_quant_args is not None:
+            assert len(input_quant_args) == 2
+            x_q, x_scale = input_quant_args
+        else:
+            x_q, x_scale = per_token_quant_int8(x)
 
         x_q_2d = x_q.view(-1, x_q.shape[-1])
         x_scale_2d = x_scale.view(-1, x_scale.shape[-1])

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -21,14 +21,13 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, cast
 import torch
 from torch.nn.parameter import Parameter
 
-
 from sglang.srt.layers.amx_utils import (
     CPUQuantMethod,
     _amx_process_weight_after_loading,
 )
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
-from sglang.srt.layers.moe.utils import get_moe_runner_backend
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend, get_moe_runner_backend
 from sglang.srt.layers.parameter import ChannelQuantScaleParameter, ModelWeightParameter
 from sglang.srt.layers.quantization.base_config import (
     FusedMoEMethodBase,
@@ -40,8 +39,8 @@ from sglang.srt.layers.quantization.compressed_tensors.utils import should_ignor
 from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
 from sglang.srt.utils import (
     cpu_has_amx_support,
-    is_cpu,
     get_bool_env_var,
+    is_cpu,
     is_cuda,
     is_hcu,
     is_host_cpu_arm64,
@@ -357,6 +356,13 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if _is_hcu and get_moe_a2a_backend().is_megamoe():
+            from sglang.srt.layers.moe.mega_moe import (
+                build_hcu_w8a8_int8_mega_moe_experts_weights,
+            )
+
+            build_hcu_w8a8_int8_mega_moe_experts_weights(layer)
+            return
         if _is_hcu and self.runner.runner_backend.is_lightop():
             from sglang.srt.layers.moe.moe_runner.lightop import (
                 process_weights_after_loading_lightop,

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -38,7 +38,9 @@ logger = logging.getLogger(__name__)
 _is_npu = is_npu()
 
 
-UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data processing
+UNBALANCED_MODEL_LOADING_TIMEOUT_S = int(
+    os.environ.get("SGLANG_UNBALANCED_MODEL_LOADING_TIMEOUT_S", "480")
+)
 
 
 def maybe_precompile_model_kernels_after_loading(model, device: str) -> None:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -906,7 +906,7 @@ class DeepseekV2MoE(nn.Module):
     ) -> torch.Tensor:
         from sglang.srt.layers.moe.mega_moe import forward_mega_moe, should_use_mega_moe
 
-        if should_use_mega_moe(self, hidden_states):
+        if should_use_mega_moe(self, hidden_states, forward_batch):
             return forward_mega_moe(
                 self,
                 hidden_states,

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -1272,7 +1272,7 @@ class MiniMaxM2DecoderLayer(nn.Module):
         if _use_fused_rms_quant:
             pre_norm = hidden_states.clone() if residual is None else residual
             hidden_states, _ = self.layer_communicator.prepare_attn(
-                hidden_states, residual, forward_batch, skip_layernorm=True
+                hidden_states, residual, forward_batch
             )
             if residual is not None:
                 assert residual.shape[0] == hidden_states.shape[0], (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6921,6 +6921,19 @@ class ServerArgs:
             logger.info(f"Waterfill is enabled with moe_a2a_backend='{a2a_backend}'.")
 
         if a2a_backend == "megamoe":
+            if (
+                is_hcu()
+                and envs.SGLANG_HCU_MEGA_MOE_RUNTIME.get().strip().lower()
+                == "megamoe"
+                and resolved_view(self).quantization == "w8a8_int8"
+            ):
+                self.disable_shared_experts_fusion = True
+                self.cuda_graph_config.decode.backend = Backend.DISABLED
+                self.cuda_graph_config.prefill.backend = Backend.DISABLED
+                logger.info(
+                    "HCU INT8 MegaMoE disables shared-expert fusion and CUDA "
+                    "graph because the standalone INT8 normal backend is eager-only."
+                )
             if not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set():
                 envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.set(True)
 


### PR DESCRIPTION
## 改动内容

- 修复 fused MoE 使用 LightOp 后端时的导入问题。
- 为 LightOp MoE 后端适配 W8A8 INT8 和 W8A8 FP8，补充权重打包、量化信息及执行路径分发。
- 适配 HCU MegaMoE，新增 W8A8 INT8 eager 执行、权重转换、对称缓冲区生命周期管理及运行限制。
- 扩展 FlashAttention 接口的 `out` 参数支持，调整 KV Cache 和 Varlen 路径的返回结果处理。
- 补充相关 ServerArgs、模型加载及 MoE 调用链适配。

## 动机 / 关联

补齐 DCU/HCU 场景下 LightOp MoE 的 W8A8 INT8/FP8 支持，并打通 MegaMoE 与 FlashAttention 接口适配，解决 fused MoE 在 LightOp 后端的导入和执行问题。

## 验证情况

| 项目 | 结果 | 环境 |
|---|---|---|
| 服务启动 | 已验证 | DCU/HCU 环境验证 |
| 推理无报错 | 已验证 | DCU/HCU 环境验证 |
| 静态检查 | 通过 | `git diff --check origin/main...main-yangyinan` |

## 环境快照

```text
0.5.12-ubuntu22.04-dtk2604-py3.10-20260807-0006
```

## 影响面

- [ ] 仅 DCU 分支代码，不影响通用路径
- [x] 改动通用路径（涉及 LightOp MoE 量化分发、MegaMoE 调用链及 FlashAttention `out` 接口；相关逻辑受后端、量化模式和 HCU 条件约束）
- [x] 涉及算子/kernel（需算子方向 review）

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->