### PR TITLE
[fix][minimax-h3]: fix HCU QK-Norm fallback and backend resolution

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -73,6 +73,7 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
 )
+from sglang.srt.utils import is_hcu
 
 logger = init_logger(__name__)
 
@@ -290,6 +291,7 @@ def _apply_qk_norm(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if (
         q.is_cuda
+        and not is_hcu()
         and q.dtype == _BF16_DTYPE
         and q.dtype == k.dtype == q_norm.weight.dtype == k_norm.weight.dtype
         and q.stride(-1) == k.stride(-1) == 1
@@ -1588,6 +1590,10 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             if isinstance(module, MiniMaxH3Attention):
                 module._set_attention_backend(backend)
         self._resolved_attention_backend = backend.get_enum()
+        logger.info(
+            "MiniMax-H3 transformer resolved attention backend: %s",
+            self._resolved_attention_backend,
+        )
 
     def _mark_missing_params_required(self) -> None:
         for _, param in self.named_parameters():
@@ -1608,6 +1614,10 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             )
         if self.adaln_cache is not None:
             self.adaln_cache.load(self.video_patch_proj.weight.device)
+        # Component-scoped backend overrides only exist while this component is
+        # being constructed and loaded. Resolve here before the loader exits
+        # that context instead of waiting until the first request.
+        self._resolve_attention_backend_once()
 
     @staticmethod
     def _pos_ids(pos_info: Any, key: str) -> torch.Tensor:

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -85,6 +85,7 @@ from sglang.multimodal_gen.utils import (
     StoreBoolean,
     expand_path_fields,
 )
+from sglang.srt.utils.common import is_hcu
 
 logger = init_logger(__name__)
 
@@ -899,6 +900,25 @@ class ServerArgs(DisaggServerArgsMixin):
                 self.component_attention_backends
             )
         )
+
+        if (
+            self.backend != Backend.DIFFUSERS
+            and type(self.pipeline_config).__name__ == "MiniMaxH3PipelineConfig"
+            and is_hcu()
+            and self.attention_backend == "fa"
+        ):
+            defaults = {
+                "text_encoder": "torch_sdpa",
+                "transformer": "fa",
+            }
+            for component, backend in defaults.items():
+                if component not in self.component_attention_backends:
+                    self.component_attention_backends[component] = backend
+                    logger.info(
+                        "Automatically set MiniMax-H3 HCU %s attention backend to %s",
+                        component,
+                        backend,
+                    )
 
         # attention_backend_config
         if self.attention_backend_config is None:

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -74,6 +74,7 @@ from sglang.multimodal_gen.runtime.pipelines.minimax_h3_pipeline import (
 )
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import (
+    Backend,
     MAX_SCHEDULER_RPC_TIMEOUT_S,
     ServerArgs,
 )
@@ -190,6 +191,49 @@ class TestServerArgsPathExpansion(unittest.TestCase):
 
         self.assertEqual(backend.name, "TORCH_SDPA")
         self.assertEqual(matched_key, "text_encoder")
+
+    def test_hcu_minimax_h3_fa_sets_safe_component_defaults(self):
+        args = ServerArgs.__new__(ServerArgs)
+        args.backend = Backend.AUTO
+        args.pipeline_config = MiniMaxH3PipelineConfig()
+        args.attention_backend = "fa"
+        args.component_attention_backends = {}
+        args.attention_backend_config = None
+        args.ring_degree = 1
+
+        with patch(
+            "sglang.multimodal_gen.runtime.server_args.server_args.is_hcu",
+            return_value=True,
+        ):
+            args._adjust_attention_backend()
+
+        self.assertEqual(
+            args.component_attention_backends,
+            {"text_encoder": "torch_sdpa", "transformer": "fa"},
+        )
+
+    def test_hcu_minimax_h3_preserves_explicit_component_backend(self):
+        args = ServerArgs.__new__(ServerArgs)
+        args.backend = Backend.AUTO
+        args.pipeline_config = MiniMaxH3PipelineConfig()
+        args.attention_backend = "fa"
+        args.component_attention_backends = {
+            "text_encoder": "fa",
+            "transformer": "torch_sdpa",
+        }
+        args.attention_backend_config = None
+        args.ring_degree = 1
+
+        with patch(
+            "sglang.multimodal_gen.runtime.server_args.server_args.is_hcu",
+            return_value=True,
+        ):
+            args._adjust_attention_backend()
+
+        self.assertEqual(
+            args.component_attention_backends,
+            {"text_encoder": "fa", "transformer": "torch_sdpa"},
+        )
 
     def test_invalid_component_attention_backend_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Avoid the CUDA-only fused QK-Norm JIT path on HCU.

Motivation
修复 MiniMax-H3 在 HCU 上的两个问题：
HCU 错误进入 CUDA 专用的 fused QK-Norm JIT 路径，可能导致兼容性问题。
Transformer Attention Backend 在组件加载上下文结束后没有被保留，运行时可能选择错误的后端。
Modifications
HCU 跳过 CUDA 专用的 fused QK-Norm JIT，使用普通 RMSNorm fallback。
在 post_load_weights() 中解析并保存 Transformer Attention Backend。
增加日志，输出最终选择的 Attention Backend，方便验证。
Accuracy Tests
该修改不改变模型计算逻辑，只修正 HCU 的执行路径和后端选择。
已验证：
MiniMax-H3 T2VA 4 卡、8 卡可正常生成视频。
MiniMax-H3 Ref2VA 4 卡、8 卡短步数推理可正常完成。
未发现异常输出或运行错误。
Speed Tests and Profiling
T2VA，768p、5 秒、50 steps：
4 卡 TP2+SP2：Server Total 231.79 秒，Denoising 219.84 秒。
8 卡 TP2+SP4：Server Total 134.56 秒，Denoising 127.47 秒。
修改后性能与原有 HCU 基线一致，没有明显性能回退。

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->