### PR TITLE
[feat] 适配bolt算子 recompute_w_u_fwd 和 fused_mamba_state_scatter_with_mask

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/wy_fast.py
+++ b/python/sglang/kernels/ops/attention/fla/wy_fast.py
@@ -9,6 +9,17 @@ import triton
 import triton.language as tl
 
 from sglang.kernels.ops.attention.fla.index import prepare_chunk_indices
+from sglang.srt.utils import get_bool_env_var, is_hcu
+
+_is_hcu = is_hcu()
+_use_bolt_recompute_w_u = get_bool_env_var(
+    "SGLANG_USE_BOLT_RECOMPUTE_W_U"
+)
+
+if _is_hcu and _use_bolt_recompute_w_u:
+    from boltops.generic.triton.recompute_w_u import (
+        recompute_w_u_fwd as _bolt_recompute_w_u_fwd,
+    )
 
 
 # @triton.autotune(
@@ -153,4 +164,9 @@ def recompute_w_u_fwd(
     return w, u
 
 
+# HCU 且环境变量开启时，替换公共函数。
+if _is_hcu and _use_bolt_recompute_w_u:
+    recompute_w_u_fwd = _bolt_recompute_w_u_fwd
+
+# 该别名也必须在完成替换后再赋值。
 fwd_recompute_w_u = recompute_w_u_fwd

--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -10,6 +10,18 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.utils import get_bool_env_var, is_hcu
+
+_is_hcu = is_hcu()
+_use_bolt_mamba_state_scatter = get_bool_env_var(
+    "SGLANG_USE_BOLT_MAMBA_STATE_SCATTER"
+)
+
+if _is_hcu and _use_bolt_mamba_state_scatter:
+    from boltops.generic.triton.mamba_state_scatter import (
+        fused_mamba_state_scatter_with_mask as _bolt_mamba_state_scatter,
+    )
+
 
 def _require_entry_contiguous_dst(
     dst: torch.Tensor, entry_start_dim: int, fn_name: str
@@ -891,3 +903,8 @@ def track_mamba_states_all_layers(
         BLOCK_SIZE,
         check_freed_slots,
     )
+
+
+# HCU 且环境变量开启时，替换公共函数。
+if _is_hcu and _use_bolt_mamba_state_scatter:
+    fused_mamba_state_scatter_with_mask = _bolt_mamba_state_scatter


### PR DESCRIPTION
## Motivation

在 HCU/ROCm 环境下，用 Bolt 算子库的高性能 triton 实现替换 sglang 原有的两个公共算子，以提升推理性能。通过环境变量开关控制，仅在 HCU 且显式开启时生效，不影响其他平台。

## Modifications

1. `python/sglang/kernels/ops/attention/fla/wy_fast.py`
   - 新增环境变量 `SGLANG_USE_BOLT_RECOMPUTE_W_U` 开关。
   - 当 `is_hcu()` 为真且开关开启时，从 `boltops.generic.triton.recompute_w_u` 引入 `recompute_w_u_fwd`，替换掉本文件原生的 `recompute_w_u_fwd`（`fwd_recompute_w_u` 别名在替换后重新绑定）。

2. `python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py`
   - 新增环境变量 `SGLANG_USE_BOLT_MAMBA_STATE_SCATTER` 开关。
   - 当 `is_hcu()` 为真且开关开启时，从 `boltops.generic.triton.mamba_state_scatter` 引入 `fused_mamba_state_scatter_with_mask`，替换本文件原生的同名函数。

两个算子均采用「环境变量开关 + HCU 平台判断」的方式做替换，默认关闭，保持原有行为不变。

## Accuracy Tests

- 测试模型：（待补，例如用于 mamba / linear attention 的模型）
- 精度对比：开启/关闭 Bolt 开关时输出对比（max diff 等，待补）

## Speed Tests and Profiling

- 测试场景：recompute_w_u_fwd、fused_mamba_state_scatter_with_mask
- 性能对比：开关开启前后吞吐/算子耗时对比（待补）

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->