### PR TITLE
 compressor 通信优化 RLC（all-to-all + 本地压缩 + all-gather）

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/common.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/common.cuh
@@ -209,7 +209,25 @@ inline PlanResult plan_prefill(
 
 }  // namespace host::compress
 
-[[maybe_unused]]
-constexpr auto& plan_compress_prefill = host::compress::plan_prefill;
+// Expose the binding for the JIT wrapper. A plain constexpr reference alias
+// breaks DTK's amdgcn device link (undefined hidden symbol); a forwarding
+// inline function keeps the target host-side and device-compilable.
+inline host::compress::PlanResult plan_compress_prefill(
+    const tvm::ffi::TensorView extend_lens,
+    const tvm::ffi::TensorView seq_lens,
+    const tvm::ffi::TensorView compress_plan,
+    const tvm::ffi::TensorView write_plan,
+    const uint32_t compress_ratio,
+    const bool is_overlap,
+    const bool use_cuda_graph) {
+  return host::compress::plan_prefill(
+      extend_lens,
+      seq_lens,
+      compress_plan,
+      write_plan,
+      compress_ratio,
+      is_overlap,
+      use_cuda_graph);
+}
 
 }  // namespace sglang

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1224,6 +1224,38 @@ class GroupCoordinator:
             pynccl_comm.reduce_scatter(output, input_, sizes=sizes)
             return output
 
+    def all_to_all_single(
+        self,
+        output: torch.Tensor,
+        input: torch.Tensor,
+        output_split_sizes: Optional[List[int]] = None,
+        input_split_sizes: Optional[List[int]] = None,
+    ) -> torch.Tensor:
+        """All-to-all over dim 0 with (optionally) variable per-rank splits.
+
+        Thin wrapper over ``torch.distributed.all_to_all_single`` on this
+        group's ``device_group``. When ``*_split_sizes`` are None, input/output
+        are split evenly across ranks along dim 0 (requires divisibility).
+
+        Used by the DSV4 compressor RLC (Repartition-Local Compression) path to
+        redistribute round-robin-scattered tokens into per-rank contiguous
+        blocks. Unlike all-gather, each element is sent to exactly one rank, so
+        per-rank traffic is ~1/world_size of an all-gather of the same tensor.
+        """
+        world_size = self.world_size
+        # Bypass if single rank: all-to-all degenerates to a copy.
+        if world_size == 1:
+            output.copy_(input)
+            return output
+        torch.distributed.all_to_all_single(
+            output,
+            input,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=self.device_group,
+        )
+        return output
+
     def _all_gather_into_tensor(self, output: torch.Tensor, input: torch.Tensor):
         # Aiter custom all-gather (ROCm). Set SGLANG_USE_AITER_AG=0 to disable.
         # Aiter's should_custom_ag still owns shape/layout validation:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1316,6 +1316,10 @@ class Envs:
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
     SGLANG_EXPERIMENTAL_ONLINE_C128_MTP = EnvBool(False)
     SGLANG_DSV4_COMPRESS_STATE_DTYPE = EnvStr("float32")
+    # RLC (Repartition-Local Compression): attention c4 + prefill-CP + round-robin optimization.
+    # Off by default; enable to replace the full-kv_score all-gather with an all-to-all repartition +
+    # local compress + all-gather of the compact output.
+    SGLANG_DSV4_COMPRESS_RLC = EnvBool(False)
     # Deprecated: DSV4 compressor V2 is always used.
     SGLANG_OPT_USE_COMPRESSOR_V2 = EnvBool(True)
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -36,7 +36,16 @@ from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
 )
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
-from sglang.srt.layers.attention.dsa.utils import dsa_use_prefill_cp
+from sglang.srt.distributed.parallel_state import get_attn_cp_group
+from sglang.srt.layers.attention.dsa.utils import (
+    dsa_use_prefill_cp,
+    is_dsa_prefill_cp_round_robin_split,
+)
+from sglang.srt.layers.attention.dsv4.rlc import compute_rlc_metadata
+from sglang.srt.layers.dp_attention import (
+    attn_cp_all_gather_into_tensor,
+    attn_cp_all_to_all_single,
+)
 from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
     quant_to_nope_fp8_rope_bf16_pack_lightop,
 )
@@ -394,6 +403,126 @@ def create_paged_compressor_data(
     return FusedCompressMetadata(write_loc=write_loc, extra_data=extra_data, plan=plan)
 
 
+# RLC (Repartition-Local Compression) run-time cache: data-independent metadata + derived GPU tensors +
+# local compress plan depend only on (ratio, extend_lens, prefix_lens, cp_rank, device), not on the
+# layer. One forward's c4 layers reuse the same bundle; rebuilt only when the lengths change.
+_rlc_bundle_cache: dict = {}
+
+
+def _rlc_prefix_aligned(forward_batch: ForwardBatch, ratio: int) -> bool:
+    """RLC's prefix-overlap patch assumes each sequence's prefix is a multiple of `ratio`, so the
+    extend-first block reads exactly the prefix's last block via the load_normal page. This holds for
+    page-aligned chunked prefill (chunks are page_size-aligned, a multiple of ratio); guard the rare
+    non-aligned-prefix case by falling back to the base path (which handles any prefix)."""
+    seq = forward_batch.seq_lens_cpu
+    ext = forward_batch.extend_seq_lens_cpu
+    if seq is None or ext is None:
+        return False
+    return all((int(s) - int(e)) % ratio == 0 for s, e in zip(seq, ext))
+
+
+def _get_rlc_bundle(extend_lens, prefix_lens, ratio, cp_size, cp_rank, device, write_plan):
+    """Build (and cache) the data-independent RLC metadata for one prefill chunk: routing tensors, the
+    local compress plan (v1) with PER-SEGMENT PREFIX, expansion rows, the per-segment global sequence
+    indices (used to gather load pages from the global paged metadata), and the state-pool WRITE
+    indices (compact/remap gather -- pure geometry from `write_plan`). Cached by
+    (ratio, cp_rank, device, extend_lens, prefix_lens) -> reused across all c4 layers of a forward."""
+    key = (ratio, cp_rank, str(device),
+           tuple(int(x) for x in extend_lens), tuple(int(x) for x in prefix_lens))
+    bundle = _rlc_bundle_cache.get(key)
+    if bundle is not None:
+        return bundle
+
+    R = ratio
+    meta = compute_rlc_metadata(extend_lens, ratio, cp_size, cp_rank)
+    send_idx = torch.tensor(meta.send_idx, dtype=torch.long, device=device)
+    recv_perm = torch.tensor(meta.recv_perm, dtype=torch.long, device=device)
+    ev = torch.tensor(meta.ev, dtype=torch.long, device=device)
+
+    n_recv = int(sum(meta.out_splits))
+    local_plan_c = None
+    local_ev = torch.empty(0, dtype=torch.long, device=device)
+    if n_recv > 0 and meta.local_extend_lens:
+        segs = meta.local_extend_lens
+        prefix_local = [int(prefix_lens[meta.local_seg_seqs[i]]) if meta.local_seg_boundary[i] else 0
+                        for i in range(len(segs))]
+        seq_local = [prefix_local[i] + segs[i] for i in range(len(segs))]
+        seq_t = torch.tensor(seq_local, dtype=torch.int64, device=device)
+        ext_t = torch.tensor(segs, dtype=torch.int64, device=device)
+        local_plan = CompressorPrefillPlan.generate(
+            compress_ratio=R, num_q_tokens=n_recv, seq_lens=seq_t, extend_lens=ext_t, device=device)
+        lev = local_plan.compress_plan.detach().cpu().contiguous().view(torch.int32)[:, 0]
+        local_ev = lev[(lev >= 0) & (lev < n_recv)].sort().values.long().to(device)
+        empty16 = torch.zeros((0, 16), dtype=torch.uint8, device=device)
+        local_plan_c = local_plan._replace(write_plan=empty16)
+
+    seg_seqs = torch.tensor(meta.local_seg_seqs, dtype=torch.long, device=device)
+
+    empty16 = torch.zeros((0, 16), dtype=torch.uint8, device=device)
+    write_W = 0
+    write_mine_idx = torch.empty(0, dtype=torch.long, device=device)
+    write_src = torch.empty(0, dtype=torch.long, device=device)
+    write_remap = empty16
+    if write_plan is not None and write_plan.numel() > 0:
+        num_q = int(sum(int(x) for x in extend_lens))
+        wpi = write_plan.contiguous().view(torch.int32)
+        g_all = wpi[:, 0].long()
+        wpi = wpi[(g_all >= 0) & (g_all < num_q)]
+        write_W = int(wpi.shape[0])
+        if write_W > 0:
+            wg = wpi[:, 0].long()
+            write_mine_idx = (wg % cp_size == cp_rank).nonzero().flatten()
+            write_src = (wg[write_mine_idx] // cp_size).contiguous()
+            remap = wpi.clone()
+            remap[:, 0] = torch.arange(write_W, dtype=torch.int32, device=device)
+            write_remap = remap.view(torch.uint8)
+
+    local_ev_kept = local_ev[meta.n_halo:]
+
+    compact_rows = []
+    for r in range(cp_size):
+        base = r * meta.max_c
+        compact_rows.extend(range(base, base + meta.counts[r]))
+    compact_idx = torch.tensor(compact_rows, dtype=torch.long, device=device)
+
+    bundle = dict(
+        meta=meta, send_idx=send_idx, recv_perm=recv_perm, ev=ev,
+        local_plan_c=local_plan_c, local_ev_kept=local_ev_kept, seg_seqs=seg_seqs,
+        compact_idx=compact_idx,
+        write_W=write_W, write_mine_idx=write_mine_idx, write_src=write_src,
+        write_remap=write_remap, empty16=empty16,
+    )
+    if len(_rlc_bundle_cache) > 8:
+        _rlc_bundle_cache.clear()
+    _rlc_bundle_cache[key] = bundle
+    return bundle
+
+
+def _rlc_write_state(state_pool, kv_score_local, ape, paged, bundle, ratio, head_dim):
+    """Persist this chunk's trailing block(s) into the (replicated) state pool so the NEXT chunk reads
+    the correct overlap, using compress_forward's WRITE kernel. All index math is precomputed once per
+    forward in `_get_rlc_bundle` (pure geometry). Here we only: fill this rank's owned write rows into
+    a compact [W, 4H] buffer, all_reduce(SUM) so every rank holds the full write-set, then run the
+    write kernel with the cached remapped plan -- reusing the global write_loc/extra_data so it writes
+    the SAME (page, slot) as base. An empty compress plan makes only the write kernel run."""
+    W = bundle["write_W"]
+    if W == 0:
+        return
+    write_buf = kv_score_local.new_zeros((W, kv_score_local.shape[1]))
+    write_src = bundle["write_src"]
+    if write_src.numel():
+        write_buf[bundle["write_mine_idx"]] = kv_score_local[write_src]
+    write_buf = get_attn_cp_group().all_reduce(write_buf)
+    write_plan_c = paged.plan._replace(
+        compress_plan=bundle["empty16"], write_plan=bundle["write_remap"]
+    )
+    compress_forward(
+        kv_score_buffer=state_pool, kv_score_input=write_buf, ape=ape,
+        indices=paged.write_loc, plan=write_plan_c, compress_ratio=ratio,
+        head_dim=head_dim, extra_data=paged.extra_data,
+    )
+
+
 class Compressor(BaseFusedOp):
     def __init__(
         self,
@@ -471,6 +600,50 @@ class Compressor(BaseFusedOp):
         assert isinstance(ret, CompressStatePool)
         return ret
 
+    def store_rlc_output(
+        self,
+        token_to_kv_pool: DeepSeekV4TokenToKVPool,
+        layer_id: int,
+        out_loc: torch.Tensor,
+        new_compressed_kv: torch.Tensor,
+    ) -> None:
+        """Write the (already normed/roped) RLC output into the extra-key cache.
+
+        Mirrors the store block of ``forward_core_compressor`` so the RLC path
+        lands in the exact same cache layout as the base path.
+        """
+        if out_loc.shape[0] > new_compressed_kv.shape[0]:
+            out_loc = out_loc[: new_compressed_kv.shape[0]]
+        if token_to_kv_pool.is_bf16_attention_kv_cache or (
+            envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get()
+        ):
+            token_to_kv_pool.set_extra_key_buffer_fused(
+                layer_id=layer_id,
+                loc=out_loc,
+                cache_k=new_compressed_kv,
+            )
+            return
+        if (
+            _is_hcu
+            and _use_dpskv4_lightop_quant_k_cache
+            and hasattr(op, "quantize_nope_fp8_rope_bf16_pack_store")
+        ):
+            token_to_kv_pool.set_extra_key_buffer_lightop_fused(
+                layer_id=layer_id,
+                loc=out_loc,
+                cache_k=new_compressed_kv.bfloat16(),
+            )
+            return
+        if _is_hcu and _use_dpskv4_lightop_quant_k_cache:
+            pack = quant_to_nope_fp8_rope_bf16_pack_lightop(
+                new_compressed_kv.bfloat16(), 1e-8
+            )
+        else:
+            pack = quant_to_nope_fp8_rope_bf16_pack_triton(
+                new_compressed_kv.bfloat16()
+            )
+        token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc, pack)
+
     def compute_kv_score(self, x: torch.Tensor, forward_batch: ForwardBatch):
         kv_score = linear_bf16_fp32(x, self.wkv_gate.weight)
 
@@ -510,6 +683,94 @@ class Compressor(BaseFusedOp):
             forward_batch=forward_batch,
             is_paged=True,
         )
+
+    def _forward_rlc(
+        self,
+        x: torch.Tensor,
+        forward_batch: ForwardBatch,
+        attn_backend: Optional[AttentionBackend] = None,
+    ) -> torch.Tensor:
+        """Repartition-Local Compression path (attention c4, prefill-CP, round-robin).
+
+        Round-robin-scattered kv_score is all-to-all'd into per-rank contiguous block-runs (+halo),
+        each rank compresses its blocks locally with the real v1 kernel, and an all-gather recovers
+        the compact output in global block order. For chunked prefill (prefix>0) each sequence's
+        extend-first block reads its overlap from the (replicated) state pool -- patched locally on
+        the owning rank -- and the chunk's trailing block is persisted back for the next chunk.
+        Produces the same per-token output + state pool as the base path.
+        """
+        from sglang.srt.layers.attention.dsa.dsa_indexer import rotate_activation
+        
+        cp_group = get_attn_cp_group()
+        cp_size = cp_group.world_size
+        cp_rank = cp_group.rank_in_group
+        R, H = self.ratio, self.head_dim
+        last_dim = 2 * (1 + self.overlap) * H
+        device = x.device
+
+        extend_lens = list(forward_batch.extend_seq_lens_cpu)
+        seq_lens = list(forward_batch.seq_lens_cpu)
+        prefix_lens = [int(s) - int(e) for s, e in zip(seq_lens, extend_lens)]
+
+        if TYPE_CHECKING:
+            assert isinstance(attn_backend, DeepseekV4AttnBackend)
+        paged = attn_backend.get_paged_compress_metadata(R)
+
+        bundle = _get_rlc_bundle(
+            extend_lens, prefix_lens, R, cp_size, cp_rank, device, paged.plan.write_plan
+        )
+        meta = bundle["meta"]
+
+        state_pool = self.get_state_pool(attn_backend).kv_score_buffer.kv_score.view(-1, R, last_dim)
+        core_meta = attn_backend.forward_metadata.core_metadata
+        out_loc = core_meta.c4_out_loc if R == 4 else core_meta.c128_out_loc
+        num_q_out = out_loc.shape[0]
+
+        kv_score_local = linear_bf16_fp32(x, self.wkv_gate.weight)
+
+        assert kv_score_local.shape[0] * cp_size == num_q_out, (
+            f"RLC expects an equal-length round-robin shard: n_local({kv_score_local.shape[0]}) "
+            f"* cp({cp_size}) != out_loc({num_q_out})"
+        )
+
+        send = (kv_score_local[bundle["send_idx"]].contiguous()
+                if bundle["send_idx"].numel() else kv_score_local.new_empty((0, last_dim)))
+        recv = kv_score_local.new_empty((sum(meta.out_splits), last_dim))
+        attn_cp_all_to_all_single(recv, send, meta.out_splits, meta.in_splits)
+        local_kv = recv[bundle["recv_perm"]].contiguous() if bundle["recv_perm"].numel() else recv
+
+        ape = self.ape.view(-1, H)
+        if local_kv.shape[0] > 0 and bundle["local_plan_c"] is not None:
+            seg_seqs = bundle["seg_seqs"]
+            local_sparse = compress_forward(
+                kv_score_buffer=state_pool, kv_score_input=local_kv, ape=ape,
+                indices=paged.write_loc[seg_seqs], plan=bundle["local_plan_c"],
+                compress_ratio=R, head_dim=H, extra_data=paged.extra_data[seg_seqs])
+            local_out = local_sparse[bundle["local_ev_kept"]].clone()
+        else:
+            local_out = kv_score_local.new_empty((0, H))
+
+        padded = local_out.new_zeros((meta.max_c, H))
+        if local_out.shape[0] > 0:
+            padded[:local_out.shape[0]] = local_out
+        gathered = local_out.new_empty((cp_size * meta.max_c, H))
+        attn_cp_all_gather_into_tensor(gathered, padded)
+        compact = gathered[bundle["compact_idx"]]
+
+        full = kv_score_local.new_zeros((num_q_out, H))
+        full[bundle["ev"]] = compact.to(full.dtype)
+
+        compress_fused_norm_rope_inplace(
+            full,
+            self.norm.weight,
+            getattr(self.norm, "eps", self.norm.variance_epsilon),
+            self.freqs_cis,
+            paged.plan,
+        )
+
+        _rlc_write_state(state_pool, kv_score_local, ape, paged, bundle, R, H)
+
+        return rotate_activation(full) if self.rotate else full
 
     def forward_npu(
         self,

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -160,6 +160,30 @@ def _compress_forward_c128_fallback(
     return out.to(kv_score_input.dtype)
 
 
+class _RLCBackendView:
+    """Adapt a v2 backend to the v1 paged-metadata interface expected by
+    ``Compressor._forward_rlc``: ``get_paged_compress_metadata`` returns the
+    v1 ``(write_loc, extra_data, plan)`` tuple built for the current batch,
+    while ``forward_metadata`` / ``token_to_kv_pool`` pass through."""
+
+    __slots__ = ("_backend", "_paged")
+
+    def __init__(self, backend, paged) -> None:
+        self._backend = backend
+        self._paged = paged
+
+    def get_paged_compress_metadata(self, compress_ratio: int):
+        return self._paged
+
+    @property
+    def forward_metadata(self):
+        return self._backend.forward_metadata
+
+    @property
+    def token_to_kv_pool(self):
+        return self._backend.token_to_kv_pool
+
+
 class CompressorBackendMixin:
     def __init__(self):
         super().__init__()
@@ -241,6 +265,22 @@ class CompressorBackendMixin:
         compressor: Compressor,
     ) -> None:
         if forward_batch.forward_mode.is_idle():
+            return
+
+        # RLC (Repartition-Local Compression): attention c4 + prefill-CP +
+        # round-robin. Replaces the full-kv_score all-gather with all-to-all
+        # repartition + local compress + all-gather of the compact output.
+        # Off by default (SGLANG_DSV4_COMPRESS_RLC); when off the checks below
+        # short-circuit and the base path runs unchanged.
+        if (
+            envs.SGLANG_DSV4_COMPRESS_RLC.get()
+            and _is_hip
+            and compressor.overlap
+            and not compressor.is_in_indexer
+            and compressor.ratio == 4
+            and self._rlc_gate(forward_batch, compressor)
+        ):
+            self._forward_unified_rlc(x, forward_batch, layer_id, compressor)
             return
 
         token_to_kv_pool = self.token_to_kv_pool
@@ -448,6 +488,69 @@ class CompressorBackendMixin:
             else:
                 pack = quant_to_nope_fp8_rope_bf16_pack_triton(kv_to_store.bfloat16())
                 token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc_to_store, pack)
+
+    def _rlc_gate(self, forward_batch: ForwardBatch, compressor: Compressor) -> bool:
+        """Remaining RLC preconditions (lazy imports: zero cost when disabled)."""
+        from sglang.srt.layers.attention.dsa.utils import (
+            dsa_use_prefill_cp,
+            is_dsa_prefill_cp_round_robin_split,
+        )
+        from sglang.srt.layers.attention.dsv4.compressor import _rlc_prefix_aligned
+
+        return (
+            dsa_use_prefill_cp(forward_batch)
+            and is_dsa_prefill_cp_round_robin_split()
+            and _rlc_prefix_aligned(forward_batch, compressor.ratio)
+        )
+
+    def _forward_unified_rlc(
+        self,
+        x: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        compressor: Compressor,
+    ) -> None:
+        """RLC variant of ``forward_unified`` for the core c4 compressor.
+
+        Runs ``Compressor._forward_rlc`` (all-to-all repartition + local
+        compress + compact all-gather) and stores its output exactly like
+        ``forward_core_compressor`` does. The v1-style paged metadata
+        (write_loc / extra_data / v1 plan) needed by the RLC kernels is built
+        once per ForwardBatch and reused across all c4 layers.
+        """
+        from sglang.srt.layers.attention.dsv4.compressor import (
+            create_paged_compressor_data,
+        )
+        
+        token_to_kv_pool = cast("DeepSeekV4TokenToKVPool", self.token_to_kv_pool)
+
+        cache = getattr(self, "_rlc_paged_cache", None)
+        if cache is None or cache[0] is not forward_batch:
+            paged = create_paged_compressor_data(
+                compressor.ratio,
+                is_prefill=True,
+                token_to_kv_pool=token_to_kv_pool,
+                req_to_token=self.req_to_token_pool.req_to_token,
+                req_pool_indices=forward_batch.req_pool_indices,
+                seq_lens=forward_batch.seq_lens,
+                extend_lens=forward_batch.extend_seq_lens,
+                seq_lens_cpu=list(forward_batch.seq_lens_cpu),
+                extend_lens_cpu=list(forward_batch.extend_seq_lens_cpu),
+            )
+            self._rlc_paged_cache = (forward_batch, paged)
+        else:
+            paged = cache[1]
+
+        compressed = compressor._forward_rlc(
+            x, forward_batch, _RLCBackendView(self, paged)
+        )
+
+        compressor.store_rlc_output(
+            token_to_kv_pool,
+            layer_id,
+            self._get_out_loc(compressor.ratio),
+            compressed,
+        )
 
     # NOTE: alias for backward compatibility
     forward_indexer_compressor = forward_unified

--- a/python/sglang/srt/layers/attention/dsv4/rlc.py
+++ b/python/sglang/srt/layers/attention/dsv4/rlc.py
@@ -1,0 +1,212 @@
+"""RLC (Repartition-Local Compression) metadata for the DeepSeek-V4 c4 compressor.
+
+Pure-CPU metadata only: block partition / all-to-all routing / halo / local compress-event
+structure / expansion rows. No communication and no kernel calls -- those live in the consumer
+`compressor.py::_forward_rlc`. Ported from the validated prototype
+`mission_all/mission_comprssor/prototype/bench/test_accuracy_1.py`
+(`get_rlc_index` + the routing half of `build_rlc_meta_torch`).
+
+Dataflow this enables (per prefill chunk, over the chunk's `extend` tokens): round-robin-scattered
+tokens are all-to-all'd into "one contiguous block-run per rank + one leading halo block", each rank
+compresses its blocks locally, then an all-gather recovers the full compact output in global block
+order.
+
+Supported (unlike the previous version, which asserted `L % ratio == 0` and ignored the state pool):
+  * NON-ALIGNED sequence lengths -- blocks use CEIL division for partitioning; compress events use
+    FLOOR (a partial tail < ratio carries no event). The partial-tail tokens are still routed but
+    produce no compressed output; downstream the c4 `out_loc` sends them to the reserved dummy slot 0
+    (they are never read), so no partial-tail block value is needed.
+  * PREFIX > 0 (chunked/continuation prefill) -- this module only needs the chunk's `extend_lens`
+    for the block geometry; `local_events` carries an `at_boundary` flag so the consumer can patch
+    each sequence's extend-FIRST block's overlap from the (replicated) state pool. `prefix_lens`
+    itself is consumed in `compressor.py`, not here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+def get_rlc_index(extend_lens: List[int], cp_size: int, ratio: int) -> List[List[int]]:
+    """Partition the global compression blocks across CP ranks; return, per rank, the list of GLOBAL
+    flat token indices it owns.
+
+    Each rank owns a CONTIGUOUS run of the global block sequence (front-loaded: the first
+    `block_sum % cp_size` ranks get one extra block). When a rank's first owned block is mid-sequence
+    (i.e. not a sequence's first block) and `ratio == 4`, one leading "halo" block is prepended so the
+    rank can compute that block's c4 overlap locally; the consumer drops the halo's output.
+
+    Blocks per sequence use CEIL division, so a non-aligned sequence's partial tail counts as one
+    block for partitioning (it carries no compress event later). Ported verbatim from the prototype
+    bench `get_rlc_index`.
+    """
+    block_size = [(L + ratio - 1) // ratio for L in extend_lens]
+    block_size_sum = int(sum(block_size))
+    block_num_t = block_size_sum // cp_size          # base blocks per rank
+    block_num_f = block_num_t + 1                    # first `device_f` ranks get one extra
+    device_f = block_size_sum % cp_size
+
+    seq_index_all_new: List[List[int]] = []
+    seq_index_start = 0
+    block_num_start = 0
+    batch_index_now = 0
+    for i in range(cp_size):
+        seq_index: List[int] = []
+        block_num_now = block_num_f if i < device_f else block_num_t
+        if block_num_now == 0:
+            seq_index_all_new.append(seq_index)
+            continue
+        # halo: prepend the previous block when this rank's first owned block is mid-sequence
+        # (not rank 0, not a sequence's first block) -- only for ratio==4 (overlap compression).
+        if i != 0 and block_num_start != 0 and ratio == 4:
+            seq_index.extend(range(seq_index_start - ratio, seq_index_start))
+        block_num_batch = block_size[batch_index_now] - block_num_start
+        # consume whole sequences whose remaining blocks fit in this rank's quota
+        while block_num_batch <= block_num_now:
+            seq_index.extend(range(
+                seq_index_start,
+                seq_index_start + (extend_lens[batch_index_now] - block_num_start * ratio),
+            ))
+            block_num_now -= block_num_batch
+            seq_index_start += extend_lens[batch_index_now] - block_num_start * ratio
+            block_num_start = 0
+            batch_index_now += 1
+            if batch_index_now >= len(extend_lens):
+                break
+            block_num_batch = block_size[batch_index_now] - block_num_start   # recompute after crossing
+        # take the remaining blocks from the current sequence
+        if block_num_now > 0:
+            seq_index.extend(range(seq_index_start, seq_index_start + block_num_now * ratio))
+            block_num_start += block_num_now
+            seq_index_start += block_num_now * ratio
+        seq_index_all_new.append(seq_index)
+    return seq_index_all_new
+
+
+@dataclass
+class RLCMetadata:
+    """Data-INDEPENDENT RLC metadata (depends only on `extend_lens`, `ratio`, `cp_size`, `cp_rank`).
+    Compute once per forward and reuse across every c4 layer. Nothing here depends on tensor values.
+    The state-pool write indices, the local compress plan, and the prefix-overlap patch descriptors
+    are built by the consumer (they need the backend's paged metadata / Triton), not here."""
+
+    cp_size: int
+    ratio: int
+    n_halo: int                                   # this rank's leading halo blocks to drop (0 or 1)
+    counts: List[int]                             # [cp_size] owned FLOOR compress events per rank
+    max_c: int                                    # max(counts) (all-gather pad width)
+    send_idx: List[int]                           # local rows of this rank's shard to send (grouped by dest)
+    in_splits: List[int]                          # [cp_size] send counts per dest rank
+    out_splits: List[int]                         # [cp_size] recv counts per source rank
+    recv_perm: List[int]                          # reorder received rows -> ascending global order
+    ev: List[int]                                 # global event-token rows, sorted == compact block order
+    local_events: List[Tuple[int, bool, int, bool]]  # (local row g, masked, seq_idx, at_boundary)
+    local_extend_lens: List[int]                  # this rank's received buffer split by sequence (halo in seg 0)
+    local_seg_seqs: List[int]                     # global sequence index of each local segment
+    local_seg_boundary: List[bool]                # whether each local segment starts at a sequence boundary
+    num_blocks: int                               # total FLOOR compress events (== len(ev) == sum(counts))
+
+
+def compute_rlc_metadata(
+    extend_lens: List[int], ratio: int, cp_size: int, cp_rank: int
+) -> RLCMetadata:
+    """Compute the RLC routing / halo / local-event / expansion metadata for one prefill chunk.
+
+    `extend_lens` are the GLOBAL per-sequence extend (this-chunk) lengths -- every sequence, not just
+    this rank's shard. Round-robin rule: global flat token `g` belongs to `rank = g % cp_size`; the
+    sender maps `g` -> its local shard row `g // cp_size`.
+    """
+    R = ratio
+    lens = [int(x) for x in extend_lens]
+    seq_index_all_new = get_rlc_index(lens, cp_size, R)
+
+    # global FLOOR event-token positions (partial tails -> no event)
+    event_pos: List[int] = []
+    off = 0
+    for L in lens:
+        for k in range(L // R):
+            event_pos.append(off + (k + 1) * R - 1)
+        off += L
+
+    def n_halo_of(rr: int) -> int:
+        # A halo is prepended (by get_rlc_index) iff this rank's first owned block is the PREVIOUS
+        # rank's last block -- i.e. this rank's first token overlaps the previous rank's tokens. Since
+        # the partition is contiguous, that is exactly `idx[0] <= prev[-1]`. Robust even when the halo
+        # block starts at a sequence boundary (this rank's first REAL block is a sequence's 2nd block,
+        # so the halo == that sequence's block 0); the old `idx[0] in starts` heuristic misdetected
+        # that case as n_halo=0, over-counting owned events (see the short-prompt shape-mismatch bug).
+        idx = seq_index_all_new[rr]
+        if rr == 0 or not idx:
+            return 0
+        prev = seq_index_all_new[rr - 1]
+        return 1 if (prev and idx[0] <= prev[-1]) else 0
+
+    def owned_count(rr: int) -> int:
+        idx = seq_index_all_new[rr]
+        if not idx:
+            return 0
+        olo = idx[0] + n_halo_of(rr) * R          # first REAL (non-halo) owned token
+        ohi = idx[-1] + 1
+        return sum(1 for e in event_pos if olo <= e < ohi)
+
+    # all-to-all routing (from the block partition)
+    send_idx: List[int] = []
+    in_splits: List[int] = []
+    for d in range(cp_size):
+        ids = [g for g in seq_index_all_new[d] if g % cp_size == cp_rank]
+        in_splits.append(len(ids))
+        send_idx.extend(g // cp_size for g in ids)
+    my_recv = seq_index_all_new[cp_rank]
+    out_splits = [sum(1 for g in my_recv if g % cp_size == s) for s in range(cp_size)]
+    recv_order_ids = [g for s in range(cp_size) for g in my_recv if g % cp_size == s]
+    recv_perm = sorted(range(len(recv_order_ids)), key=lambda i: recv_order_ids[i])
+    n_halo = n_halo_of(cp_rank)
+
+    # local segmentation -> local compress events. Each event carries its local row g, the first-block
+    # mask flag, its sequence index, and whether its segment starts at a sequence boundary. Only
+    # boundary-first masked blocks may need a prefix>0 overlap patch (consumer); halo-first masked
+    # blocks are always dropped, and mid-seq blocks read overlap from within the extend.
+    local_events: List[Tuple[int, bool, int, bool]] = []
+    local_extend_lens: List[int] = []              # segment lengths (this rank's recv buffer by sequence)
+    local_seg_seqs: List[int] = []                 # global sequence index of each segment
+    local_seg_boundary: List[bool] = []            # whether each segment starts at a sequence boundary
+    if my_recv:
+        lo, hi = my_recv[0], my_recv[-1] + 1
+        off_g = 0        # global extend offset (sequence start, extend space)
+        loc = 0          # local row offset within the received buffer
+        for b, L in enumerate(lens):
+            seg_lo = max(lo, off_g)
+            seg = min(hi, off_g + L) - seg_lo
+            if seg > 0:
+                at_boundary = seg_lo == off_g
+                local_extend_lens.append(seg)
+                local_seg_seqs.append(b)
+                local_seg_boundary.append(at_boundary)
+                for j in range(seg):
+                    if (j + 1) % R == 0:
+                        local_events.append((loc + j, j < 2 * R - 1, b, at_boundary))
+                loc += seg
+            off_g += L
+
+    counts = [owned_count(rr) for rr in range(cp_size)]
+    max_c = max(counts) if counts else 0
+    ev = sorted(event_pos)                         # already ascending; sorted() is a safe no-op
+
+    return RLCMetadata(
+        cp_size=cp_size,
+        ratio=R,
+        n_halo=n_halo,
+        counts=counts,
+        max_c=max_c,
+        send_idx=send_idx,
+        in_splits=in_splits,
+        out_splits=out_splits,
+        recv_perm=recv_perm,
+        ev=ev,
+        local_events=local_events,
+        local_extend_lens=local_extend_lens,
+        local_seg_seqs=local_seg_seqs,
+        local_seg_boundary=local_seg_boundary,
+        num_blocks=len(event_pos),
+    )

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -983,6 +983,24 @@ def attn_tp_all_gather_into_tensor(output: torch.Tensor, input: torch.Tensor):
 def attn_cp_all_gather_into_tensor(output: torch.Tensor, input: torch.Tensor):
     return get_attn_cp_group().all_gather_into_tensor(output, input)
 
+def attn_cp_all_to_all_single(
+    output: torch.Tensor,
+    input: torch.Tensor,
+    output_split_sizes: Optional[List[int]] = None,
+    input_split_sizes: Optional[List[int]] = None,
+):
+    """All-to-all over dim 0 within the attention CP group (variable splits ok).
+
+    Used by the DSV4 compressor RLC path to repartition round-robin-scattered
+    tokens into per-rank contiguous blocks.
+    """
+    return get_attn_cp_group().all_to_all_single(
+        output,
+        input,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+    )
+
 
 def get_moe_cp_group() -> GroupCoordinator:
     """Returns the MOE_DP group, which includes CP partners when attn_cp_size > moe_dp_size."""


### PR DESCRIPTION
合入 c4 compressor 通信优化。原路径 linear_bf16_fp32 -> all_gather -> compress 在 DCU 上 all_gather 通信量为 data_num * (cp_size - 1)，是 attn 通 信最耗时的一段；改为 linear_bf16_fp32 -> all_to_all -> 本地 compress -> all_gather 压缩后的紧凑输出，通信量降为 data_num + data_num * (cp_size - 1) / (ratio * coff). 实测TTFT 提升约 2%。

改动：
- 新增 SGLANG_DSV4_COMPRESS_RLC 环境变量（默认 False），不开启时短路，运行 路径与之前完全一致。
- 新增 layers/attention/dsv4/rlc.py：块划分 / all-to-all 路由 / halo / 本地 compress event 等纯 CPU 元数据（数据无关，按 (ratio, extend_lens, prefix_lens, cp_rank, device) 缓存，一次 forward 内的 c4 层复用）。
- compressor.py：新增 _forward_rlc / _get_rlc_bundle / _rlc_write_state / store_rlc_output 等实现（all-to-all 重分区 -> 本地压缩 -> 紧凑 all-gather -> 展开到 event 行 -> norm/rope -> 写回 state pool）。支持 prefix=0 与 chunked prefill 的 prefix > 0（页对齐时命中，非对齐时 fallback），支持非 对齐序列长度（CEIL 分块 + FLOOR 事件）。
- compressor_v2.py：真实入口 forward_unified 中加入 RLC gate（仅 HIP、c4、 非 indexer、prefill-CP、round-robin、prefix 页对齐），命中时通过 _RLCBackendView 将 v2 后端适配为 v1 paged 元数据接口，调用 Compressor._forward_rlc 并复用 store_rlc_output 写回 cache；paged 元数据 按 ForwardBatch 缓存，跨 c4 层复用。
- parallel_state.py 新增 GroupCoordinator.all_to_all_single；dp_attention.py 新增 attn_cp_all_to_all_single 包装，供 CP group 使用。

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->