### PR TITLE
fix

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -297,6 +297,28 @@ def _flashinfer_hc_pre(
 
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip and not _is_hcu
 _use_aiter_tilelang_mhc = get_bool_env_var("SGLANG_ROCM_USE_AITER_TILELANG_MHC")
+
+
+@functools.cache
+def _hcu_arch_supports_tilelang_mmac() -> bool:
+    """Whether the current HCU can JIT-compile tilelang T.gemm (MLS/GEMM_MLS).
+
+    tilelang's ``hcu_mmac_k_dim`` only accepts gfx938 / gfx92a / gfx946; other
+    archs (e.g. gfx936) fatal at LayerInference for any ``T.gemm``. On those
+    archs we must skip sglang's tilelang split-k mhc_pre and go straight to
+    AITER's fully-fused ``mhc_pre_big_fuse`` instead.
+    """
+    if not _is_hcu:
+        return True
+    try:
+        gcn_arch = getattr(
+            torch.cuda.get_device_properties(0), "gcnArchName", ""
+        )
+    except Exception:
+        return True
+    return any(a in gcn_arch for a in ("gfx938", "gfx92a", "gfx946"))
+
+
 # PoC: compute the (replicated TP1) shared expert on LOCAL hidden before the dp
 # gather instead of on the gathered global buffer. Requires
 # SGLANG_SHARED_EXPERT_TP1=1 (replicated shared expert). Default OFF.
@@ -1634,6 +1656,32 @@ class DeepseekV4DecoderLayer(nn.Module):
             return y, post, comb, False
 
         if envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
+            if (
+                _is_hcu
+                and _use_aiter_tilelang_mhc
+                and not _hcu_arch_supports_tilelang_mmac()
+            ):
+                # This HCU arch (e.g. gfx936) lacks tilelang T.gemm support, so
+                # sglang's own tilelang split-k mhc_pre fatals in LayoutInference.
+                # Bypass it entirely and use AITER's fully-fused mhc_pre_big_fuse,
+                # which is also what earlier sglang releases dispatched to here.
+                from aiter.ops.tilelang import mhc_pre_big_fuse
+
+                post, comb, y = mhc_pre_big_fuse(
+                    residual=x,
+                    fn=hc_fn,
+                    mhc_scale=hc_scale,
+                    mhc_base=hc_base,
+                    rms_eps=self.rms_norm_eps,
+                    mhc_pre_eps=self.hc_eps,
+                    mhc_sinkhorn_eps=self.hc_eps,
+                    mhc_post_mult_value=_MHC_POST_MULT_VALUE,
+                    sinkhorn_repeat=self.hc_sinkhorn_iters,
+                    n_splits=16,
+                )
+                # AITER mhc_pre_big_fuse does not fuse the decoder RMSNorm.
+                return y, post.squeeze(-1), comb, False
+
             from sglang.kernels.ops.layernorm.mhc import mhc_pre
 
             norm_kwargs = {}

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -177,6 +177,7 @@ QUANTIZATION_CHOICES = [
     "mlx_q8",  # 8 bits, group_size=64
     "unquant",
     "humming",
+    "slimquant_marlin",
 ]
 
 ATTENTION_BACKEND_CHOICES = [


### PR DESCRIPTION
1.Add slimquant_marlin to quantization options./2. Fix DSv4 mhc_pre crash on HCU archs unsupported by tilelang MMAC

's TileLang branch unconditionally calls
, whose split-k stage_0 kernel
emits a . tilelang's  only accepts
gfx938 / gfx92a / gfx946, so on other HCU archs (e.g. gfx936, K100-AI) LayoutInference fatals with:

    InternalError: HCU arch gfx936 not supported for MLS/GEMM_MLS;
    supported: gfx938, gfx92a, gfx946

Restore the pre-existing HCU compat path: when
is on and the runtime arch isn't in tilelang's supported set, dispatch directly to AITER's fully-fused  instead. Arch detection is a 'd  probe, so supported archs
(gfx938 / gfx92a / gfx946) keep the current fast path unchanged and no imports are touched at module load time.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->