### PR TITLE
ci(hcu): allow fork checkout in target workflows

### DIFF
--- a/.github/workflows/lint-hcu.yml
+++ b/.github/workflows/lint-hcu.yml
@@ -27,6 +27,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Fetch PR base revision
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/release-pr-hcu.yml
+++ b/.github/workflows/release-pr-hcu.yml
@@ -79,6 +79,7 @@ jobs:
           ref: ${{ env.WHEEL_COMMIT_SHA }}
           submodules: 'recursive'
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       # 容器内已预装 Python 3.10 + DTK/ROCm + gcc + cmake
       - name: Install build deps


### PR DESCRIPTION
The pull_request_target conversion now resolves repository variables and starts the build container, but the current actions/checkout v4 explicitly blocks fork-head checkout unless the workflow opts in. Add allow-unsafe-pr-checkout to the two target workflows that use actions/checkout. The token remains read-only and credentials are not persisted.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->