### PR TITLE
ci(hcu): detect runner workspace ownership

### DIFF
--- a/.github/workflows/nightly-test-hcu.yml
+++ b/.github/workflows/nightly-test-hcu.yml
@@ -307,14 +307,21 @@ jobs:
       PIP_INDEX_URL: http://10.16.1.201:9929/nightly/dtk2604/+simple/
       PIP_TRUSTED_HOST: 10.16.1.201
       RESOURCE_SERVER: http://10.16.1.201:8000/
-      HCU_RUNNER_HOST_UID: ${{ vars.HCU_RUNNER_HOST_UID || '1000' }}
-      HCU_RUNNER_HOST_GID: ${{ vars.HCU_RUNNER_HOST_GID || '1000' }}
       WHEEL_COMMIT_SHA: ${{ needs.probe-hcu-wheels.outputs.full_sha }}
       HCU_WHEEL_STAGING_ROOT: /ci_public/sglang-das/hcu-wheel-staging
     steps:
+      - name: Detect runner workspace ownership
+        shell: bash
+        run: |
+          host_uid="$(stat -c '%u' "${RUNNER_TEMP}")"
+          host_gid="$(stat -c '%g' "${RUNNER_TEMP}")"
+          [[ "${host_uid}" =~ ^[0-9]+$ && "${host_gid}" =~ ^[0-9]+$ ]]
+          echo "HCU_RUNNER_HOST_UID=${host_uid}" >> "${GITHUB_ENV}"
+          echo "HCU_RUNNER_HOST_GID=${host_gid}" >> "${GITHUB_ENV}"
+
       - name: Normalize workspace ownership before checkout
         run: |
-          chown -R "${HCU_RUNNER_HOST_UID}:${HCU_RUNNER_HOST_GID}" "${GITHUB_WORKSPACE}" || true
+          chown -R "${HCU_RUNNER_HOST_UID}:${HCU_RUNNER_HOST_GID}" "${GITHUB_WORKSPACE}"
 
       - uses: actions/checkout@v4
         with:
@@ -456,6 +463,11 @@ jobs:
           touch "${STAGING_DIR}/READY"
           chown -R "${HCU_RUNNER_HOST_UID}:${HCU_RUNNER_HOST_GID}" "${STAGING_DIR}" || true
           echo "HCU nightly wheels are staged locally at ${STAGING_DIR}"
+
+      - name: Normalize workspace ownership
+        if: always()
+        run: |
+          chown -R "${HCU_RUNNER_HOST_UID}:${HCU_RUNNER_HOST_GID}" "${GITHUB_WORKSPACE}"
 
   wait-hcu-wheels:
     name: Wait HCU wheels

--- a/.github/workflows/release-pr-hcu.yml
+++ b/.github/workflows/release-pr-hcu.yml
@@ -59,8 +59,6 @@ jobs:
       PIP_INDEX_URL: http://10.16.1.201:9929/nightly/dtk2604/+simple/
       PIP_TRUSTED_HOST: 10.16.1.201
       RESOURCE_SERVER: http://10.16.1.201:8000/
-      HCU_RUNNER_HOST_UID: ${{ vars.HCU_RUNNER_HOST_UID || '1000' }}
-      HCU_RUNNER_HOST_GID: ${{ vars.HCU_RUNNER_HOST_GID || '1000' }}
       WHEEL_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       HCU_WHEEL_STAGING_ROOT: /ci_public/sglang-das/hcu-wheel-staging
 
@@ -69,9 +67,18 @@ jobs:
       # 环境准备
       # =======================================================================
 
+      - name: Detect runner workspace ownership
+        shell: bash
+        run: |
+          host_uid="$(stat -c '%u' "${RUNNER_TEMP}")"
+          host_gid="$(stat -c '%g' "${RUNNER_TEMP}")"
+          [[ "${host_uid}" =~ ^[0-9]+$ && "${host_gid}" =~ ^[0-9]+$ ]]
+          echo "HCU_RUNNER_HOST_UID=${host_uid}" >> "${GITHUB_ENV}"
+          echo "HCU_RUNNER_HOST_GID=${host_gid}" >> "${GITHUB_ENV}"
+
       - name: Normalize workspace ownership before checkout
         run: |
-          chown -R "${HCU_RUNNER_HOST_UID}:${HCU_RUNNER_HOST_GID}" "${GITHUB_WORKSPACE}" || true
+          chown -R "${HCU_RUNNER_HOST_UID}:${HCU_RUNNER_HOST_GID}" "${GITHUB_WORKSPACE}"
 
       - uses: actions/checkout@v4
         with:
@@ -263,4 +270,4 @@ jobs:
       - name: Normalize workspace ownership
         if: always()
         run: |
-          chown -R "${HCU_RUNNER_HOST_UID}:${HCU_RUNNER_HOST_GID}" "${GITHUB_WORKSPACE}" || true
+          chown -R "${HCU_RUNNER_HOST_UID}:${HCU_RUNNER_HOST_GID}" "${GITHUB_WORKSPACE}"


### PR DESCRIPTION
Fix HCU wheel jobs changing self-hosted runner workspaces to the hard-coded fallback owner 1000:1000. Detect the host UID/GID from the bind-mounted RUNNER_TEMP directory, restore the workspace before checkout and after execution, and add the missing Nightly cleanup. This supports nmz4 runners with different UIDs while retaining their shared group.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->