### PR TITLE
[MiniMax-H3] Adapt HCU inference and fix CacheDiT performance for SGLang 0.5.18

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -671,7 +671,6 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
                 model,
                 positive,
                 device=device,
-                shared_conditioning=emb,
             )
             _precompute_rope_cache(
                 model,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -36,6 +36,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     VerificationResult,
 )
 from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.srt.utils import is_hcu
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.nvtx_pytorch_hooks import maybe_nvtx_range
@@ -620,8 +621,12 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
 
         ctx = _resolve_full_loop_context(batch)
 
-        if not (current_platform.is_cuda() or current_platform.is_mps()):
-            raise RuntimeError("MiniMax H3 full-loop denoise requires CUDA or MPS")
+        if not (
+            current_platform.is_cuda() or is_hcu() or current_platform.is_mps()
+        ):
+            raise RuntimeError(
+                "MiniMax H3 full-loop denoise requires CUDA, HCU, or MPS"
+            )
         device = current_platform.get_local_torch_device()
         sigmas_video = [float(v) for v in ctx.sigmas["video"]]
         self._maybe_enable_cache_dit_and_torch_compile(


### PR DESCRIPTION
## Motivation

本 PR 适配 MiniMax-H3 在 SGLang DAS 0.5.18 分支上的 HCU 推理链路，解决两个问题：

1. HCU 平台下 full-loop denoise 路径被平台判断拦住，导致 MiniMax-H3 不能正常进入完整 denoising loop。
2. FL2VA 开启 CacheDiT 时，refined prompt embeds 被写回 shared conditioning，干扰 CacheDiT 路径，导致 4 卡 TP2+SP2 CacheDiT ON 性能明显回退。

## Modifications

- 放开 MiniMax-H3 denoising loop 的 HCU platform guard，使 HCU 可以正常走 full-loop denoise。
- 调整 refined prompt embeds 的预计算逻辑，避免将 refined prompt 写回 shared conditioning。
- 保持 refined prompt 只在当前 denoise 分支内使用，避免影响 CacheDiT 的缓存上下文。

## Accuracy Tests

已完成 MiniMax-H3 三场景冒泡验证：

- T2VA / FL2VA / Ref2VA
- CacheDiT OFF / ON
- 2 卡、4 卡冒泡链路验证
- 未观察到 VMFault
- CacheDiT 命中后 residual diff 无 NaN

本 PR 不改变模型权重，不引入新的 kernel；第二处修改只调整 refined prompt 的缓存作用域，避免共享状态污染。

## Speed Tests and Profiling

在 NMZ26 上复测 FL2VA 4 卡 TP2+SP2 CacheDiT ON：

修复前：

- Server Total: 215.40s
- Denoising: 174.14s
- Decoding: 39.09s

修复后：

- Server Total: 108.13s
- Denoising: 81.19s
- Decoding: 25.18s

修复后性能恢复到0.5.15基线水平。

在 BW151 下 4 卡 TP2+SP2 三场景正式性能：

CacheDiT OFF:

- T2VA: 231.34s
- FL2VA: 242.79s
- Ref2VA: 346.15s

CacheDiT ON:

- T2VA: 82.93s
- FL2VA: 82.93s
- Ref2VA: 118.83s

Decode 阶段稳定在 5.7s 左右，VAE decode fast path 正常。

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->