### PR TITLE
fix(hy3): align LightOp routed scaling factor handling

### DIFF
--- a/python/sglang/srt/models/hunyuan_v3.py
+++ b/python/sglang/srt/models/hunyuan_v3.py
@@ -83,6 +83,7 @@ _use_fused_hunyuan_rotary = get_bool_env_var("SGLANG_USE_FUSED_RMS_ROTARY")
 _use_aiter = (
     get_bool_env_var("SGLANG_USE_AITER") and is_hip() and not _is_hcu
 )
+_use_lightop = get_bool_env_var("SGLANG_USE_LIGHTOP")
 
 if _is_hcu:
     from lightop import rms_rotary_embedding_fuse_with_kv_store
@@ -206,7 +207,9 @@ class HYV3MoEFused(nn.Module):
             scoring_func=scoring_func,
             correction_bias=self.e_score_correction_bias,
             routed_scaling_factor=self.router_scaling_factor,
-            apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
+            apply_routed_scaling_factor_on_output=(
+                self.experts.should_fuse_routed_scaling_factor_in_topk or _use_lightop
+            ),
         )
 
         if getattr(config, "num_shared_experts", 0) > 0:
@@ -266,7 +269,9 @@ class HYV3MoEFused(nn.Module):
         # apply_routed_scaling_factor_on_output through to moe_fused_gate,
         # lightop no longer bakes rsf when apply is False (Hy3 W8A8+triton).
         scale_already_applied = (
-            self.experts.should_fuse_routed_scaling_factor_in_topk or _use_aiter
+            self.experts.should_fuse_routed_scaling_factor_in_topk
+            or _use_lightop
+            or _use_aiter
         )
         if scale_already_applied:
             if shared_output is not None:


### PR DESCRIPTION
## Problem

Hy3 W8A8 inference showed an accuracy regression on the HCU LightOp path. The RSF application contract between the LightOp TopK path and the Hy3 output merge path was inconsistent, which could cause the routed scaling factor to be applied at the wrong stage.

## Change

- Make the LightOp TopK RSF application decision explicit.
- Align the Hy3 output merge logic with the actual RSF application path.
- Ensure that the routed scaling factor is applied exactly once.
- Keep the existing AITER handling unchanged.

## Validation

- Model: Hunyuan3 W8A8
- Backend: HCU + LightOp
- Compared the original and patched implementations.
- The patch was validated with the Hy3 accuracy test.
- The patch only changes `python/sglang/srt/models/hunyuan_v3.py`.

## Scope

This change is limited to the Hy3 MoE RSF handling logic and does not change model weights or general serving parameters.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->