### PR TITLE
ci(hcu): use bash for wheel build jobs

### DIFF
--- a/.github/workflows/nightly-test-hcu.yml
+++ b/.github/workflows/nightly-test-hcu.yml
@@ -292,6 +292,9 @@ jobs:
     if: needs.validate-config.result == 'success' && needs.probe-hcu-wheels.outputs.wheel_available != 'true'
     runs-on: [self-hosted, hcu, nmz4]
     timeout-minutes: 180
+    defaults:
+      run:
+        shell: bash
     container:
       image: ${{ vars.HCU_CI_RELEASE_IMAGE }}
       options: >

--- a/.github/workflows/release-pr-hcu.yml
+++ b/.github/workflows/release-pr-hcu.yml
@@ -36,6 +36,9 @@ jobs:
     # ---- 自托管 HCU runner，在 Docker 容器内执行 ----
     runs-on: [self-hosted, hcu, nmz4]
     timeout-minutes: 180
+    defaults:
+      run:
+        shell: bash
 
     container:
       image: ${{ vars.HCU_CI_RELEASE_IMAGE }}

--- a/.github/workflows/release-pypi-nightly-hcu.yml
+++ b/.github/workflows/release-pypi-nightly-hcu.yml
@@ -45,6 +45,9 @@ jobs:
     # ---- 自托管 HCU runner，在 Docker 容器内执行 ----
     runs-on: [self-hosted, hcu, nmz4]
     timeout-minutes: 180
+    defaults:
+      run:
+        shell: bash
 
     container:
       image: ${{ vars.HCU_CI_RELEASE_IMAGE }}


### PR DESCRIPTION
Use Bash explicitly for HCU PR, nightly fallback, and nightly release wheel jobs. This prevents container image changes to /bin/sh from breaking source, shopt, and Bash array syntax. YAML parsing and HCU registration checks pass.