### PR TITLE
ci(hcu): enable release CI and use bash for wheel jobs

### DIFF
--- a/.github/workflows/nightly-test-hcu.yml
+++ b/.github/workflows/nightly-test-hcu.yml
@@ -292,6 +292,9 @@ jobs:
     if: needs.validate-config.result == 'success' && needs.probe-hcu-wheels.outputs.wheel_available != 'true'
     runs-on: [self-hosted, hcu, nmz4]
     timeout-minutes: 180
+    defaults:
+      run:
+        shell: bash
     container:
       image: ${{ vars.HCU_CI_RELEASE_IMAGE }}
       options: >

--- a/.github/workflows/pr-test-hcu.yml
+++ b/.github/workflows/pr-test-hcu.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - v0.5.15.post1_dev
       - main
+      - "release/**"
     paths:
       - ".github/workflows/pr-test-hcu.yml"
       - ".github/workflows/pr-gate.yml"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -7,6 +7,7 @@ on:
       - v0.5.12_dev
       - v0.5.15.post1_dev
       - main
+      - "release/**"
 
 permissions:
   contents: read

--- a/.github/workflows/release-pr-hcu.yml
+++ b/.github/workflows/release-pr-hcu.yml
@@ -36,6 +36,9 @@ jobs:
     # ---- 自托管 HCU runner，在 Docker 容器内执行 ----
     runs-on: [self-hosted, hcu, nmz4]
     timeout-minutes: 180
+    defaults:
+      run:
+        shell: bash
 
     container:
       image: ${{ vars.HCU_CI_RELEASE_IMAGE }}

--- a/.github/workflows/release-pypi-nightly-hcu.yml
+++ b/.github/workflows/release-pypi-nightly-hcu.yml
@@ -21,6 +21,9 @@ jobs:
     # ---- 自托管 HCU runner，在 Docker 容器内执行 ----
     runs-on: [self-hosted, hcu, nmz4]
     timeout-minutes: 180
+    defaults:
+      run:
+        shell: bash
 
     container:
       image: ${{ vars.BASE_COMPILE_IMAGE_ROCKY_PY310 }}


### PR DESCRIPTION
Enable HCU PR Test and Quality Gate for release branches, and use Bash explicitly in all three HCU wheel build jobs. This prevents the updated container image with /bin/sh pointing to dash from failing on source, shopt, and Bash arrays. YAML parsing and HCU registration checks pass.