### PR TITLE
ci(hcu): trust wheel build workspaces

### DIFF
--- a/.github/workflows/nightly-test-hcu.yml
+++ b/.github/workflows/nightly-test-hcu.yml
@@ -331,6 +331,10 @@ jobs:
           ref: ${{ env.WHEEL_COMMIT_SHA }}
           submodules: 'recursive'
 
+      - name: Trust checked-out workspace
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
       - name: Install build deps
         run: |
           pip install torch==${TORCH_VERSION} build scikit-build-core cmake ninja wheel setuptools setuptools-scm setuptools-rust maturin ciupload

--- a/.github/workflows/release-pr-hcu.yml
+++ b/.github/workflows/release-pr-hcu.yml
@@ -91,6 +91,10 @@ jobs:
           persist-credentials: false
           allow-unsafe-pr-checkout: true
 
+      - name: Trust checked-out workspace
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
       # 容器内已预装 Python 3.10 + DTK/ROCm + gcc + cmake
       - name: Install build deps
         run: |


### PR DESCRIPTION
Configure the checked-out workspace as a Git safe directory in HCU PR and Nightly fallback wheel build jobs. This fixes setuptools-scm Git introspection failures when the container runs as root and the mounted workspace belongs to the runner UID. YAML parsing and HCU registration checks pass.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->