### PR TITLE
fix(moe): fix W4A8 DeepEP accuracy with SwiGLU clamp

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -126,7 +126,7 @@ from deepgemm import (
     m_grouped_w4a8_gemm_nt_masked_hipc,
 )
 from deepgemm.m_group_gemm import grouped_gemm_w4a16_nt_masked_entry
-from lightop import moe as lightop_op
+from lightop import fuse_silu_mul_clamp_quant, moe as lightop_op
 from lightop.activation import (
     fuse_silu_and_mul,
     fuse_silu_mul_fp8_quant,
@@ -2000,9 +2000,19 @@ class DeepEPMoE(FusedMoE):
                 self.moe_runner_config.gemm1_clamp_limit,
             )
         else:
-            q_a2_all, q_a2_scale = torch.ops.sglang.fuse_silu_mul_quant_ep(
-                gateup_output, masked_m
-            )
+            # Only models that declare a SwiGLU clamp limit use the clamp kernel.
+            swiglu_limit = getattr(self.moe_runner_config, "swiglu_limit", None)
+            if swiglu_limit is None:
+                q_a2_all, q_a2_scale = torch.ops.sglang.fuse_silu_mul_quant_ep(
+                    gateup_output, masked_m
+                )
+            else:
+                q_a2_all, q_a2_scale = fuse_silu_mul_clamp_quant(
+                    gateup_output,
+                    float(swiglu_limit),
+                    mask_m=masked_m,
+                    expect_m=expected_m,
+                )
         # The first-stage BF16 activation is no longer needed after quantization.
         # Releasing it here lowers peak memory during low-latency graph capture.
         del gateup_output


### PR DESCRIPTION
## Motivation

DeepSeek-V4 produces garbled or corrupted outputs on the MATH-500 dataset when running through the W4A8 DeepEP path.

The issue is caused by the W4A8 activation quantization path always using the standard SiLU quantization kernel and ignoring the configured `swiglu_limit`. As a result, the expected SwiGLU clamp is not applied, leading to incorrect model outputs.

## Modifications

- Import the LightOp `fuse_silu_mul_clamp_quant` kernel.
- Apply clamp-aware activation quantization when `swiglu_limit` is configured.
- Preserve the existing `fuse_silu_mul_quant_ep` path when no clamp limit is configured.
- Preserve the existing SiTU-specific path for Kimi K3.
- Keep behavior unchanged for models that do not use a SwiGLU clamp.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->