### PR TITLE
hcu ci: docker 镜像 daily 定时构建, router 改用 vendored openssl, 补装 flash_kda

### DIFF
--- a/.github/workflows/release-docker-hcu.yml
+++ b/.github/workflows/release-docker-hcu.yml
@@ -5,6 +5,8 @@ name: Release Docker Images (HCU)
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 14 * * *"  # 22:00 Beijing Time daily
 
 env:
   HARBOR_SITE: ${{ vars.HARBOR_SITE }}

--- a/.github/workflows/release-pr-hcu.yml
+++ b/.github/workflows/release-pr-hcu.yml
@@ -183,8 +183,8 @@ jobs:
           source $HOME/.cargo/env
           export RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static
           export RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup
-          cd sgl-model-gateway && cargo build --release
-          cd bindings/python && maturin build --release --skip-auditwheel
+          cd sgl-model-gateway && cargo build --release --features vendored-openssl
+          cd bindings/python && maturin build --release --skip-auditwheel --features vendored-openssl
           echo "=== sgl-model-gateway wheel ==="
           ls -lh target/wheels/*.whl
 

--- a/.github/workflows/release-pypi-nightly-hcu.yml
+++ b/.github/workflows/release-pypi-nightly-hcu.yml
@@ -150,6 +150,8 @@ jobs:
           source /opt/dtk/env.sh
           source $HOME/.cargo/env
           cd python
+          # setup.py 固定读 pyproject.toml; HCU 依赖清单在 pyproject_hcu.toml, 构建前换入
+          cp pyproject_hcu.toml pyproject.toml
           export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}"
           python -m build --wheel --no-isolation -Cfeatures=all_hip
           echo "=== sglang wheel ==="

--- a/.github/workflows/release-pypi-nightly-hcu.yml
+++ b/.github/workflows/release-pypi-nightly-hcu.yml
@@ -164,8 +164,8 @@ jobs:
           source $HOME/.cargo/env
           export RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static
           export RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup
-          cd sgl-model-gateway && cargo build --release
-          maturin build --manifest-path bindings/python/Cargo.toml --release --skip-auditwheel
+          cd sgl-model-gateway && cargo build --release --features vendored-openssl
+          maturin build --manifest-path bindings/python/Cargo.toml --release --skip-auditwheel --features vendored-openssl
           echo "=== sgl-model-gateway wheel ==="
           ls -lh "$GITHUB_WORKSPACE/sgl-model-gateway/target/wheels/"*.whl
 

--- a/.github/workflows/release-pypi-nightly-hcu.yml
+++ b/.github/workflows/release-pypi-nightly-hcu.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Build sglang python package
         if: steps.changes.outputs.sglang == 'true' || github.event_name == 'workflow_dispatch'
         env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: "0.5.15.post1"
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.5.18"
         run: |
           source /opt/dtk/env.sh
           source $HOME/.cargo/env

--- a/docker/hcu.Dockerfile
+++ b/docker/hcu.Dockerfile
@@ -64,6 +64,7 @@ RUN TORCH_TAG="torch${TORCH_VERSION//./}" \
     && das-install boltops ${TORCH_TAG} \
     && das-install causal_conv1d==1.5.4 ${TORCH_TAG} \
     && das-install flash_mla ${TORCH_TAG} \
+    && das-install flash_kda ${TORCH_TAG} \
     && das-install fastsafetensors ${TORCH_TAG} \
     && das-install triton==3.6.0 ${TORCH_TAG} \
     && pip install --no-cache-dir numpy==1.25.0 \

--- a/docker/hcu.Dockerfile
+++ b/docker/hcu.Dockerfile
@@ -75,11 +75,9 @@ RUN pip uninstall -y starlette fastapi prometheus-fastapi-instrumentator \
     && pip install --no-cache-dir torchaudio==2.11.0 -i https://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com \
     && pip install --no-cache-dir nvidia-cutlass-dsl==4.4.2 -i https://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com \
     && pip install --no-cache-dir sgl-deep-gemm==0.1.0 -i https://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com \
-    && pip install --no-cache-dir sglang==${SGLANG_VERSION} sglang-router sglang[diffusion] \
+    && pip install --no-cache-dir sglang[diffusion]==${SGLANG_VERSION} sglang-router \
     && pip install --no-cache-dir numpy==1.25.0 \
-    && pip install --no-cache-dir kernels==0.14 -i https://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com \
-    && pip install --no-cache-dir setuptools==79.0.1 \
-    && pip uninstall -y torchcodec
+    && pip install --no-cache-dir setuptools==79.0.1 
 
 
 # 构建完成后移除内网 pip 源, 避免运行时意外拉取内网依赖

--- a/python/pyproject_hcu.toml
+++ b/python/pyproject_hcu.toml
@@ -1,0 +1,255 @@
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-rust>=1.10", "setuptools-scm>=8.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sglang"
+dynamic = ["version"]
+description = "SGLang is a fast serving framework for large language models and vision language models."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: Apache Software License",
+]
+
+# Please keep dependency lists in this file sorted alphabetically by package name.
+dependencies = [
+  "aiohttp",
+  "anthropic>=0.20.0",
+  "apache-tvm-ffi==0.1.11",
+  "av==16.1.0 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
+  "blobfile==3.0.0",
+  "build",
+  "compressed-tensors",
+  "cuda-python>=13.0",
+  # Transitive dep of flashinfer-python, pinned because 1.6.0rc6 shipped no cp310 linux x86_64 wheel.
+  "cuda-tile==1.6.0rc5",
+  "datasets",
+  "decord2 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
+  "distro",
+  "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
+  "einops",
+  "fastapi",
+  "flash-attn",
+  "flashinfer_python[cu13]==0.6.17", # keep it aligned with jit-cache version in Dockerfile
+  "gguf",
+  "humming-kernels[cu13]==0.1.10",
+  "interegular",
+  "IPython",
+  "kernels>=0.14.1,<0.15",
+  "llguidance>=1.7.6,<2.0.0",
+  "mistral_common>=1.11.5",
+  "modelscope",
+  "msgspec",
+  "ninja",
+  "numba==0.65.1",
+  "numpy",
+  "nvidia-cutlass-dsl[cu13]==4.6.2",
+  "nvidia-mathdx==25.6.0",
+  "nvidia-ml-py",
+  "openai==2.6.1",
+  "openai-harmony==0.0.4",
+  "orjson",
+  "outlines==0.1.11",
+  "packaging",
+  "partial_json_parser",
+  "pillow",
+  "prometheus-client>=0.20.0",
+  "psutil",
+  "py-spy",
+  "pybase64",
+  "pydantic",
+  "python-multipart",
+  "pyzmq>=25.1.2",
+  "quack-kernels==0.6.4",
+  "requests",
+  "scipy",
+  "sentencepiece",
+  "setproctitle",
+  "deep-ep",
+  "deepgemm",
+  "sglang-kernel==0.4.6.post1",
+  "smg-grpc-servicer>=0.5.0",
+  "soundfile==0.13.1",
+  "tiktoken",
+  "tilelang",
+  "timm==1.0.16",
+  "tokenizers==0.22.2", # 0.23.0rc0 is incompatible with transformers' CLIPTokenizer.
+  "tokenspeed_mla==0.1.8",
+  "tomli ; python_version < '3.11'",
+  "torch==2.11.0",
+  "torch_memory_saver>=0.0.9.post1",
+  "torchaudio==2.11.0",
+  "torchvision",
+  "tqdm",
+  "transformers==5.12.1",
+  "uvicorn",
+  "uvloop",
+  "watchfiles",
+  "xgrammar==0.2.1",
+  "xxhash",
+  "zstandard",
+]
+
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true
+
+[project.optional-dependencies]
+checkpoint-engine = ["checkpoint-engine==0.1.2"]
+runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
+diffusion = [
+  "addict==2.4.0",
+  "av==16.1.0",
+  "cache-dit==1.3.0",
+  "cloudpickle==3.1.2",
+  "diffusers==0.37.0",
+  "imageio==2.36.0",
+  "imageio-ffmpeg==0.5.1",
+  "moviepy>=2.0.0",
+  "msgpack",
+  "nvidia-modelopt",
+  "opencv-python-headless==4.10.0.84",
+  "PyYAML==6.0.1",
+  "remote-pdb==2.1.0",
+  "runai_model_streamer>=0.15.7",
+  "scikit-image==0.25.2",
+  "st_attn==0.0.7 ; platform_machine != 'aarch64' and platform_machine != 'arm64'",
+  "trimesh>=4.0.0",
+  "vsa==0.0.4 ; platform_machine != 'aarch64' and platform_machine != 'arm64'",
+  "websockets",
+  "xatlas",
+]
+
+diffusion-qvg = [
+  # quant-videogen 0.1.0 pins an incompatible Torch version, so it is
+  # installed separately with --no-deps; this extra provides its missing
+  # import-time dependencies.
+  "loguru>=0.7",
+  "termcolor>=2.3",
+]
+
+ray = [
+  "ray[default]>=2.55.1",
+]
+
+tracing = [
+  "opentelemetry-api",
+  "opentelemetry-exporter-otlp",
+  "opentelemetry-exporter-otlp-proto-grpc",
+  "opentelemetry-sdk",
+]
+
+http2 = [
+  "granian>=2.6.0",
+]
+
+fastokens = [
+  "fastokens>=0.1.1,<0.2.0",
+]
+
+test = [
+  "accelerate",
+  "addict",
+  "auto-round>=0.13.1",
+  "av==16.1.0",
+  "bitsandbytes",
+  "pymupdf",
+  "diff-cover",
+  "expecttest",
+  "granian>=2.6.0",
+  "jsonlines",
+  "lm-eval[api]>=0.4.9.2",
+  "matplotlib",
+  # 4.9.3 is what sgl-eval's math_verify grader needs (latex2sympy2_extended
+  # raises ImportError on 4.7.x), so a `sglang[test]` environment is already
+  # compatible when sgl-eval is installed on top of it.
+  # Do NOT declare sgl-eval itself here: it is git-only, and PyPI rejects any
+  # uploaded distribution whose metadata carries a direct URL requirement.
+  # CUDA CI installs it in scripts/ci/cuda/ci_install_dependency.sh.
+  "antlr4-python3-runtime==4.9.3",
+  "pandas",
+  "parameterized",
+  "peft>=0.18.0",
+  "polars",
+  "pytest",
+  "pytest-cov",
+  "sentence_transformers",
+  "sglang[fastokens]",
+  "tabulate",
+]
+
+dev = ["sglang[test]"]
+
+all = [
+  "sglang[diffusion]",
+  "sglang[http2]",
+  "sglang[tracing]",
+]
+
+[tool.uv.extra-build-dependencies]
+st-attn = ["setuptools", "torch"]
+vsa = ["setuptools", "torch"]
+
+[project.urls]
+"Homepage" = "https://github.com/sgl-project/sglang"
+"Bug Tracker" = "https://github.com/sgl-project/sglang/issues"
+
+[project.scripts]
+sglang = "sglang.cli.main:main"
+killall_sglang = "sglang.cli.killall:main"
+
+[tool.setuptools.package-data]
+"sglang" = [
+  "srt/**/*",
+  "kernels/**/*",
+  "multimodal_gen/apps/realtime_webui/**/*"
+]
+
+[tool.setuptools.exclude-package-data]
+"sglang" = [
+  "kernels/aot/*",
+  "kernels/aot/**/*",
+]
+
+[tool.setuptools.packages.find]
+exclude = [
+  "assets*",
+  "benchmark*",
+  "docs*",
+  "dist*",
+  "playground*",
+  "scripts*",
+  "sglang.kernels.aot*",
+  "tests*",
+]
+
+[tool.wheel]
+exclude = [
+  "assets*",
+  "benchmark*",
+  "docs*",
+  "dist*",
+  "playground*",
+  "scripts*",
+  "sglang/kernels/aot*",
+  "tests*",
+]
+
+[tool.setuptools_scm]
+root = ".."
+version_file = "sglang/_version.py"
+git_describe_command = ["python3", "scripts/release/get_version_tag.py"]
+# Allow editable installs even when .git metadata is not available.
+fallback_version = "0.0.0.dev0"
+
+# Rust extension modules are auto-discovered by setup.py from the cargo
+# workspace in ../rust ([package.metadata.sglang] python-module in each crate).
+# This CUDA pyproject builds all of them; platform variants restrict the set
+# via [tool.sglang] rust-extensions (see pyproject_other.toml).
+
+[tool.kernels.dependencies]
+"kernels-community/sgl-flash-attn3" = 1


### PR DESCRIPTION
## Summary

- `.github/workflows/release-docker-hcu.yml`: 增加 `schedule` 触发,每天北京时间 22:00 自动构建并推送 HCU 镜像
- `.github/workflows/release-pypi-nightly-hcu.yml` / `.github/workflows/release-pr-hcu.yml`: router(sgl-model-gateway)编包加 `--features vendored-openssl`,不再依赖系统 openssl
- `docker/hcu.Dockerfile`: 补装 `das-install flash_kda`

## Test plan

- [ ] 手动触发一次 release-docker-hcu 确认镜像构建
- [ ] 观察 nightly 编包是否成功编译 router(vendored openssl 需要 perl-IPC-Cmd,nightly 构建依赖已含)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->