### PR TITLE
fix(moe): apply SwiGLU clamp in contiguous W4A8 path

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -1245,7 +1245,18 @@ class DeepEPMoE(FusedMoE):
                     self.moe_runner_config.gemm1_clamp_limit,
                 )
             else:
-                q_a2_all, q_a2_scale = fuse_silu_mul_quant(gateup_output)
+                # Apply the model-declared SwiGLU clamp when present. Models
+                # without swiglu_limit retain the original unclamped path.
+                swiglu_limit = getattr(
+                    self.moe_runner_config, "swiglu_limit", None
+                )
+                if swiglu_limit is None:
+                    q_a2_all, q_a2_scale = fuse_silu_mul_quant(gateup_output)
+                else:
+                    q_a2_all, q_a2_scale = fuse_silu_mul_clamp_quant(
+                        gateup_output,
+                        float(swiglu_limit),
+                    )
             del gateup_output
 
             down_output = torch.empty(


### PR DESCRIPTION
## Motivation

The DeepSeek-V4 contiguous W4A8 MoE path always used the unclamped `fuse_silu_mul_quant` kernel, even when the model configuration declared a `swiglu_limit`.

## Modifications

- Read `swiglu_limit` from the MoE runner configuration.
- Use `fuse_silu_mul_clamp_quant` when a clamp limit is configured.
- Preserve the original `fuse_silu_mul_quant` path when `swiglu_limit` is not set.
- Keep the existing SiTU path unchanged.
- Limit the change to the contiguous W4A8 MoE execution path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->