### PR TITLE
fix(dspark): transfer draft KV from PD prefill

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_disaggregation.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_disaggregation.py
@@ -82,6 +82,19 @@ def resolve_disagg_metadata_config(
     if mode_value not in ("decode", "prefill"):
         return DSparkDisaggMetadataConfig()
 
+    # The upstream pp_size=1 PD path injects target hidden states into the
+    # prefill-side draft KV cache and transfers that cache to decode. Keep the
+    # HCU hidden-state wire path as an explicit fallback only: setting either
+    # pool variable opts into it, while leaving both unset selects draft-KV
+    # transfer and avoids allocating a hidden row pool on P or D.
+    pool_env_value = os.getenv("SGLANG_PD_HIDDEN_POOL_TOKENS")
+    if mode_value == "decode":
+        pool_env_value = os.getenv("SGLANG_PD_HIDDEN_RECV_POOL_TOKENS")
+        if pool_env_value is None:
+            pool_env_value = os.getenv("SGLANG_PD_HIDDEN_POOL_TOKENS")
+    if pool_env_value is None:
+        return DSparkDisaggMetadataConfig()
+
     should_probe = (
         spec_algorithm.is_dspark()
         or mode_value == "prefill"
@@ -102,19 +115,9 @@ def resolve_disagg_metadata_config(
         )
 
     hidden_size = len(target_layer_ids) * int(model_config.hidden_size)
-    default_pool_rows = max(
-        1,
-        int(server_args.max_prefill_buffer_tokens() or 0),
-        int(max_prefill_tokens or 0),
-    )
-    pool_env_value = os.getenv("SGLANG_PD_HIDDEN_POOL_TOKENS")
-    if mode_value == "decode":
-        pool_env_value = os.getenv("SGLANG_PD_HIDDEN_RECV_POOL_TOKENS")
-        if pool_env_value is None:
-            pool_env_value = os.getenv("SGLANG_PD_HIDDEN_POOL_TOKENS")
     hidden_pool_size = max(
         0,
-        int(pool_env_value if pool_env_value is not None else str(default_pool_rows)),
+        int(pool_env_value),
     )
 
     if mode_value == "prefill" and pp_size > 1:

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -297,9 +297,6 @@ class DSparkWorkerV2(BaseSpecWorker):
             self.draft_model.prune_to_ctx_kv_injection()
 
     def _attach_shared_modules(self) -> None:
-        if self._is_pd_prefill:
-            return
-
         if getattr(self.draft_model, "uses_own_vocab_modules", False):
             if self.ps.tp_rank == 0:
                 logger.info(
@@ -487,18 +484,6 @@ class DSparkWorkerV2(BaseSpecWorker):
                 "DSpark requires target aux hidden capture for prefill, but got None. "
                 "Make sure the target model has DFlash layers-to-capture configured."
             )
-
-        # A PD prefill worker does not run local speculative decode. Keep the
-        # captured target states on the result so the scheduler can transfer
-        # them to the decode worker; injecting them into the local draft cache
-        # and clearing the result would make the remote draft start without its
-        # context features.
-        if self._is_pd_prefill:
-            batch_output.next_draft_input = make_next_draft_input(
-                bonus_tokens=next_token_ids,
-                new_seq_lens=batch.seq_lens,
-            )
-            return batch_output
 
         if batch.extend_lens is None or batch.prefix_lens is None:
             raise RuntimeError(


### PR DESCRIPTION
## Motivation

This PR supports enabling DSpark on the Prefill side in a disaggregated PD deployment.

Previously, the PD Prefill path returned immediately after capturing target hidden states. As a result, the Prefill-side draft model did not construct its local Draft KV cache, and Decode could not continue speculative decoding from Prefill-generated Draft KV.

## Fix

This PR fixes the Prefill-side DSpark path as follows:

```text
Target model runs Prefill
        ↓
Capture the hidden states required by DSpark
        ↓
Inject hidden states into the Prefill-side Draft KV cache
        ↓
Clear the raw hidden-state output
        ↓
Transfer Target KV and Draft KV through the PD transfer path
        ↓
Decode continues speculative decoding from the transferred Draft KV
```

The main changes are:

- Remove the PD Prefill early return in `dspark_worker_v2.py`.
- Attach the target model's shared embedding and LM head to the Prefill-side draft model.
- Inject captured target hidden states into the local Draft KV before Prefill returns.
- Clear `logits_output.hidden_states` after injection to avoid copying or transferring the large raw hidden-state buffer.
- Make the legacy hidden-state transfer path explicitly controlled by the hidden-pool environment variables in `dspark_disaggregation.py`.

## Usage

DSpark supports two PD deployment modes.

### Mode 1: DSpark on both Prefill and Decode

This is the path fixed by this PR.

Both hidden-pool variables must be unset on Prefill and Decode:

```bash
unset SGLANG_PD_HIDDEN_POOL_TOKENS
unset SGLANG_PD_HIDDEN_RECV_POOL_TOKENS
```

Enable DSpark on both sides:

```bash
--speculative-algorithm DSPARK \
--speculative-num-steps 1 \
--speculative-eagle-topk 1 \
--speculative-moe-a2a-backend deepep \
--speculative-moe-runner-backend deep_gemm
```

The data path is:

```text
P target hidden states → P Draft KV → PD KV transfer → D
```

Prefill constructs the Draft KV before transferring it to Decode. Therefore, no hidden-state sending or receiving pool is required.

The new path is currently validated with `PP=1`.

### Mode 2: DSpark only on Decode

This is the legacy compatibility path.

Prefill does not enable DSpark. It transfers target hidden states to Decode, and Decode constructs the Draft KV cache locally.

Hidden-state pools are required.

Prefill:

```bash
export SGLANG_PD_HIDDEN_POOL_TOKENS=<POOL_SIZE>
```

Decode:

```bash
export SGLANG_PD_HIDDEN_RECV_POOL_TOKENS=<POOL_SIZE>
```

Enable DSpark only on Decode:

```bash
--speculative-algorithm DSPARK \
--speculative-num-steps 1 \
--speculative-eagle-topk 1 \
--speculative-moe-a2a-backend deepep \
--speculative-moe-runner-backend deep_gemm
```

The data path is:

```text
P target hidden states → D hidden receive pool → D Draft KV
```

Setting either hidden-pool variable selects the legacy hidden-state transfer path. Leaving both variables unset selects the new Prefill-generated Draft-KV transfer path.

## Accuracy Tests

Validated on **DeepSeek-V4-Flash-0731 W4A8** with DSpark enabled on both Prefill and Decode.

Test configuration:

- Prefill: CP8 / TP8 / EP8
- Decode: DP16 / TP16 / EP16
- Target and Draft CUDA Graph batch sizes: 1–8
- Hidden-pool variables unset
- EvalScope batch size: 32
- Temperature: 0
- Maximum output tokens: 10240

| Dataset | Samples | Metric | Score |
| --- | ---: | --- | ---: |
| HumanEval | 164 | Pass@1 | **90.2%** |
| GSM8K | 1,319 | Accuracy | **96.5%** |
| MATH-500 | 500 | Accuracy | **94.0%** |

The results confirm that the Prefill-generated Draft-KV transfer path preserves the accuracy of DeepSeek-V4-Flash-0731.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->