### PR TITLE
fix(hcu): enable W4A8 DeepEP aiter path and FlashMLA workspace reuse

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -673,7 +673,7 @@ class DeepseekV4AttnBackend(
         )
         self._dsv4_lightop_kvcache_op = None
         self._dsv4_bf16_flashmla_workspaces: Dict[
-            Tuple[str, int], Tuple[torch.Tensor, torch.Tensor]
+            str, Tuple[torch.Tensor, torch.Tensor]
         ] = {}
         if self._dsv4_lightop_bf16_gather and not self._dsv4_bf16_flashmla_decode:
             raise RuntimeError(
@@ -1760,11 +1760,17 @@ class DeepseekV4AttnBackend(
     ) -> None:
         if not self._dsv4_bf16_flashmla_decode or capacity <= 0 or topk <= 0:
             return
-        key = (slot, topk)
-        current = self._dsv4_bf16_flashmla_workspaces.get(key)
-        current_capacity = 0 if current is None else current[0].shape[0]
-        if current_capacity >= capacity:
-            return
+        current = self._dsv4_bf16_flashmla_workspaces.get(slot)
+        if current is not None:
+            current_capacity = current[0].shape[0]
+            current_topk = current[0].shape[1]
+            if current_capacity >= capacity and current_topk == topk:
+                return
+            # Drop the previous buffer before reallocating. c128 topk grows
+            # every prefill chunk; keeping one workspace per topk OOMs on
+            # long context with small chunked_prefill_size.
+            del self._dsv4_bf16_flashmla_workspaces[slot]
+            del current
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(
                 "DSV4 BF16 FlashMLA gather workspace must be allocated before "
@@ -1780,7 +1786,7 @@ class DeepseekV4AttnBackend(
             dtype=torch.int32,
             device=self.device,
         )
-        self._dsv4_bf16_flashmla_workspaces[key] = (
+        self._dsv4_bf16_flashmla_workspaces[slot] = (
             gathered_kv,
             compact_indices,
         )
@@ -1792,7 +1798,7 @@ class DeepseekV4AttnBackend(
         topk: int,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         self._allocate_dsv4_bf16_flashmla_workspace(slot, num_queries, topk)
-        workspace = self._dsv4_bf16_flashmla_workspaces.get((slot, topk))
+        workspace = self._dsv4_bf16_flashmla_workspaces.get(slot)
         if workspace is None:
             raise RuntimeError("DSV4 BF16 FlashMLA gather workspace is unavailable")
         gathered_kv, compact_indices = workspace

--- a/python/sglang/srt/layers/quantization/slimquant_w4a8_marlin.py
+++ b/python/sglang/srt/layers/quantization/slimquant_w4a8_marlin.py
@@ -1255,6 +1255,8 @@ class SlimQuantW4A8Int8AiterMoEMethod:
 
     def __init__(self, quant_config):
         self.quant_config = quant_config
+        self.use_deepep = get_moe_a2a_backend().is_deepep()
+        self._ep_use_marlin = False
 
     def create_weights(
         self,
@@ -1313,6 +1315,29 @@ class SlimQuantW4A8Int8AiterMoEMethod:
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self.use_deepep:
+            # DeepEP grouped GEMM consumes the HIPC pack + x16 scale, not the
+            # Aiter TP shuffle layout. Matching SlimQuantW4A8Int8MarlinMoEMethod.
+            from deepgemm import pack_w4a8_moe_hipc_weight
+
+            layer.w13_weight = Parameter(
+                pack_w4a8_moe_hipc_weight(layer.w13_weight.data),
+                requires_grad=False,
+            )
+            layer.w2_weight = Parameter(
+                pack_w4a8_moe_hipc_weight(layer.w2_weight.data),
+                requires_grad=False,
+            )
+            scale_mul = 16.0
+            layer.w13_weight_scale = Parameter(
+                layer.w13_weight_scale.data * scale_mul, requires_grad=False
+            )
+            layer.w2_weight_scale = Parameter(
+                layer.w2_weight_scale.data * scale_mul, requires_grad=False
+            )
+            self._ep_use_marlin = False
+            return
+
         E = layer.w13_weight.shape[0]
         layer.w13_weight = Parameter(
             repack_and_shuffle_w4a8(layer.w13_weight.data, E), requires_grad=False
@@ -1320,6 +1345,7 @@ class SlimQuantW4A8Int8AiterMoEMethod:
         layer.w2_weight = Parameter(
             repack_and_shuffle_w4a8(layer.w2_weight.data, E), requires_grad=False
         )
+        self._ep_use_marlin = False
 
         layer.w13_weight_scale = Parameter(
             layer.w13_weight_scale.data, requires_grad=False
@@ -1398,3 +1424,220 @@ class SlimQuantW4A8Int8AiterMoEMethod:
             routed_scaling_factor=self.moe_runner_config.routed_scaling_factor,
         )
         return StandardCombineInput(hidden_states=output)
+
+    def _get_ep_expert_map(
+        self,
+        global_num_experts: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        cached = getattr(self, "_ep_expert_map", None)
+        if (
+            cached is not None
+            and cached.numel() == global_num_experts
+            and cached.device == device
+        ):
+            return cached
+        from sglang.srt.distributed import (
+            get_moe_expert_parallel_rank,
+            get_moe_expert_parallel_world_size,
+        )
+        from sglang.srt.layers.moe.fused_moe_triton.layer import determine_expert_map
+
+        _, expert_map = determine_expert_map(
+            get_moe_expert_parallel_world_size(),
+            get_moe_expert_parallel_rank(),
+            global_num_experts,
+        )
+        expert_map = expert_map.to(device=device, dtype=torch.int32)
+        self._ep_expert_map = expert_map
+        return expert_map
+
+    @torch._dynamo.disable()
+    def apply_ep(
+        self,
+        x: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        global_num_experts: int = -1,
+        expert_map: Optional[torch.Tensor] = None,
+        apply_router_weight_on_input: bool = False,
+        activation: str = "silu",
+        w1_scale: Optional[torch.Tensor] = None,
+        w2_scale: Optional[torch.Tensor] = None,
+        a1_scale: Optional[torch.Tensor] = None,
+        a2_scale: Optional[torch.Tensor] = None,
+        use_nn_moe: Optional[bool] = False,
+        num_local_tokens: Optional[torch.Tensor] = None,
+        routed_scaling_factor: Optional[float] = 1.0,
+        shared_output: Optional[torch.Tensor] = None,
+        num_recv_tokens_per_expert: List = None,
+        **_,
+    ):
+        if getattr(self, "_ep_use_marlin", False):
+            # Weights were packed into the lightop Marlin layout. Honor the
+            # DeepEP dummy-global-id ABI the same way SlimQuantW4A8Int8MarlinMoEMethod does.
+            _ensure_lightop_w4a8_marlin_available()
+            workspace, global_reduce_buffer = MarlinMoeWorkspace(x.device).get_buffers()
+            routed_scaling_factor = (
+                1.0 if routed_scaling_factor is None else routed_scaling_factor
+            )
+            return fused_experts_impl_w4a8_marlin(
+                x,
+                w1,
+                w2,
+                topk_ids=topk_ids,
+                topk_weights=topk_weights,
+                workspace=workspace,
+                global_reduce_buffer=global_reduce_buffer,
+                inplace=True,
+                use_int4_w4a8=True,
+                per_channel_quant=True,
+                activation=activation,
+                expert_map=expert_map,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+                global_num_experts=global_num_experts,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                a1_scale=a1_scale,
+                use_nn_moe=use_nn_moe,
+                shared_output=shared_output,
+                routed_scaling_factor=float(routed_scaling_factor),
+            )
+
+        # Non-DeepEP / TP path: aiter shuffled [E, N, K/2] weights.
+        _ensure_aiter_w4a8_marlin_available()
+        if apply_router_weight_on_input:
+            raise NotImplementedError(
+                "apply_router_weight_on_input is not supported by AITER W4A8 apply_ep."
+            )
+        if shared_output is not None:
+            raise NotImplementedError(
+                "shared_output is not supported by AITER W4A8 apply_ep."
+            )
+        if x.shape[0] == 0:
+            return x.bfloat16() if x.dtype != torch.bfloat16 else x
+
+        e = w1.size(0)
+        k = x.size(-1)
+        n1 = w1.size(1)
+        n2 = n1 // 2
+        topk_ids = topk_ids.to(torch.int32)
+        topk = topk_ids.size(1)
+        if x.dim() == 2:
+            m = x.size(0)
+        else:
+            assert x.dim() == 3
+            assert x.size(0) == e, f"{x.size(0)} == {e}"
+            m = x.size(1)
+        orig_m = m
+        scatter_idx = None
+
+        if global_num_experts is None or global_num_experts < 0:
+            global_num_experts = e
+        if global_num_experts > e:
+            from sglang.srt.distributed import (
+                get_moe_expert_parallel_rank,
+                get_moe_expert_parallel_world_size,
+            )
+
+            ep_rank = get_moe_expert_parallel_rank()
+            rank_offset = ep_rank * (
+                global_num_experts // get_moe_expert_parallel_world_size()
+            )
+            dummy = global_num_experts - 1 if ep_rank == 0 else 0
+            local_ids = topk_ids - rank_offset
+            invalid = (
+                (topk_ids == dummy)
+                | (topk_ids < 0)
+                | (local_ids < 0)
+                | (local_ids >= e)
+            )
+            valid = ~invalid
+            if not valid.any():
+                return torch.zeros(
+                    orig_m, k, device=x.device, dtype=torch.bfloat16
+                )
+            # DeepEP pads unused top-k slots with a dummy global id. aiter_moe
+            # has no skip mask, so compact to valid (token, expert) pairs with
+            # topk=1 and scatter-add. Dummy traffic must not run as expert 0.
+            scatter_idx, _ = torch.where(valid)
+            x = x.index_select(0, scatter_idx)
+            if a1_scale is not None:
+                scale = a1_scale
+                if scale.dim() == 1:
+                    scale = scale.unsqueeze(-1)
+                a1_scale = scale.index_select(0, scatter_idx)
+            topk_ids = local_ids[valid].to(torch.int32).view(-1, 1)
+            topk_weights = topk_weights[valid].view(-1, 1)
+            m = x.size(0)
+            topk = 1
+            global_num_experts = e
+            expert_map = None
+
+        x = x.contiguous()
+        topk_ids = topk_ids.contiguous()
+        topk_weights = topk_weights.contiguous()
+        if a1_scale is not None:
+            a1_scale = a1_scale.contiguous()
+
+        if x.dtype not in (torch.float16, torch.bfloat16):
+            if a1_scale is None:
+                raise RuntimeError(
+                    "AITER W4A8 apply_ep received non-floating activations "
+                    f"({x.dtype}) without a1_scale."
+                )
+            # Keep INT8 + per-token scale. Dequantizing to BF16 made aiter
+            # pick the wrong W4A8 kernel and produced garbage logits.
+            output_dtype = torch.bfloat16
+            config_dtype = x.dtype
+        else:
+            output_dtype = x.dtype
+            config_dtype = x.dtype
+        status, moe_config = get_aiter_moe_config(
+            M=m,
+            E=e,
+            N1=n1,
+            N2=n2,
+            K=k,
+            top_k=topk,
+            block_size=None,
+            dtype=config_dtype,
+            quant_type=MoeQuantType.W4A8,
+            activation=activation,
+        )
+        if not status:
+            raise RuntimeError(
+                "aiter backend did not find a valid w4a8 tpmoe config for "
+                f"M={m}, E={e}, N1={n1}, N2={n2}, K={k}, topk={topk}, "
+                f"dtype={output_dtype}, activation={activation}."
+            )
+
+        routed_scaling_factor = (
+            1.0 if routed_scaling_factor is None else routed_scaling_factor
+        )
+        output = aiter_moe(
+            x,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights.to(torch.float32),
+            topk_ids=topk_ids,
+            moe_config=moe_config,
+            activation=activation,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+            routed_scaling_factor=float(routed_scaling_factor),
+            output_dtype=output_dtype,
+        )
+        if scatter_idx is None:
+            return output
+        combined = torch.zeros(
+            orig_m, k, device=output.device, dtype=output.dtype
+        )
+        combined.index_add_(0, scatter_idx, output)
+        return combined


### PR DESCRIPTION
## Motivation

HCU 上 DeepSeek-V4 Flash W4A8 在 DeepEP + `SGLANG_W4A8_TPMOE_BACKEND=aiter` 路径下无法正确运行：

1. `SlimQuantW4A8Int8AiterMoEMethod` 在 DeepEP 下仍按 Aiter TP shuffle 布局打包权重，与 DeepGEMM contiguous/masked HIPC kernel 期望布局不一致，导致 MoE 计算失败或精度错误。
2. 开启 `SGLANG_DSV4_HCU_USE_BF16_FLASH_MLA` 时，BF16 FlashMLA gather workspace 按 `(slot, topk)` 缓存；chunked prefill 过程中 c128 topk 逐步增大，旧 buffer 不被释放，长上下文场景易 OOM。

本 PR 对齐 Marlin DeepEP 路径的 HIPC 打包逻辑，并修复 FlashMLA workspace 复用策略，使 aiter + DeepEP W4A8 可正确服务。

## Modifications

1. **`slimquant_w4a8_marlin.py` (`SlimQuantW4A8Int8AiterMoEMethod`)**
   - DeepEP 时：`process_weights_after_loading` 使用 `pack_w4a8_moe_hipc_weight` + `scale × 16`（与 `SlimQuantW4A8Int8MarlinMoEMethod` 一致）。
   - 非 DeepEP：仍走原有 aiter shuffle 路径，不影响 TP/DP decode。
   - 新增 `apply_ep`：作为 DeepEP 且关闭 contiguous HIPC 时的 fallback；主路径配合 `SGLANG_USE_W4A8_CONTIGUOUS_HIPC` / `SGLANG_USE_W4A8_MASKED_HIPC` 使用 HIPC GEMM。

2. **`deepseek_v4_backend.py`**
   - BF16 FlashMLA gather workspace 改为按 `slot` 复用；`capacity`/`topk` 变化时先释放旧 buffer 再扩容，避免长上下文 + 小 chunk 时显存堆积。

**运行注意**：DeepEP + Aiter + HIPC 打包后，建议同时设置：
```bash
export SGLANG_USE_W4A8_CONTIGUOUS_HIPC=true   # prefill (normal)
export SGLANG_USE_W4A8_MASKED_HIPC=true        # decode (low-latency)
```

## Accuracy Tests

模型：DeepSeek-V4-Flash-0731-W4A8-INT4-Channel-Attn-W8A8-INT8-Channel  
评测：`python3 -m sglang.test.run_eval --eval-name gsm8k --num-examples 50 --api chat`

| 场景 | 配置 | GSM8K Score |
|------|------|-------------|
| Colocated | TP8 + CP8 + EP8, DeepEP, aiter + HIPC, chunk=32768 | **1.00** (50/50) |
| PD 分离 | P: CP8+EP8 / D: DP8+DSpark  / Router:8000 | **0.98** (49/50) |

## Speed Tests and Profiling

本 PR 主要为正确性与 OOM 修复，未以性能为主要目标。此前同配置 32×128k prefill 吞吐验证仍可用；本次未额外附详细 profile。


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->