### PR TITLE
fix(attention): running Qwen3-0.6B dismatch shape of one step off policy

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1498,25 +1498,27 @@ class FlashAttentionBackend(AttentionBackend):
                     **kwargs,
                 )
             else:
-                result = flash_attn_with_kvcache(
-                    q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
-                    k_cache=key_cache,
-                    v_cache=value_cache,
-                    page_table=page_table,
-                    cache_seqlens=cache_seqlens,
-                    cu_seqlens_q=cu_seqlens_q,
-                    cu_seqlens_k_new=cu_seqlens_k if not use_local_attn else None,
-                    max_seqlen_q=max_seqlen_q,
+                result = vllm_flash_attn_varlen_func(
+                    q=q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                    k=key_cache.view(-1, layer.tp_k_head_num, self.page_size, layer.head_dim),
+                    v=value_cache.view(-1, layer.tp_k_head_num, layer.v_head_dim, self.page_size),
+                    cu_seqlens_q=metadata.cu_seqlens_q,
+                    max_seqlen_q=metadata.max_seq_len_q,
+                    seqused_k=metadata.cache_seqlens_int32,
+                    max_seqlen_k=metadata.max_seq_len_k,
                     softmax_scale=layer.scaling,
-                    causal=False if use_cascade_attn else causal,
+                    causal=True,
                     window_size=window_size,
-                    softcap=layer.logit_cap,
-                    return_softmax_lse=use_cascade_attn,
-                    num_splits=self.num_splits,
-                    out=_fa_out,
-                    ver=self.fa_impl_ver,
-                    **kwargs,
+                    block_table=metadata.page_table,
+                    fa_version=2,
+                    q_descale=k_descale,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
                 )
+            if forward_batch.mha_return_lse:
+                output, lse, *rest = result
+                lse = torch.transpose(lse, 0, 1).contiguous()
+                return output, lse
 
             if use_cascade_attn:
                 o, softmax_lse, *rest = result


### PR DESCRIPTION
### What does this PR do?
When running Qwen3-0.6B of one step off policy, the attention shape dismatched. Using vllm_flash_attn_varlen_func instead of flash_attn_with_kvcache on Hygon hcu

### Checklist Before Starting

- [ ] Format the PR title as `{type}({modules}): {description}`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->