### PR TITLE
ci: enable HCU PR tests for release branches

### DIFF
--- a/.github/workflows/pr-test-hcu.yml
+++ b/.github/workflows/pr-test-hcu.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - v0.5.15.post1_dev
       - main
+      - "release/**"
     paths:
       - ".github/workflows/pr-test-hcu.yml"
       - ".github/workflows/pr-gate.yml"


### PR DESCRIPTION
Allow the HCU PR Test pull_request_target workflow to run for PRs targeting release branches. This fixes release/20260825_v0.5.18 PRs receiving wheel builds without the corresponding HCU PR Test workflow.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->