### PR TITLE
feat(dsv4): support PP/DSpark and CP-aware sparse prefill on HCU

### DIFF
--- a/python/sglang/kernels/aot/setup_hip.py
+++ b/python/sglang/kernels/aot/setup_hip.py
@@ -47,6 +47,7 @@ sources = [
     "csrc/attention/decode_metadata.cu",
     "csrc/common_extension_rocm.cc",
     "csrc/elementwise/activation.cu",
+    "csrc/elementwise/concat_mla_absorb_q_hcu.cu",
     "csrc/elementwise/deepseek_v4_topk.cu",
     "csrc/elementwise/dsv4_norm_rope.cu",
     "csrc/elementwise/l2norm_kernel.cu",

--- a/python/sglang/kernels/ops/attention/dsv4/sparse_prefill_kernels.py
+++ b/python/sglang/kernels/ops/attention/dsv4/sparse_prefill_kernels.py
@@ -8,6 +8,82 @@ import triton.language as tl
 
 
 @triton.jit
+def _build_cp_sparse_query_metadata_kernel(
+    real_query_lens_ptr,
+    physical_query_lens_ptr,
+    query_positions_out_ptr,
+    extend_seq_lens_ptr,
+    extend_start_loc_ptr,
+    query_positions_in_ptr,
+    num_reqs,
+    num_local_queries,
+    cp_rank,
+    CP_SIZE: tl.constexpr,
+    BLOCK_REQS: tl.constexpr,
+    BLOCK_QUERIES: tl.constexpr,
+):
+    """Build CP-local sparse-prefill metadata without host synchronization.
+
+    Every program redundantly computes the small per-request length vector so
+    it can independently identify the real-query prefix. Program 0 also emits
+    the real and physical per-request lengths; every program sanitizes one
+    query-position tile by replacing the physical padding suffix with -1.
+    """
+    req_offsets = tl.arange(0, BLOCK_REQS)
+    req_mask = req_offsets < num_reqs
+    global_start = tl.load(
+        extend_start_loc_ptr + req_offsets, mask=req_mask, other=0
+    ).to(tl.int32)
+    extend_len = tl.load(
+        extend_seq_lens_ptr + req_offsets, mask=req_mask, other=0
+    ).to(tl.int32)
+    global_end = global_start + extend_len
+
+    # Avoid relying on negative-modulo semantics: both cp_rank and the request
+    # phase are in [0, CP_SIZE), so adding CP_SIZE keeps the dividend positive.
+    request_phase = global_start % CP_SIZE
+    first_global = global_start + (cp_rank - request_phase + CP_SIZE) % CP_SIZE
+    real_len = tl.where(
+        req_mask & (first_global < global_end),
+        1 + (global_end - 1 - first_global) // CP_SIZE,
+        0,
+    ).to(tl.int32)
+    total_real = tl.sum(real_len, axis=0)
+    local_padding = num_local_queries - total_real
+
+    # Physical CP padding is a suffix of the flattened stream and therefore
+    # belongs to the final request's physical segment only.
+    physical_len = real_len + tl.where(
+        req_offsets == num_reqs - 1, local_padding, 0
+    )
+    program_is_zero = tl.program_id(0) == 0
+    tl.store(
+        real_query_lens_ptr + req_offsets,
+        real_len,
+        mask=req_mask & program_is_zero,
+    )
+    tl.store(
+        physical_query_lens_ptr + req_offsets,
+        physical_len,
+        mask=req_mask & program_is_zero,
+    )
+
+    query_offsets = (
+        tl.program_id(0) * BLOCK_QUERIES + tl.arange(0, BLOCK_QUERIES)
+    )
+    query_mask = query_offsets < num_local_queries
+    query_position = tl.load(
+        query_positions_in_ptr + query_offsets, mask=query_mask, other=-1
+    ).to(tl.int32)
+    query_position = tl.where(query_offsets < total_real, query_position, -1)
+    tl.store(
+        query_positions_out_ptr + query_offsets,
+        query_position,
+        mask=query_mask,
+    )
+
+
+@triton.jit
 def _build_swa_token_ids_kernel(
     out_ptr,
     swa_first_pos_ptr,
@@ -44,6 +120,7 @@ def _combine_topk_swa_indices_kernel(
     topk_indices_ptr,
     topk_indices_stride,
     query_start_loc_ptr,
+    query_positions_ptr,
     seq_lens_ptr,
     gather_lens_ptr,
     compressed_base_ptr,
@@ -52,6 +129,7 @@ def _combine_topk_swa_indices_kernel(
     COMPRESS_RATIO: tl.constexpr,
     WINDOW_SIZE: tl.constexpr,
     PADDED_TOP_K: tl.constexpr,
+    USE_EXPLICIT_POSITIONS: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
     worker_id = tl.program_id(1)
@@ -74,8 +152,11 @@ def _combine_topk_swa_indices_kernel(
     gather_start = seq_len - gather_len
 
     for token_idx in range(query_start + worker_id, query_end, num_workers):
-        token_idx_in_query = token_idx - query_start
-        pos = start_pos + token_idx_in_query
+        if USE_EXPLICIT_POSITIONS:
+            pos = tl.load(query_positions_ptr + token_idx)
+        else:
+            token_idx_in_query = token_idx - query_start
+            pos = start_pos + token_idx_in_query
         # Both the C4 indexer and the C128 metadata builder emit
         # min((pos+1)//compress_ratio, topk_tokens) valid entries. Caller
         # passes top_k=0 for SWA-only layers to zero this out.

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -120,11 +120,20 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
     # (dense prefill) behavior on ROCm until the sparse kernel is validated
     # there;
     if is_hip():
-        logger.warning(
-            "Disabling SGLANG_OPT_FLASHMLA_SPARSE_PREFILL by default on ROCm/HIP "
-            f"for {model_arch}; set it explicitly to override."
-        )
-        envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.set(False)
+        if (
+            envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.is_set()
+            and envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+        ):
+            logger.warning(
+                "Keeping explicitly enabled SGLANG_OPT_FLASHMLA_SPARSE_PREFILL "
+                f"on ROCm/HIP for experimental {model_arch} validation."
+            )
+        else:
+            logger.warning(
+                "Disabling SGLANG_OPT_FLASHMLA_SPARSE_PREFILL by default on "
+                f"ROCm/HIP for {model_arch}; set it explicitly to override."
+            )
+            envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.set(False)
 
     # The kv-cache dtype default moved to the resolution pipeline
     # (arg_groups/overrides.py: _deepseek_v4_kv_cache_dtype), invoked here at
@@ -210,11 +219,20 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
             "('none', 'deepep', 'megamoe'), "
             f"got {server_args.moe_a2a_backend!r}."
         )
-    logger.warning(
-        "Disabling SGLANG_OPT_FLASHMLA_SPARSE_PREFILL because DeepSeekV4 "
-        "context parallelism is enabled."
-    )
-    envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.set(False)
+    if (
+        envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.is_set()
+        and envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+    ):
+        logger.warning(
+            "Keeping explicitly enabled SGLANG_OPT_FLASHMLA_SPARSE_PREFILL "
+            "for experimental DeepSeekV4 context-parallel validation."
+        )
+    else:
+        logger.warning(
+            "Disabling SGLANG_OPT_FLASHMLA_SPARSE_PREFILL because DeepSeekV4 "
+            "context parallelism is enabled."
+        )
+        envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.set(False)
     logger.warning(
         f"Enable Context Parallel for DeepSeekV4, "
         f"dp_size={server_args.dp_size}, moe_dense_tp_size={server_args.moe_dense_tp_size}, "

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -348,7 +348,6 @@ def _is_supported_dspark_pd_prefill_cp(server_args: ServerArgs) -> bool:
     return (
         server_args.disaggregation_mode == "prefill"
         and server_args.disaggregation_transfer_backend == "mooncake"
-        and server_args.pp_size == 1
         and server_args.attn_cp_size > 1
         and attn_tp_size == 1
         and server_args.enable_prefill_cp
@@ -375,7 +374,7 @@ def _handle_dspark(server_args: ServerArgs) -> None:
     if server_args.attn_cp_size > 1 and not pd_prefill_cp:
         raise ValueError(
             "DSpark context parallel is only supported for DeepSeek-V4 PD prefill "
-            "with Mooncake, pp_size == 1, attn_tp_size == 1, and interleave "
+            "with Mooncake, attn_tp_size == 1, and interleave "
             f"(round-robin-split) CP; got disaggregation_mode="
             f"{server_args.disaggregation_mode!r}, pp_size={server_args.pp_size}, "
             f"attn_cp_size={server_args.attn_cp_size}, attn_tp_size="
@@ -443,9 +442,13 @@ def _handle_dspark(server_args: ServerArgs) -> None:
                 f"runner={draft_runner!r}."
             )
 
-    if server_args.pp_size != 1:
+    if server_args.pp_size != 1 and server_args.disaggregation_mode not in (
+        "prefill",
+        "decode",
+    ):
         raise ValueError(
-            "Currently DSpark speculative decoding only supports pp_size == 1."
+            "DSpark with pipeline parallelism is only supported in PD "
+            "disaggregation mode."
         )
 
     if server_args.speculative_draft_model_path is None:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -52,7 +52,10 @@ from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
+    pack_state_types,
     resolve_dcp_dst_entry_indices,
+    resolve_state_component_dst_index,
+    unpack_state_types,
 )
 from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs
@@ -152,6 +155,7 @@ class KVArgsRegisterInfo:
     dst_state_dim_per_tensor: List[List[int]]
     dst_kv_layer_ids: List[int]
     dst_state_layer_ids: List[List[int]]
+    dst_state_types: List[StateType] = dataclasses.field(default_factory=list)
     dst_state_data_formats: List[str] = dataclasses.field(default_factory=list)
     # Local-only validation result; this is never serialized on the wire.
     registration_error: Optional[str] = dataclasses.field(default=None, repr=False)
@@ -194,6 +198,7 @@ class KVArgsRegisterInfo:
             dst_state_data_formats=(
                 unpack_string_list(msg[18]) if len(msg) > 18 and msg[18] != b"" else []
             ),
+            dst_state_types=unpack_state_types(msg[19]) if len(msg) > 19 else [],
             staging_base_ptr=(
                 struct.unpack("Q", msg[14])[0]
                 if len(msg) > 14 and len(msg[14]) == 8
@@ -1481,32 +1486,52 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             src_state_layer_ids = (
                 src_state_layer_ids[i] if i < len(src_state_layer_ids) else []
             )
+            dst_component_index = i
             if target_rank_registration_info is not None:
+                dst_component_index = resolve_state_component_dst_index(
+                    state_types,
+                    target_rank_registration_info.dst_state_types,
+                    i,
+                )
                 dst_data_ptrs = (
-                    target_rank_registration_info.dst_state_data_ptrs[i]
-                    if i < len(target_rank_registration_info.dst_state_data_ptrs)
+                    target_rank_registration_info.dst_state_data_ptrs[
+                        dst_component_index
+                    ]
+                    if dst_component_index
+                    < len(target_rank_registration_info.dst_state_data_ptrs)
                     else []
                 )
                 dst_item_lens = (
-                    target_rank_registration_info.dst_state_item_lens[i]
-                    if i < len(target_rank_registration_info.dst_state_item_lens)
+                    target_rank_registration_info.dst_state_item_lens[
+                        dst_component_index
+                    ]
+                    if dst_component_index
+                    < len(target_rank_registration_info.dst_state_item_lens)
                     else []
                 )
                 dst_dim_per_tensor = (
-                    target_rank_registration_info.dst_state_dim_per_tensor[i]
-                    if i < len(target_rank_registration_info.dst_state_dim_per_tensor)
+                    target_rank_registration_info.dst_state_dim_per_tensor[
+                        dst_component_index
+                    ]
+                    if dst_component_index
+                    < len(target_rank_registration_info.dst_state_dim_per_tensor)
                     else []
                 )
                 dst_state_layer_ids = (
-                    target_rank_registration_info.dst_state_layer_ids[i]
-                    if i < len(target_rank_registration_info.dst_state_layer_ids)
+                    target_rank_registration_info.dst_state_layer_ids[
+                        dst_component_index
+                    ]
+                    if dst_component_index
+                    < len(target_rank_registration_info.dst_state_layer_ids)
                     else []
                 )
             else:
                 dst_data_ptrs, dst_item_lens, dst_dim_per_tensor = [], [], []
                 dst_state_layer_ids = []
             dst_indices = (
-                req.dst_state_indices[i] if i < len(req.dst_state_indices) else []
+                req.dst_state_indices[dst_component_index]
+                if dst_component_index < len(req.dst_state_indices)
+                else []
             )
 
             if st == StateType.MAMBA:
@@ -3180,6 +3205,7 @@ class MooncakeKVReceiver(MooncakeFailureExceptionMixin, CommonKVReceiver):
             packed_state_layer_ids = pack_int_lists(
                 self.kv_mgr.kv_args.state_layer_ids, "I"
             )
+            packed_state_types = pack_state_types(self.kv_mgr.kv_args.state_types)
             packed_kv_layer_ids = b"".join(
                 struct.pack("I", layer_id)
                 for layer_id in self.kv_mgr.kv_args.kv_layer_ids
@@ -3238,6 +3264,7 @@ class MooncakeKVReceiver(MooncakeFailureExceptionMixin, CommonKVReceiver):
             except zmq.ZMQError:
                 self.kv_mgr.record_failure(
                     self.bootstrap_room,
+                            packed_state_types,
                     f"_register_kv_args to prefill {bootstrap_info.get('rank_ip')}:{bootstrap_info.get('rank_port')} failed",
                 )
                 self.conclude_state = KVPoll.Failed

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -43,7 +43,10 @@ from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
+    pack_state_types,
     resolve_dcp_dst_entry_indices,
+    resolve_state_component_dst_index,
+    unpack_state_types,
 )
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_schedule
@@ -233,6 +236,7 @@ class KVArgsRegisterInfo:
     dst_state_item_lens: List[List[int]] = dataclasses.field(default_factory=list)
     dst_state_dim_per_tensor: List[List[int]] = dataclasses.field(default_factory=list)
     dst_state_layer_ids: List[List[int]] = dataclasses.field(default_factory=list)
+    dst_state_types: List[StateType] = dataclasses.field(default_factory=list)
     dst_homogeneous_mem_kind: Optional[str] = None
     kv_xfer_segments: Optional[List[_KVXferPreparedSegment]] = None
     staging_base_ptr: int = 0
@@ -277,6 +281,7 @@ class KVArgsRegisterInfo:
             if len(msg) > 20 and msg[20] != b""
             else []
         )
+        dst_state_types = unpack_state_types(msg[23]) if len(msg) > 23 else []
 
         return cls(
             room=str(msg[0].decode("ascii")),
@@ -305,6 +310,7 @@ class KVArgsRegisterInfo:
             dst_state_item_lens=dst_state_item_lens,
             dst_state_dim_per_tensor=dst_state_dim_per_tensor,
             dst_state_layer_ids=dst_state_layer_ids,
+            dst_state_types=dst_state_types,
             staging_base_ptr=(
                 struct.unpack("Q", msg[14])[0]
                 if len(msg) > 14 and len(msg[14]) == 8
@@ -1275,6 +1281,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                                 dst_state_item_lens=dst_info.dst_state_item_lens,
                                 dst_state_dim_per_tensor=dst_info.dst_state_dim_per_tensor,
                                 dst_state_layer_ids=dst_info.dst_state_layer_ids,
+                                dst_state_types=dst_info.dst_state_types,
                             )
                             handles.extend(
                                 h for h in state_xfer_handles if h is not None
@@ -2220,6 +2227,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         dst_state_item_lens: List[List[int]] | None = None,
         dst_state_dim_per_tensor: List[List[int]] | None = None,
         dst_state_layer_ids: List[List[int]] | None = None,
+        dst_state_types: List[StateType] | None = None,
     ):
         """Send state per hybrid component, dispatching by state_type[i]."""
         state_types = getattr(self.kv_args, "state_types", []) or []
@@ -2238,9 +2246,15 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         dst_state_item_lens = dst_state_item_lens or []
         dst_state_dim_per_tensor = dst_state_dim_per_tensor or []
         dst_state_layer_ids = dst_state_layer_ids or []
+        dst_state_types = dst_state_types or []
 
         handles = []
         for i, st in enumerate(state_types):
+            dst_component_index = resolve_state_component_dst_index(
+                state_types,
+                dst_state_types,
+                i,
+            )
             src_indices = (
                 prefill_state_indices[i] if i < len(prefill_state_indices) else None
             )
@@ -2262,13 +2276,31 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 else []
             )
             src_lids = src_state_layer_ids[i] if i < len(src_state_layer_ids) else []
-            dst_ptrs = dst_state_data_ptrs[i] if i < len(dst_state_data_ptrs) else []
-            dst_indices = dst_state_indices[i] if i < len(dst_state_indices) else []
-            dst_lens = dst_state_item_lens[i] if i < len(dst_state_item_lens) else []
-            dst_dims = (
-                dst_state_dim_per_tensor[i] if i < len(dst_state_dim_per_tensor) else []
+            dst_ptrs = (
+                dst_state_data_ptrs[dst_component_index]
+                if dst_component_index < len(dst_state_data_ptrs)
+                else []
             )
-            dst_lids = dst_state_layer_ids[i] if i < len(dst_state_layer_ids) else []
+            dst_indices = (
+                dst_state_indices[dst_component_index]
+                if dst_component_index < len(dst_state_indices)
+                else []
+            )
+            dst_lens = (
+                dst_state_item_lens[dst_component_index]
+                if dst_component_index < len(dst_state_item_lens)
+                else []
+            )
+            dst_dims = (
+                dst_state_dim_per_tensor[dst_component_index]
+                if dst_component_index < len(dst_state_dim_per_tensor)
+                else []
+            )
+            dst_lids = (
+                dst_state_layer_ids[dst_component_index]
+                if dst_component_index < len(dst_state_layer_ids)
+                else []
+            )
             comp_notif = f"{notif}_{i}"
 
             if st == StateType.MAMBA:
@@ -2984,6 +3016,7 @@ class NixlKVReceiver(CommonKVReceiver):
             packed_state_layer_ids = pack_int_lists(
                 self.kv_mgr.kv_args.state_layer_ids, "I"
             )
+            packed_state_types = pack_state_types(self.kv_mgr.kv_args.state_types)
 
             # Include staging allocator metadata if available
             if (
@@ -3032,6 +3065,7 @@ class NixlKVReceiver(CommonKVReceiver):
                             packed_kv_layer_ids,
                             str(self.kv_mgr.dcp_size).encode("ascii"),
                             str(self.kv_mgr.dcp_rank).encode("ascii"),
+                            packed_state_types,
                         ]
                     )
             except zmq.ZMQError:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -48,6 +48,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    build_kv_layer_ids,
     get_dsv4_c128_state_indices,
     get_kv_class,
     is_aborted,
@@ -355,7 +356,11 @@ class PrefillBootstrapQueue:
         layer_shard_rank = getattr(self.token_to_kv_pool, "layer_shard_rank", None)
         layer_shard_size = getattr(self.token_to_kv_pool, "layer_shard_size", 1)
         transfer_draft_cache = (
-            not layer_shard_enabled or layer_shard_rank == layer_shard_size - 1
+            (self.pp_size <= 1 or self.pp_rank == self.pp_size - 1)
+            and (
+                not layer_shard_enabled
+                or layer_shard_rank == layer_shard_size - 1
+            )
         )
         kv_args.prefill_start_layer = (
             getattr(
@@ -370,30 +375,33 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
-        has_kv_layer_ids = hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-        kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids() if has_kv_layer_ids else []
-        )
         kv_args.prefill_end_layer = (
             kv_args.prefill_start_layer + len(kv_data_ptrs)
             if layer_shard_enabled
             else getattr(self.token_to_kv_pool, "end_layer", None)
         )
 
-        if self.draft_token_to_kv_pool is not None and transfer_draft_cache:
+        draft_kv_pool = (
+            self.draft_token_to_kv_pool if transfer_draft_cache else None
+        )
+        num_draft_entries = 0
+        if draft_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
-                self.draft_token_to_kv_pool.get_contiguous_buf_infos()
+                draft_kv_pool.get_contiguous_buf_infos()
             )
+            num_draft_entries = len(draft_kv_data_ptrs)
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
-            if has_kv_layer_ids:
-                target_layer_num = self.scheduler.model_config.num_hidden_layers
-                kv_layer_ids += [
-                    target_layer_num + i for i in range(len(draft_kv_data_ptrs))
-                ]
+
+        kv_layer_ids = build_kv_layer_ids(
+            token_to_kv_pool=self.token_to_kv_pool,
+            draft_token_to_kv_pool=draft_kv_pool,
+            num_draft_entries=num_draft_entries,
+            num_hidden_layers=self.scheduler.model_config.num_hidden_layers,
+        )
 
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
@@ -629,7 +637,7 @@ class PrefillBootstrapQueue:
         if not local_layer_ids or pd_hidden_state(req).src_indices:
             return False
 
-        pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
+        pool = getattr(getattr(self, "metadata_buffers", None), "pd_hidden_pool", None)
         if pool is None:
             return False
         hidden_len = int(dspark_meta.get("hidden_len", len(req.origin_input_ids)))
@@ -655,7 +663,9 @@ class PrefillBootstrapQueue:
         metadata_credits = (
             self.req_to_metadata_buffer_idx_allocator.available_size()
         )
-        pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
+        pool = getattr(
+            getattr(self, "metadata_buffers", None), "pd_hidden_pool", None
+        )
         hidden_row_credits = pool.available_size() if pool is not None else 0
 
         resource_blocked = False
@@ -958,19 +968,25 @@ class PrefillBootstrapQueue:
         metadata_credits = (
             self.req_to_metadata_buffer_idx_allocator.available_size()
         )
-        pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
+        pool = getattr(
+            getattr(self, "metadata_buffers", None), "pd_hidden_pool", None
+        )
         hidden_row_credits = pool.available_size() if pool is not None else 0
+        admission_blocked = False
 
         for req, poll in zip(self.queue, polls):
             if poll == KVPoll.Failed:
                 failed_rids.append(req.rid)
             elif poll == KVPoll.WaitingForInput:
+                if admission_blocked:
+                    continue
                 if should_force_retry(req):
                     metadata_cost = 1 if req.metadata_buffer_index < 0 else 0
                     if metadata_cost > metadata_credits:
-                        break
+                        admission_blocked = True
+                        continue
                     metadata_credits -= metadata_cost
-                elif req.pending_bootstrap:
+                elif getattr(req, "pending_bootstrap", False):
                     costs, error = self._probe_bootstrap_ready(
                         req, metadata_credits, hidden_row_credits
                     )
@@ -979,14 +995,17 @@ class PrefillBootstrapQueue:
                         failed_rids.append(req.rid)
                         continue
                     if costs is None:
-                        if self._is_pd_hidden_credit_blocked(
-                            req, metadata_credits, hidden_row_credits
-                        ):
-                            break
-                        break
+                        admission_blocked = True
+                        continue
                     metadata_cost, hidden_cost = costs
                     metadata_credits -= metadata_cost
                     hidden_row_credits -= hidden_cost
+                else:
+                    metadata_cost = 1 if req.metadata_buffer_index < 0 else 0
+                    if metadata_cost > metadata_credits:
+                        admission_blocked = True
+                        continue
+                    metadata_credits -= metadata_cost
                 good_rids.append(req.rid)
             elif poll == KVPoll.Bootstrapping:
                 continue
@@ -1623,16 +1642,19 @@ class SchedulerDisaggregationPrefillMixin:
         )
 
     def process_disagg_prefill_inflight_queue(
-        self: Scheduler, rids_to_check: Optional[List[str]] = None
+        self: Scheduler,
+        transfer_status: Optional[Tuple[List[str], List[str]]] = None,
     ) -> List[Req]:
         """
         Poll the requests in the middle of transfer. If done, return the request.
-        rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
+        transfer_status: For PP, the globally agreed successful and failed rids.
         """
         if len(self.disagg_prefill_inflight_queue) == 0:
             return []
 
         done_reqs = []
+        success_rids = set(transfer_status[0]) if transfer_status is not None else set()
+        failed_rids = set(transfer_status[1]) if transfer_status is not None else set()
 
         polls = poll_and_all_reduce_attn_cp_tp_group(
             [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
@@ -1641,32 +1663,43 @@ class SchedulerDisaggregationPrefillMixin:
         )
 
         undone_reqs: List[Req] = []
-        terminal_rids_to_check = set(rids_to_check) if rids_to_check is not None else None
         # Check .poll() for the reqs in disagg_prefill_inflight_queue. If Success, respond to the client and remove it from the queue
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
-            if terminal_rids_to_check is not None:
-                if req.rid not in terminal_rids_to_check:
-                    undone_reqs.append(req)
+            if transfer_status is not None:
+                consensus_failed = req.rid in failed_rids
+                failure_pending = isinstance(req.finished_reason, FINISH_ABORT)
+                if consensus_failed or failure_pending:
+                    if consensus_failed and not failure_pending:
+                        prepare_abort(
+                            req,
+                            (
+                                "Prefill transfer failed on another PP rank; "
+                                "waiting for the local transfer to stop"
+                            ),
+                            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                        )
+                    local_transfer_stopped = req.pending_bootstrap or poll in (
+                        KVPoll.Success,
+                        KVPoll.Failed,
+                    )
+                    if not local_transfer_stopped:
+                        undone_reqs.append(req)
+                        continue
+                    self.handle_inflight_transfer_failure(req)
+                    done_reqs.append(req)
                     continue
 
-                # In PP mode, the previous rank may have reached a terminal
-                # state (Success/Failed) while this rank's local poll is still
-                # in a transient state due to clock skew or propagation delay.
-                # Treat non-terminal states as undone instead of crashing.
-                if poll not in (
-                    KVPoll.Success,
-                    KVPoll.Failed,
-                ):
-                    logger.warning_once(
-                        f"PP rank {self.ps.pp_rank}: unexpected poll state {poll} for rid {req.rid} "
-                        f"from consensus; treating as undone",
-                    )
+                if req.rid not in success_rids:
                     undone_reqs.append(req)
                     continue
 
             maybe_release_pd_hidden_rows_on_hidden_done(
                 req,
-                getattr(self.disagg_metadata_buffers, "pd_hidden_pool", None),
+                getattr(
+                    getattr(self, "disagg_metadata_buffers", None),
+                    "pd_hidden_pool",
+                    None,
+                ),
             )
 
             if req.pending_bootstrap:
@@ -1730,7 +1763,11 @@ class SchedulerDisaggregationPrefillMixin:
             maybe_release_metadata_buffer(
                 req,
                 self.req_to_metadata_buffer_idx_allocator,
-                getattr(self.disagg_metadata_buffers, "pd_hidden_pool", None),
+                getattr(
+                    getattr(self, "disagg_metadata_buffers", None),
+                    "pd_hidden_pool",
+                    None,
+                ),
             )
 
         self.disagg_prefill_inflight_queue = undone_reqs
@@ -1766,7 +1803,9 @@ class SchedulerDisaggregationPrefillMixin:
             self.metrics_collector.increment_transfer_failed_reqs()
         return exc
 
-    def get_transferred_rids(self: Scheduler) -> List[str]:
+    def get_transferred_rids(
+        self: Scheduler,
+    ) -> Tuple[List[str], List[str]]:
         """
         Used by PP to inspect local terminal transfers without popping requests.
         """
@@ -1776,17 +1815,20 @@ class SchedulerDisaggregationPrefillMixin:
             self.attn_tp_cpu_group,
         )
 
-        transferred_rids: List[str] = []
+        success_rids: List[str] = []
+        failed_rids: List[str] = []
         pd_hidden_pool = getattr(
             self.disagg_metadata_buffers, "pd_hidden_pool", None
         )
 
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
             maybe_release_pd_hidden_rows_on_hidden_done(req, pd_hidden_pool)
-            if poll == KVPoll.Success or poll == KVPoll.Failed:
-                transferred_rids.append(req.rid)
+            if poll == KVPoll.Success:
+                success_rids.append(req.rid)
+            elif poll == KVPoll.Failed:
+                failed_rids.append(req.rid)
 
-        return transferred_rids
+        return success_rids, failed_rids
 
     def clear_pending_chunk_send(self: Scheduler, req: Req) -> None:
         """Drop `req` from the sent-but-unconcluded chunk set.

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1047,6 +1047,48 @@ def get_kv_class(
     return class_mapping.get(class_type)
 
 
+def pack_state_types(state_types) -> bytes:
+    return ",".join(state_type.value for state_type in (state_types or [])).encode(
+        "ascii"
+    )
+
+
+def unpack_state_types(data: bytes):
+    from sglang.srt.disaggregation.base.conn import StateType
+
+    if not data:
+        return []
+    return [StateType(value) for value in data.decode("ascii").split(",") if value]
+
+
+def resolve_state_component_dst_index(src_state_types, dst_state_types, src_index: int):
+    if not dst_state_types:
+        return src_index
+    if not src_state_types:
+        raise RuntimeError(
+            "Destination state_types are present but source state_types are empty."
+        )
+    if src_index >= len(src_state_types):
+        raise RuntimeError(
+            f"Source state component index {src_index} exceeds "
+            f"state_types length {len(src_state_types)}."
+        )
+    state_type = src_state_types[src_index]
+    occurrence = sum(
+        1 for item in src_state_types[: src_index + 1] if item == state_type
+    )
+    seen = 0
+    for dst_index, dst_state_type in enumerate(dst_state_types):
+        if dst_state_type == state_type:
+            seen += 1
+            if seen == occurrence:
+                return dst_index
+    raise RuntimeError(
+        f"Decode peer is missing state component {state_type!s} "
+        f"occurrence {occurrence}."
+    )
+
+
 def _get_cp_rank_page_bounds(
     total_pages: int, cp_rank: int, cp_size: int
 ) -> Tuple[int, int]:
@@ -1267,6 +1309,58 @@ def build_transfer_entry_pairs(
     return [(i, i) for i in range(n_src)]
 
 
+def build_kv_layer_ids(
+    *,
+    token_to_kv_pool,
+    draft_token_to_kv_pool,
+    num_draft_entries: int,
+    num_hidden_layers: int,
+) -> List[int]:
+    """Return a global layer id for every target and draft KV entry."""
+    if not hasattr(token_to_kv_pool, "get_kv_layer_ids"):
+        return []
+    layer_ids = token_to_kv_pool.get_kv_layer_ids()
+    if not layer_ids:
+        return []
+    num_target_entries = len(token_to_kv_pool.get_contiguous_buf_infos()[0])
+    if len(layer_ids) == num_target_entries:
+        target_layer_ids = layer_ids
+    elif len(layer_ids) * 2 == num_target_entries:
+        target_layer_ids = layer_ids * 2
+    else:
+        return []
+    if draft_token_to_kv_pool is None:
+        return target_layer_ids
+
+    draft_ids = _draft_entry_layer_ids(
+        pool=draft_token_to_kv_pool, num_entries=num_draft_entries
+    )
+    band_index = {lid: i for i, lid in enumerate(dict.fromkeys(draft_ids))}
+    return target_layer_ids + [
+        num_hidden_layers + band_index[lid] for lid in draft_ids
+    ]
+
+
+def _draft_entry_layer_ids(*, pool, num_entries: int) -> List[int]:
+    from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+
+    if isinstance(pool, HybridLinearKVPool):
+        ids = pool.get_kv_layer_ids()
+    else:
+        if pool.layer_num <= 0 or num_entries % pool.layer_num != 0:
+            raise RuntimeError(
+                "Draft KV buffers must register a whole number of per-layer "
+                f"groups: entries={num_entries}, layers={pool.layer_num}"
+            )
+        ids = list(range(pool.layer_num)) * (num_entries // pool.layer_num)
+    if len(ids) != num_entries:
+        raise RuntimeError(
+            "Draft KV layer ids must cover every registered entry: "
+            f"ids={len(ids)}, entries={num_entries}"
+        )
+    return ids
+
+
 def resolve_dcp_dst_entry_indices(
     src_layer_ids: List[int],
     dst_layer_ids: List[int],
@@ -1304,8 +1398,6 @@ def append_state_component(
     layer_ids: Optional[List[int]] = None,
     data_format: str = "",
 ) -> None:
-    """Append one state component. Caller orders state_types consistently
-    on prefill and decode sides."""
     kv_args.state_types.append(state_type)
     kv_args.state_data_ptrs.append(data_ptrs)
     kv_args.state_data_lens.append(data_lens)

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1359,7 +1359,7 @@ class GroupCoordinator:
                 return torch.ops.sgl_kernel.shm_allgather(input_, dim)
             else:
                 torch.distributed.all_gather_into_tensor(
-                    output_tensor, input_, group=self.device_group
+                    output_tensor, input_, group=self.cpu_group
                 )
         else:
             self.all_gather_into_tensor(output_tensor, input_)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -83,6 +83,7 @@ from sglang.srt.layers.attention.dsv4.metadata import (
 from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
     SparsePrefillChunkCache,
     SparsePrefillWorkspace,
+    build_cp_sparse_query_metadata,
     use_dsv4_q8kv8_sparse_prefill,
 )
 from sglang.srt.layers.attention.verify_mask import (
@@ -174,13 +175,15 @@ T = TypeVar("T", bound=Optional[torch.Tensor])
 
 
 def _should_use_sparse_prefill(q: torch.Tensor, forward_batch: ForwardBatch) -> bool:
+    sparse_prefill_enabled = envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+    explicit_cp_override = (
+        envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.is_set()
+        and sparse_prefill_enabled
+    )
     return (
         not _is_sm120
-        and not dsa_use_prefill_cp(forward_batch)
-        and (
-            q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
-            or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
-        )
+        and (not dsa_use_prefill_cp(forward_batch) or explicit_cp_override)
+        and (q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD or sparse_prefill_enabled)
     )
 
 
@@ -2403,6 +2406,40 @@ class DeepseekV4AttnBackend(
             assert seq_lens_cpu is not None
             extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
             assert extend_seq_lens_cpu is not None
+
+            query_seq_lens = None
+            real_query_seq_lens = None
+            query_positions = None
+            if dsa_use_prefill_cp(forward_batch):
+                cp_size = get_parallel().attn_cp_size
+                cp_rank = get_parallel().attn_cp_rank
+
+                # Interleave CP owns global flattened rows rank::cp_size. The
+                # sparse-prefill combiner must loop over those local rows, not
+                # the original global extend lengths. Build both real and
+                # physical rank-local geometry on-device: physical padding is
+                # appended to the last request, while C4/C128 source-row
+                # selection must continue to use the real lengths.
+                assert forward_batch.extend_start_loc is not None
+                # Both CP-v2 and legacy DSA round-robin call
+                # DSV4AttnMetadata.apply_cp_reindex() before attention, so
+                # positions_casual is already rank-local in both paths.
+                rank_local_positions = core_attn_metadata.positions_casual[
+                    : q_flat.shape[0]
+                ].contiguous()
+                assert rank_local_positions.shape[0] == q_flat.shape[0]
+                (
+                    query_seq_lens,
+                    real_query_seq_lens,
+                    query_positions,
+                ) = build_cp_sparse_query_metadata(
+                    extend_seq_lens=forward_batch.extend_seq_lens.to(torch.int32),
+                    extend_start_loc=forward_batch.extend_start_loc.to(torch.int32),
+                    query_positions=rank_local_positions,
+                    cp_size=cp_size,
+                    cp_rank=cp_rank,
+                )
+
             total_swa = sum(
                 min(int(seq_len), int(extend_len) + SWA_WINDOW - 1)
                 for seq_len, extend_len in zip(
@@ -2422,6 +2459,9 @@ class DeepseekV4AttnBackend(
                 num_qo_tokens=q_flat.shape[0],
                 max_seq_len=int(seq_lens_cpu.max().item()),
                 total_swa=total_swa,
+                query_seq_lens=query_seq_lens,
+                query_positions=query_positions,
+                real_query_seq_lens=real_query_seq_lens,
             )
             self.forward_metadata.sparse_prefill_cache = cache
 

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -52,6 +52,7 @@ DSV4_Q8KV8_PREFILL_ENV = "SGLANG_DSV4_Q8KV8_PREFILL"
 DSV4_Q8KV8_PREFILL_LOG_ENV = "SGLANG_DSV4_Q8KV8_PREFILL_LOG"
 
 from sglang.kernels.ops.attention.dsv4.sparse_prefill_kernels import (
+    _build_cp_sparse_query_metadata_kernel,
     _build_swa_token_ids_kernel,
     _combine_topk_swa_indices_kernel,
 )
@@ -111,6 +112,57 @@ def combined_topk_width(topk: int, window_size: int) -> int:
     return ceil_align(topk + window_size, SPARSE_PREFILL_TOPK_ALIGNMENT)
 
 
+def build_cp_sparse_query_metadata(
+    extend_seq_lens: torch.Tensor,
+    extend_start_loc: torch.Tensor,
+    query_positions: torch.Tensor,
+    cp_size: int,
+    cp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build CP-local query geometry entirely on the accelerator.
+
+    Returns physical per-request lengths (including the final padding suffix),
+    real per-request lengths, and rank-local query positions with every dummy
+    row replaced by the explicit -1 sentinel.
+    """
+    assert extend_seq_lens.dtype == torch.int32
+    assert extend_start_loc.dtype == torch.int32
+    assert query_positions.dtype == torch.int32
+    assert extend_seq_lens.device == extend_start_loc.device
+    assert extend_seq_lens.device == query_positions.device
+    assert extend_seq_lens.shape == extend_start_loc.shape
+    assert query_positions.is_contiguous()
+    assert cp_size > 1
+    assert 0 <= cp_rank < cp_size
+
+    num_reqs = extend_seq_lens.shape[0]
+    num_local_queries = query_positions.shape[0]
+    assert num_reqs > 0
+    assert num_local_queries > 0
+
+    real_query_lens = torch.empty_like(extend_seq_lens)
+    physical_query_lens = torch.empty_like(extend_seq_lens)
+    sanitized_query_positions = torch.empty_like(query_positions)
+
+    block_queries = 256
+    grid = (max(triton.cdiv(num_local_queries, block_queries), 1),)
+    _build_cp_sparse_query_metadata_kernel[grid](
+        real_query_lens,
+        physical_query_lens,
+        sanitized_query_positions,
+        extend_seq_lens,
+        extend_start_loc,
+        query_positions,
+        num_reqs,
+        num_local_queries,
+        cp_rank,
+        CP_SIZE=cp_size,
+        BLOCK_REQS=triton.next_power_of_2(num_reqs),
+        BLOCK_QUERIES=block_queries,
+    )
+    return physical_query_lens, real_query_lens, sanitized_query_positions
+
+
 def combine_topk_swa_indices(
     topk_indices: torch.Tensor,
     query_start_loc: torch.Tensor,
@@ -123,6 +175,7 @@ def combine_topk_swa_indices(
     topk: int,
     out_indices: Optional[torch.Tensor] = None,
     out_lens: Optional[torch.Tensor] = None,
+    query_positions: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Combine topk + SWA indices into a single ``flash_mla_sparse_fwd`` row.
 
@@ -153,6 +206,9 @@ def combine_topk_swa_indices(
             valid-prefix length must hold across reuses).
         out_lens: optional preallocated ``(num_tokens,)`` int32 buffer; the
             kernel fully overwrites it, so any dtype-correct buffer works.
+        query_positions: optional ``(num_tokens,)`` int32 tensor containing the
+            real sequence position for every local query row. Context-parallel
+            callers use this because their local rows are interleaved.
 
     Returns:
         combined_indices: (num_tokens, padded_topk_swa) int32, padded to a
@@ -166,6 +222,10 @@ def combine_topk_swa_indices(
     assert compressed_base.dtype == torch.int32
     assert swa_base.dtype == torch.int32
     assert compress_ratio >= 1, "compress_ratio must be >= 1 (use topk=0 for SWA-only)"
+    if query_positions is not None:
+        assert query_positions.dtype == torch.int32
+        assert query_positions.shape == (topk_indices.shape[0],)
+        assert query_positions.device == topk_indices.device
     assert (
         topk_indices.shape[-1] >= topk
     ), f"topk_indices width {topk_indices.shape[-1]} must be >= topk {topk}"
@@ -201,6 +261,7 @@ def combine_topk_swa_indices(
         topk_indices,
         topk_indices.stride(0),
         query_start_loc,
+        query_positions if query_positions is not None else seq_lens,
         seq_lens,
         gather_lens,
         compressed_base,
@@ -209,6 +270,7 @@ def combine_topk_swa_indices(
         COMPRESS_RATIO=compress_ratio,
         WINDOW_SIZE=window_size,
         PADDED_TOP_K=triton.next_power_of_2(topk_indices.shape[-1]),
+        USE_EXPLICIT_POSITIONS=query_positions is not None,
     )
     return combined_indices, combined_lens
 
@@ -317,6 +379,12 @@ class SparsePrefillChunkCache:
     swa_gather_lens: torch.Tensor  # (num_reqs,) int32
     swa_offsets: torch.Tensor  # (num_reqs+1,) int32
 
+    # Local query positions after CP sharding; None on the ordinary path.
+    query_positions: Optional[torch.Tensor] = None  # (num_qo_tokens,) int32
+    # Real rank-local query rows per request. Unlike query_start_loc's physical
+    # segments, these lengths exclude CP padding and may legitimately be zero.
+    real_query_seq_lens: Optional[torch.Tensor] = None  # (num_reqs,) int32
+
     # c0 pre-computed combine output (entire input set is chunk-invariant).
     c0_combined_indices: torch.Tensor = field(default=None)
     c0_combined_lens: torch.Tensor = field(default=None)
@@ -348,12 +416,29 @@ class SparsePrefillChunkCache:
         num_qo_tokens: int,
         max_seq_len: int,
         total_swa: int,
+        query_seq_lens: Optional[torch.Tensor] = None,
+        query_positions: Optional[torch.Tensor] = None,
+        real_query_seq_lens: Optional[torch.Tensor] = None,
     ) -> "SparsePrefillChunkCache":
         device = seq_lens.device
         num_reqs = seq_lens.shape[0]
 
+        if query_seq_lens is None:
+            query_seq_lens = extend_seq_lens
+        assert query_seq_lens.dtype == torch.int32
+        assert query_seq_lens.shape == seq_lens.shape
+        if real_query_seq_lens is None:
+            real_query_seq_lens = query_seq_lens
+        assert real_query_seq_lens.dtype == torch.int32
+        assert real_query_seq_lens.shape == seq_lens.shape
+        assert real_query_seq_lens.device == device
+        if query_positions is not None:
+            assert query_positions.dtype == torch.int32
+            assert query_positions.shape == (num_qo_tokens,)
+            assert query_positions.device == device
+
         query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32, device=device)
-        query_start_loc[1:] = torch.cumsum(extend_seq_lens, dim=0).to(torch.int32)
+        query_start_loc[1:] = torch.cumsum(query_seq_lens, dim=0).to(torch.int32)
 
         swa_token_ids, swa_first_pos, swa_gather_lens, swa_offsets = (
             build_swa_token_ids(
@@ -379,6 +464,8 @@ class SparsePrefillChunkCache:
             swa_first_pos=swa_first_pos,
             swa_gather_lens=swa_gather_lens,
             swa_offsets=swa_offsets,
+            query_positions=query_positions,
+            real_query_seq_lens=real_query_seq_lens,
         )
 
         # Pre-compute the c0 combine output: TOPK=0, compressed_base=0,
@@ -396,6 +483,7 @@ class SparsePrefillChunkCache:
             window_size=swa_window_size,
             compress_ratio=1,
             topk=0,
+            query_positions=query_positions,
         )
         return cache
 
@@ -420,10 +508,26 @@ class SparsePrefillChunkCache:
             f"live c128 extent {c128_max} exceeds metadata capacity "
             f"{c128_page_indices.shape[-1]}"
         )
-        last_q_per_req = (self.query_start_loc[1:] - 1).long()
+        real_query_seq_lens = self.real_query_seq_lens
+        if real_query_seq_lens is None:
+            real_query_seq_lens = self.query_start_loc[1:] - self.query_start_loc[:-1]
+        has_real_q = real_query_seq_lens > 0
+        last_real_q_per_req = (
+            self.query_start_loc[:-1] + real_query_seq_lens - 1
+        )
+        last_q_per_req = (
+            torch.where(
+                has_real_q,
+                last_real_q_per_req,
+                torch.zeros_like(last_real_q_per_req),
+            )
+            .clamp(min=0, max=self.num_qo_tokens - 1)
+            .long()
+        )
         per_req_c128 = c128_page_indices.narrow(1, 0, c128_max).index_select(
             0, last_q_per_req
         )
+        per_req_c128 = torch.where(has_real_q[:, None], per_req_c128, -1)
         # Clamp -1 -> 0 so dequant doesn't OOB; combine masks the invalid
         # tail via topk_len.
         flat_c128_ids = per_req_c128.reshape(-1).clamp_min(0).to(torch.int32)
@@ -450,6 +554,7 @@ class SparsePrefillChunkCache:
             window_size=self.swa_window_size,
             compress_ratio=128,
             topk=c128_max,
+            query_positions=self.query_positions,
         )
 
         self.c128_flat_token_ids = flat_c128_ids
@@ -476,11 +581,26 @@ class SparsePrefillChunkCache:
         assert (
             c4_max <= c4_capacity
         ), f"live c4 extent {c4_max} exceeds metadata capacity {c4_capacity}"
-        first_q_per_req = self.query_start_loc[:-1].long()
+        real_query_seq_lens = self.real_query_seq_lens
+        if real_query_seq_lens is None:
+            real_query_seq_lens = self.query_start_loc[1:] - self.query_start_loc[:-1]
+        has_real_q = real_query_seq_lens > 0
+        first_q_per_req = (
+            torch.where(
+                has_real_q,
+                self.query_start_loc[:-1],
+                torch.zeros_like(self.query_start_loc[:-1]),
+            )
+            .clamp(min=0, max=self.num_qo_tokens - 1)
+            .long()
+        )
         num_blocks = (c4_max + c4_page_size - 1) // c4_page_size
         assert num_blocks <= page_table.shape[1]
         per_req_page_table = page_table.narrow(1, 0, num_blocks).index_select(
             0, first_q_per_req
+        )
+        per_req_page_table = torch.where(
+            has_real_q[:, None], per_req_page_table, -1
         )
 
         k_arange = torch.arange(c4_max, dtype=torch.int32, device=device)
@@ -537,4 +657,5 @@ class SparsePrefillChunkCache:
             topk=topk,
             out_indices=self.c4_combined_indices,
             out_lens=self.c4_combined_lens,
+            query_positions=self.query_positions,
         )

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -20,7 +20,7 @@ import time
 from array import array
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -71,6 +71,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
 
+PPTransferStatus = Tuple[List[str], List[str]]
+PPReleasePayload = Union[List[str], PPTransferStatus]
+
 
 def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
     """Check if output send/recv can be skipped for this batch."""
@@ -82,6 +85,35 @@ def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
         and not batch.contains_last_prefill_chunk
         and not batch.return_logprob
     )
+
+
+def _pp_ordered_intersection(left: List[str], right: List[str]) -> List[str]:
+    right_set = set(right)
+    return [rid for rid in left if rid in right_set]
+
+
+def _pp_ordered_union(left: List[str], right: List[str]) -> List[str]:
+    seen = set(left)
+    merged = list(left)
+    for rid in right:
+        if rid not in seen:
+            seen.add(rid)
+            merged.append(rid)
+    return merged
+
+
+def _pp_merge_transfer_status(
+    previous: PPTransferStatus,
+    current: PPTransferStatus,
+) -> PPTransferStatus:
+    previous_success, previous_failed = previous
+    current_success, current_failed = current
+    failed = _pp_ordered_union(previous_failed, current_failed)
+    success = _pp_ordered_intersection(previous_success, current_success)
+    if failed:
+        failed_set = set(failed)
+        success = [rid for rid in success if rid not in failed_set]
+    return success, failed
 
 
 @dataclass
@@ -261,8 +293,8 @@ class SchedulerPPMixin:
         bmbs = [None] * self.pp_loop_size
         tmbs = [None] * self.pp_loop_size
         consensus_bootstrapped_rids: Optional[List[str]] = None
-        transferred_rids: List[str] = []
-        release_rids: Optional[List[str]] = None
+        transferred_rids: PPTransferStatus = ([], [])
+        release_rids: Optional[PPTransferStatus] = None
         send_bootstrapped_work = []
         send_transfer_work = []
         send_consensus_bootstrapped_work = []
@@ -872,7 +904,13 @@ class SchedulerPPMixin:
             # if ready_reqs:
             #     self._try_send_prefill_kv_ready_batch(ready_reqs)
             self.waiting_queue.extend(good_reqs)
-            return [[req.rid for req in good_reqs], [req.rid for req in failed_reqs]]
+            return [
+                [req.rid for req in good_reqs],
+                _pp_ordered_union(
+                    bad_consensus_bootstrapped_rids,
+                    [req.rid for req in failed_reqs],
+                ),
+            ]
         return None
 
     def _pp_ordered_intersection(
@@ -928,20 +966,21 @@ class SchedulerPPMixin:
         )
         return [good_bootstrapped_rids, bad_bootstrapped_rids]
 
-    def _pp_pd_get_prefill_transferred_ids(self: Scheduler):
+    def _pp_pd_get_prefill_transferred_ids(
+        self: Scheduler,
+    ) -> PPTransferStatus:
         # get the current stage transfer success
+        current_status = self.get_transferred_rids()
         if self.pp_group.is_first_rank:
-            transferred_rids = self.get_transferred_rids()
+            transferred_rids = current_status
         # if other ranks, do intersection with the previous rank's transferred rids
         else:
             # 2 (Release): Receive the transferred rids from the previous rank
             # 1. recv previous stage's transferred reqs info
-            prev_transferred_rids = self._pp_recv_pyobj_from_prev_stage()
-            # 2. get the current stage's transferred reqs info
-            curr_transferred_rids = self.get_transferred_rids()
-            # 3. new consensus rids = intersection(previous consensus rids, transfer finished rids)
-            transferred_rids = self._pp_ordered_intersection(
-                prev_transferred_rids, curr_transferred_rids
+            previous_status = self._pp_recv_pyobj_from_prev_stage()
+            transferred_rids = _pp_merge_transfer_status(
+                previous=previous_status,
+                current=current_status,
             )
         return transferred_rids
 
@@ -970,10 +1009,10 @@ class SchedulerPPMixin:
 
     def _pp_pd_send_consensus_release_ids(
         self: Scheduler,
-        tmbs: List[List[str]],
+        tmbs: List[Optional[PPReleasePayload]],
         next_first_rank_mb_id: int,
-        release_rids: List[str],
-        transferred_rids: List[str],
+        release_rids: Optional[PPReleasePayload],
+        transferred_rids: PPReleasePayload,
     ):
         send_release_work = []
         if self.pp_group.is_last_rank:
@@ -1107,6 +1146,8 @@ class SchedulerPPMixin:
     def _pp_should_owner_direct_pd_hidden(
         self: Scheduler, batch: ScheduleBatch
     ) -> bool:
+        if batch and batch.spec_algorithm.is_dspark():
+            return False
         if not hasattr(self, "disagg_prefill_bootstrap_queue"):
             return False
         if not batch or not get_pd_hidden_capture_layer_ids(batch.reqs):
@@ -1256,7 +1297,6 @@ class SchedulerPPMixin:
         d2h_event = self.device_module.Event()
         d2h_event.record(self.device_module.current_stream())
         return None, batch_result, d2h_event
-
     def _pp_prep_batch_result(
         self: Scheduler,
         batch: ScheduleBatch,
@@ -1286,6 +1326,22 @@ class SchedulerPPMixin:
                     logits_output = LogitsProcessorOutput(next_token_logits=None)
                 logits_output.auxiliary_device_output = auxiliary_output
         next_token_ids = pp_outputs["next_token_ids"].to(torch.int64)
+        next_draft_input = None
+        if isinstance(batch, ScheduleBatch) and batch.spec_algorithm.is_dspark():
+            next_token_ids = next_token_ids.to(
+                device=batch.device,
+                dtype=torch.int64,
+                non_blocking=True,
+            )
+            from sglang.srt.speculative.dspark_components.dspark_draft import (
+                make_next_draft_input,
+            )
+
+            next_draft_input = make_next_draft_input(
+                bonus_tokens=next_token_ids,
+                new_seq_lens=batch.seq_lens,
+            )
+            batch.spec_info = next_draft_input
         # PP rank 0 also relays into output_tokens_buf so the next iter's
         # resolve_forward_inputs finds these tokens for the decode portion
         # of mixed-chunk batches (which gather via mix_running_indices).
@@ -1305,6 +1361,7 @@ class SchedulerPPMixin:
                 PPProxyTensors(pd_aux_hidden) if pd_aux_hidden else None
             ),
             next_token_ids=pp_outputs["next_token_ids"],
+            next_draft_input=next_draft_input,
             extend_input_len_per_req=extend_input_len_per_req,
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             can_run_cuda_graph=mb_metadata.can_run_cuda_graph,
@@ -1437,7 +1494,15 @@ class SchedulerPPMixin:
                     "set_run_batch_cpu_start_time",
                     trace_only=True,
                 )
-                result = self.run_batch(cur_batch, pp_proxy_tensors)
+                if cur_batch.spec_algorithm.is_dspark():
+                    self.model_worker.set_pp_proxy_tensors_for_next_forward(
+                        pp_proxy_tensors
+                    )
+                try:
+                    result = self.run_batch(cur_batch, pp_proxy_tensors)
+                finally:
+                    if cur_batch.spec_algorithm.is_dspark():
+                        self.model_worker.set_pp_proxy_tensors_for_next_forward(None)
                 self._pp_maybe_send_dspark_owner_direct_hidden(cur_batch, result)
                 set_time_batch(
                     cur_batch.reqs,

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -123,7 +123,7 @@ class GenerationBatchResult:
         Only the tensors which are needed for processing results are copied,
         e.g., next_token_ids, logits outputs
         """
-        if return_logprob:
+        if self.logits_output is not None and return_logprob:
             if self.logits_output.next_token_logprobs is not None:
                 self.logits_output.next_token_logprobs = _async_d2h(
                     self.logits_output.next_token_logprobs
@@ -147,11 +147,16 @@ class GenerationBatchResult:
                     _async_d2h(v) if torch.is_tensor(v) else v
                     for v in self.logits_output.next_token_token_ids_logprobs_val
                 ]
-        if return_hidden_states and self.logits_output.hidden_states is not None:
+        if (
+            self.logits_output is not None
+            and return_hidden_states
+            and self.logits_output.hidden_states is not None
+        ):
             self.logits_output.hidden_states = _async_d2h(
                 self.logits_output.hidden_states
             )
-        self.next_token_ids = _async_d2h(self.next_token_ids)
+        if self.next_token_ids is not None:
+            self.next_token_ids = _async_d2h(self.next_token_ids)
 
         if self.accept_lens is not None:
             self.accept_lens = _async_d2h(self.accept_lens)

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -825,6 +825,20 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         assert self.full_to_swa_index_mapping is not None
         return self.full_to_swa_index_mapping[kv_indices]
 
+    def get_kv_layer_ids(self) -> List[int]:
+        stage_ratios = self.compression_ratios[self._stage_start : self._stage_end]
+        c4_layer_ids = [
+            self._stage_start + local_layer_id
+            for local_layer_id, ratio in enumerate(stage_ratios)
+            if ratio == 4
+        ]
+        c128_layer_ids = [
+            self._stage_start + local_layer_id
+            for local_layer_id, ratio in enumerate(stage_ratios)
+            if ratio == 128
+        ]
+        return c4_layer_ids + c4_layer_ids + c128_layer_ids
+
     def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs: List[int] = []
         data_lens: List[int] = []

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -817,6 +817,10 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
             if self._is_layer_owned(layer_id)
         ]
 
+    def get_kv_layer_ids(self):
+        my_start, my_end = self._owned_local_layer_range()
+        return list(range(self.start_layer + my_start, self.start_layer + my_end))
+
     def get_key_buffer(self, layer_id: int):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1685,6 +1685,9 @@ class KVCache(abc.ABC):
             maybe_init_custom_mem_pool(device=self.device)
         )
 
+    def get_kv_layer_ids(self) -> List[int]:
+        return list(range(self.start_layer, self.end_layer))
+
     def _finalize_allocation_log(self, num_tokens: int):
         """Common logging and mem_usage computation for KV cache allocation.
         Supports both tuple (K, V) size returns and single KV size returns.

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import msgspec
 
 from sglang.srt.configs.model_config import ModelImpl
-from sglang.srt.distributed import get_world_group
+from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     prealloc_symmetric_memory_pool,
 )
@@ -149,12 +149,16 @@ def capture_cuda_graphs(
             set_masked_standard_layout_memory_budget,
         )
 
-        world_group = get_world_group()
+        # The speculative draft runner can exist only on the last PP stage.
+        # All-reducing over the world group here would deadlock with collectives
+        # entered by the other PP stages, while every rank in this TP group
+        # executes this branch.
+        memory_group = get_tp_group()
         available_memory_gb = get_available_gpu_memory(
             model_runner.device,
             model_runner.gpu_id,
-            distributed=world_group.world_size > 1,
-            cpu_group=world_group.cpu_group,
+            distributed=memory_group.world_size > 1,
+            cpu_group=memory_group.cpu_group,
         )
         budget_bytes = set_masked_standard_layout_memory_budget(
             int(available_memory_gb * (1 << 30))

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -200,6 +200,7 @@ def _assert_pp_mtp_compat(
     assert (
         (not model_has_mtp_layers)
         or (spec_algorithm.is_none())
+        or spec_algorithm.is_dspark()
         or (
             (not spec_algorithm.is_none())
             and (num_effective_layers == model_num_layers)

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -133,7 +133,7 @@ class DecodeInputBuffers(ForwardInputBuffers):
                 is_mhc = hc_hidden_size is not None
                 hs = hc_hidden_size if is_mhc else hidden_size
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                    "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
                 }
                 if not is_mhc:
                     # Only Kimi K3 supplies num_blocks: its PP bank is token-major
@@ -141,7 +141,7 @@ class DecodeInputBuffers(ForwardInputBuffers):
                     residual_shape = (
                         (max_num_token, pp_proxy_residual_num_blocks, hidden_size)
                         if pp_proxy_residual_num_blocks is not None
-                        else (max_bs, hidden_size)
+                        else (max_num_token, hidden_size)
                     )
                     pp_proxy_tensors["residual"] = torch.zeros(
                         residual_shape, dtype=dtype

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3066,6 +3066,7 @@ class DeepseekV4Model(nn.Module):
         cp_v2_active = is_cp_v2_active(forward_batch)
         use_prefill_cp = dsa_use_prefill_cp(forward_batch)
         incoming_pd_aux_hidden_states: List[torch.Tensor] = []
+        local_dspark_aux_hidden_states: List[torch.Tensor] = []
         if self.pp_group.is_first_rank:
             if input_embeds is None:
                 hidden_states = self.embed_tokens(input_ids)
@@ -3182,7 +3183,9 @@ class DeepseekV4Model(nn.Module):
                         )
                     else:
                         completed = hidden_states
-                    pd_aux_hidden_states.append(completed.mean(dim=1))
+                    captured_hidden = completed.mean(dim=1)
+                    pd_aux_hidden_states.append(captured_hidden)
+                    local_dspark_aux_hidden_states.append(captured_hidden)
             if use_fused and last_layer is not None:
                 hidden_states = last_layer.hc_post(
                     hidden_states, prev_residual, prev_post, prev_comb
@@ -3198,6 +3201,17 @@ class DeepseekV4Model(nn.Module):
             and self.pp_group.is_last_rank
         )
 
+        # With PP+D-Spark, each stage projects only its own capture features.
+        # The final stage receives the prior projected accumulator separately,
+        # so its logits output must contain local features rather than the old
+        # concatenated raw-hidden relay.
+        if (
+            capture_dspark
+            and self.pp_group.world_size > 1
+            and self.pp_group.is_last_rank
+        ):
+            pd_aux_hidden_states = local_dspark_aux_hidden_states
+
         if isinstance(pd_aux_hidden_states, AuxHiddenStatePacker):
             pd_aux_hidden = pd_aux_hidden_states.finalize()
         else:
@@ -3210,6 +3224,14 @@ class DeepseekV4Model(nn.Module):
                 for idx, aux_hidden in enumerate(pd_aux_hidden_states):
                     proxy_tensors[f"pd_aux_hidden_states_{idx}"] = (
                         aux_hidden.flatten(1) if aux_hidden.ndim == 3 else aux_hidden
+                    )
+                if local_dspark_aux_hidden_states:
+                    proxy_tensors["dspark_aux_hidden_states"] = torch.cat(
+                        local_dspark_aux_hidden_states, dim=-1
+                    )
+                else:
+                    proxy_tensors["dspark_aux_hidden_states"] = (
+                        hidden_states.new_empty(hidden_states.shape[0], 0)
                     )
             return PPProxyTensors(proxy_tensors)
 
@@ -3329,14 +3351,17 @@ class DeepseekV4ForCausalLM(nn.Module):
         return self.model.get_input_embeddings()
 
     def set_dspark_layers_to_capture(self, layer_ids: List[int]) -> None:
-        if not self.pp_group.is_last_rank:
-            return
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
-        self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        local_layer_ids = [
+            int(layer_id)
+            for layer_id in layer_ids
+            if self.model.start_layer <= int(layer_id) < self.model.end_layer
+        ]
+        self.capture_aux_hidden_states = bool(local_layer_ids)
+        self.model.dspark_layers_to_capture = local_layer_ids or None
 
     @classmethod
     def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3083,14 +3083,6 @@ class DeepseekV4Model(nn.Module):
                     if key.startswith("pd_aux_hidden_states_")
                 )
             ]
-            if hidden_states.shape[0] != positions.shape[0]:
-                rids = getattr(forward_batch, "rids", None)
-                raise RuntimeError(
-                    "PP proxy hidden token count does not match current positions: "
-                    f"pp_rank={self.pp_group.rank_in_group}, "
-                    f"hidden_tokens={hidden_states.shape[0]}, "
-                    f"position_tokens={positions.shape[0]}, rids={rids}"
-                )
             # Unflatten 2D PP IPC tensor back to 3D mHC shape.
             if hidden_states.ndim == 2:
                 hidden_states = hidden_states.view(

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -17,12 +17,18 @@ from sglang.kernels.ops.speculative.dspark.dspark_draft_model import (
     CommitKvProj,
 )
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
+from sglang.srt.distributed.parallel_state import model_parallel_is_initialized
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import is_dp_attention_enabled
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe.utils import is_shared_experts_fusion_disabled
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+from sglang.srt.layers.quantization.fp8_utils import (
+    inverse_transform_scale_ue8m0,
+    transform_scale_ue8m0,
+)
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -50,9 +56,10 @@ from sglang.srt.models.dspark import (
     project_through_lm_head,
     run_markov_block,
 )
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_disagg, get_parallel
 from sglang.srt.speculative.dspark_components.dspark_config import (
     parse_dspark_draft_config,
+    use_empty_draft_model_for_pp_prefill,
 )
 from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyMode,
@@ -70,6 +77,81 @@ _CONFIDENCE = Invariant(
     "dspark.model.confidence", Bucket.GUARD, InClosedRange(0.0, 1.0)
 )
 _is_npu = is_npu()
+
+
+class _BlockFp8LinearSlice(nn.Module):
+    def __init__(
+        self,
+        *,
+        source: ReplicatedLinear,
+        feature_indices: List[int],
+        feature_width: int,
+    ) -> None:
+        super().__init__()
+        quant_method = source.quant_method
+        if not (
+            isinstance(quant_method, Fp8LinearMethod)
+            and quant_method.block_quant
+            and not quant_method.use_mxfp8
+            and not quant_method.use_marlin
+        ):
+            raise ValueError(
+                "DSpark block-FP8 projection slice requires a non-MXFP8 "
+                "block-quantized Fp8LinearMethod."
+            )
+
+        block_k = int(quant_method.weight_block_size[1])
+        if feature_width % block_k != 0:
+            raise ValueError(
+                f"DSpark feature width {feature_width} must align to FP8 "
+                f"block_k={block_k}."
+            )
+        blocks_per_feature = feature_width // block_k
+        device = source.weight.device
+        weight_columns = torch.cat(
+            [
+                torch.arange(
+                    feature_index * feature_width,
+                    (feature_index + 1) * feature_width,
+                    device=device,
+                )
+                for feature_index in feature_indices
+            ]
+        )
+        scale_columns = torch.cat(
+            [
+                torch.arange(
+                    feature_index * blocks_per_feature,
+                    (feature_index + 1) * blocks_per_feature,
+                    device=device,
+                )
+                for feature_index in feature_indices
+            ]
+        )
+
+        self.quant_method = quant_method
+        self.weight = nn.Parameter(
+            source.weight.detach().index_select(1, weight_columns).contiguous(),
+            requires_grad=False,
+        )
+        source_scale = source.weight_scale_inv.detach()
+        scale_is_ue8m0 = source.weight_scale_inv.format_ue8m0
+        if scale_is_ue8m0:
+            source_scale = inverse_transform_scale_ue8m0(
+                source_scale, mn=source.weight.shape[0]
+            )
+        local_scale = source_scale.index_select(1, scale_columns).contiguous()
+        if scale_is_ue8m0:
+            local_scale = transform_scale_ue8m0(local_scale, mn=source.weight.shape[0])
+        self.weight_scale_inv = nn.Parameter(
+            local_scale,
+            requires_grad=False,
+        )
+        self.weight_scale_inv.format_ue8m0 = scale_is_ue8m0
+        self.register_parameter("bias", None)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.quant_method.apply(self, hidden_states, bias=None)
 
 
 def apply_rotary_emb(
@@ -663,12 +745,6 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
             hf_config, quant_config
         )
 
-    @classmethod
-    def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):
-        return DeepseekV4ForCausalLM.shared_experts_fusion_disable_reason(
-            hf_config, quant_config
-        )
-
     def __init__(
         self,
         config: DeepSeekV4Config,
@@ -709,6 +785,43 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
 
         self.start_layer = 0
         self.end_layer = self.num_stages
+        if model_parallel_is_initialized():
+            parallel = get_parallel()
+            pp_rank = parallel.pp_rank
+            pp_size = parallel.pp_size
+        else:
+            pp_rank = 0
+            pp_size = 1
+        self.is_lifecycle_only = use_empty_draft_model_for_pp_prefill(
+            disaggregation_mode=get_disagg().disaggregation_mode,
+            pp_rank=pp_rank,
+            pp_size=pp_size,
+            target_layer_ids=[
+                int(layer_id) for layer_id in (dspark_config.target_layer_ids or [])
+            ],
+            num_hidden_layers=target_num_layers,
+        )
+        self.hc_mult = int(config.hc_mult)
+        self.norm_eps = float(config.rms_norm_eps)
+        self.hc_eps = float(config.hc_eps)
+        self.embed_tokens: Optional[nn.Module] = None
+        self.lm_head: Optional[nn.Module] = None
+        self._partial_feature_indices: tuple[int, ...] = ()
+        self._partial_main_proj: Optional[_BlockFp8LinearSlice] = None
+        self._use_fp32_lm_head = envs.SGLANG_DSPARK_FP32_LM_HEAD.get()
+        self._opt_markov_w2_tp_shard = envs.SGLANG_DSPARK_OPT_MARKOV_W2_TP_SHARD.get()
+        if self.is_lifecycle_only:
+            self.stages = nn.ModuleList()
+            self.markov_head = None
+            self.confidence_head = None
+            logger.info(
+                "DSpark PP rank %s uses a lifecycle-only draft model; all target "
+                "features are owned by final PP rank %s.",
+                parallel.pp_rank,
+                parallel.pp_size - 1,
+            )
+            return
+
         use_multi_stream = (
             envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get()
             and envs.SGLANG_DSPARK_ENABLE_MULTI_STREAM.get()
@@ -739,10 +852,6 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         self.confidence_head = build_dspark_v4_confidence_head(
             config=config, markov_rank=int(dspark_config.markov_rank)
         )
-        self.hc_mult = int(config.hc_mult)
-        self.norm_eps = float(config.rms_norm_eps)
-        self.hc_eps = float(config.hc_eps)
-
         if self.uses_own_vocab_modules:
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
@@ -759,8 +868,6 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         else:
             self.embed_tokens: Optional[nn.Module] = None
             self.lm_head: Optional[nn.Module] = None
-        self._use_fp32_lm_head = envs.SGLANG_DSPARK_FP32_LM_HEAD.get()
-        self._opt_markov_w2_tp_shard = envs.SGLANG_DSPARK_OPT_MARKOV_W2_TP_SHARD.get()
         if self.lm_head is not None:
             self.markov_head.configure_tp_shard(lm_head=self.lm_head)
 
@@ -776,10 +883,97 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
             self.lm_head = lm_head
         self.markov_head.configure_tp_shard(lm_head=self.lm_head)
 
-    def project_target_hidden(self, main_hidden: torch.Tensor) -> torch.Tensor:
+    def prune_to_ctx_projection(self) -> None:
+        if vars(self).get("is_lifecycle_only", False):
+            return
         stage0 = self.stages[0]
-        projected, _ = stage0.main_proj(main_hidden)
-        return stage0.main_norm(projected)
+        projection_stage = nn.Module()
+        projection_stage.main_proj = stage0.main_proj
+        projection_stage.main_norm = stage0.main_norm
+        self.stages = nn.ModuleList([projection_stage])
+        self.markov_head = None
+        self.confidence_head = None
+        self.embed_tokens = None
+        self.lm_head = None
+        del stage0
+        torch.cuda.empty_cache()
+
+    def project_target_hidden(self, main_hidden: torch.Tensor) -> torch.Tensor:
+        projected, _ = self.stages[0].main_proj(main_hidden)
+        return self.stages[0].main_norm(projected)
+
+    def prepare_target_hidden_partial(self, feature_indices: List[int]) -> None:
+        feature_indices = [int(index) for index in feature_indices]
+        main_proj = self.stages[0].main_proj
+        quant_method = main_proj.quant_method
+        self._partial_feature_indices = tuple(feature_indices)
+        if not (
+            isinstance(quant_method, Fp8LinearMethod)
+            and quant_method.block_quant
+            and not quant_method.use_mxfp8
+            and not quant_method.use_marlin
+        ):
+            self._partial_main_proj = None
+            logger.warning(
+                "DSpark partial projection cannot slice quant method %s; "
+                "falling back to the full-K projection.",
+                type(quant_method).__name__,
+            )
+            return
+        self._partial_main_proj = _BlockFp8LinearSlice(
+            source=main_proj,
+            feature_indices=feature_indices,
+            feature_width=int(self.config.hidden_size),
+        )
+        logger.info(
+            "DSpark block-FP8 partial projection uses feature columns %s "
+            "(local K=%s, full K=%s).",
+            feature_indices,
+            len(feature_indices) * int(self.config.hidden_size),
+            int(main_proj.weight.shape[1]),
+        )
+
+    def project_target_hidden_partial(
+        self, main_hidden: torch.Tensor, feature_indices: list[int]
+    ) -> torch.Tensor:
+        if not feature_indices:
+            raise ValueError("feature_indices must be non-empty.")
+        feature_indices = [int(index) for index in feature_indices]
+        if min(feature_indices) < 0 or max(feature_indices) >= self.num_target_features:
+            raise ValueError(
+                "DeepSeek-V4 DSpark feature_indices out of range: "
+                f"{feature_indices=} {self.num_target_features=}."
+            )
+
+        hidden_size = int(self.config.hidden_size)
+        expected = len(feature_indices) * hidden_size
+        if main_hidden.ndim != 2 or int(main_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "DeepSeek-V4 DSpark partial main_hidden feature dim mismatch. "
+                f"Expected shape [N, {expected}] for {feature_indices=}, "
+                f"but got shape={tuple(main_hidden.shape)}."
+            )
+
+        if (
+            self._partial_main_proj is not None
+            and tuple(feature_indices) == self._partial_feature_indices
+        ):
+            return self._partial_main_proj(main_hidden)
+
+        local_features = main_hidden.view(
+            main_hidden.shape[0], len(feature_indices), hidden_size
+        )
+        full_features = main_hidden.new_zeros(
+            main_hidden.shape[0], self.num_target_features, hidden_size
+        )
+        feature_index = torch.tensor(
+            feature_indices, dtype=torch.long, device=main_hidden.device
+        )
+        full_features.index_copy_(1, feature_index, local_features)
+        projected, _ = self.stages[0].main_proj(
+            full_features.view(main_hidden.shape[0], -1)
+        )
+        return projected
 
     def write_target_hidden_kv(
         self,
@@ -790,6 +984,37 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         pool: DeepSeekV4TokenToKVPool,
     ) -> None:
         main_x = self.project_target_hidden(main_hidden)
+        self._write_context_hidden_kv(
+            main_x=main_x,
+            swa_loc=swa_loc,
+            positions=positions,
+            pool=pool,
+        )
+
+    def write_projected_context_kv(
+        self,
+        *,
+        projected_context: torch.Tensor,
+        swa_loc: torch.Tensor,
+        positions: torch.Tensor,
+        pool: DeepSeekV4TokenToKVPool,
+    ) -> None:
+        main_x = self.stages[0].main_norm(projected_context)
+        self._write_context_hidden_kv(
+            main_x=main_x,
+            swa_loc=swa_loc,
+            positions=positions,
+            pool=pool,
+        )
+
+    def _write_context_hidden_kv(
+        self,
+        *,
+        main_x: torch.Tensor,
+        swa_loc: torch.Tensor,
+        positions: torch.Tensor,
+        pool: DeepSeekV4TokenToKVPool,
+    ) -> None:
         swa_loc = swa_loc.to(torch.int32)
         kvs = CommitKvProj.execute(
             main_x=main_x,
@@ -902,6 +1127,8 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         return confidence
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
+        if vars(self).get("is_lifecycle_only", False):
+            return
         params_dict = dict(self.named_parameters())
         loaded_params = set()
 

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -497,6 +497,7 @@ class DFlashDraftModel(nn.Module):
 
     decoder_layer_cls = DFlashDecoderLayer
     supports_fused_context_kv = True
+    uses_own_vocab_modules = False
 
     def __init__(self, config, quant_config=None, prefix: str = "") -> None:
         super().__init__()
@@ -589,6 +590,39 @@ class DFlashDraftModel(nn.Module):
                 "the draft checkpoint/config expects."
             )
         return self.hidden_norm(self.fc(target_hidden))
+
+    def project_target_hidden_partial(
+        self, target_hidden: torch.Tensor, feature_indices: list[int]
+    ) -> torch.Tensor:
+        if not feature_indices:
+            raise ValueError("feature_indices must be non-empty.")
+        feature_indices = [int(i) for i in feature_indices]
+        if (
+            min(feature_indices) < 0
+            or max(feature_indices) >= self.num_context_features
+        ):
+            raise ValueError(
+                "feature_indices out of range for DFLASH context projection: "
+                f"{feature_indices=} {self.num_context_features=}."
+            )
+        hidden_size = int(self.config.hidden_size)
+        expected = len(feature_indices) * hidden_size
+        if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "DFLASH partial target_hidden feature dim mismatch. "
+                f"Expected shape [N, {expected}] for {feature_indices=}, "
+                f"but got shape={tuple(target_hidden.shape)}."
+            )
+
+        cols = []
+        for idx in feature_indices:
+            start = idx * hidden_size
+            cols.extend(range(start, start + hidden_size))
+        index = torch.tensor(cols, dtype=torch.long, device=self.fc.weight.device)
+        weight = self.fc.weight.index_select(1, index)
+        if target_hidden.dtype != weight.dtype:
+            target_hidden = target_hidden.to(weight.dtype)
+        return F.linear(target_hidden, weight)
 
     @torch.no_grad()
     def forward(
@@ -819,6 +853,35 @@ def _follow_maps(maps, initial_indices, edges: int):
         index = maps[:, edge].gather(-1, index[:, None])[:, 0]
         path.append(index)
     return torch.stack(path, dim=1)
+
+    def project_target_hidden_partial(
+        self, target_hidden: torch.Tensor, feature_indices: list[int]
+    ) -> torch.Tensor:
+        if not feature_indices:
+            raise ValueError("feature_indices must be non-empty.")
+        feature_indices = [int(i) for i in feature_indices]
+        hidden_size = int(self.config.hidden_size)
+        expected = len(feature_indices) * hidden_size
+        if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "Laguna DFLASH partial target_hidden feature dim mismatch. "
+                f"Expected shape [N, {expected}] for {feature_indices=}, "
+                f"but got shape={tuple(target_hidden.shape)}."
+            )
+        slices = target_hidden.view(
+            target_hidden.shape[0], len(feature_indices), hidden_size
+        )
+        compute_dtype = self.fc.weight.dtype
+        if slices.dtype != compute_dtype:
+            slices = slices.to(compute_dtype)
+        normed = torch.empty_like(slices)
+        for out_idx, feature_idx in enumerate(feature_indices):
+            normed[:, out_idx, :] = self.aux_hidden_norms[feature_idx](
+                slices[:, out_idx, :]
+            )
+        return super().project_target_hidden_partial(
+            normed.reshape(target_hidden.shape[0], -1), feature_indices
+        )
 
 
 class CandidateSelector(nn.Module):

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -606,7 +606,44 @@ class DSparkDraftMixin:
         commit_lens: Optional[torch.Tensor] = None,
     ) -> None:
         ctx_hidden = self.project_target_hidden(target_hidden)
+        self.write_context_hidden_kv(
+            ctx_hidden=ctx_hidden,
+            pool=pool,
+            positions=positions,
+            cache_loc=cache_loc,
+            cache_loc_2d=cache_loc_2d,
+            commit_lens=commit_lens,
+        )
 
+    def write_projected_context_kv(
+        self,
+        *,
+        projected_context: torch.Tensor,
+        pool,
+        positions: torch.Tensor,
+        cache_loc: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+    ) -> None:
+        self.write_context_hidden_kv(
+            ctx_hidden=self.hidden_norm(projected_context),
+            pool=pool,
+            positions=positions,
+            cache_loc=cache_loc,
+            cache_loc_2d=cache_loc_2d,
+            commit_lens=commit_lens,
+        )
+
+    def write_context_hidden_kv(
+        self,
+        *,
+        ctx_hidden: torch.Tensor,
+        pool,
+        positions: torch.Tensor,
+        cache_loc: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+    ) -> None:
         bundle = self._fused_kv_write_bundle(pool)
         if bundle is not None:
             from sglang.kernels.ops.speculative.dspark.fused_kv_write import (

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -2633,16 +2633,29 @@ class KimiK3LinearModel(nn.Module):
                 )
 
         if not self.pp_group.is_last_rank:
+            proxy_tensors = {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+            if self.dspark_layers_to_capture is not None:
+                if aux_hidden_states:
+                    proxy_tensors["dspark_aux_hidden_states"] = torch.cat(
+                        aux_hidden_states, dim=-1
+                    )
+                else:
+                    proxy_tensors["dspark_aux_hidden_states"] = hidden_states.new_empty(
+                        hidden_states.shape[0], 0
+                    )
             assert not sp_sharded
             if attn_res is not None:
                 if residual is not None:
                     # Materialize the delayed MLP add: the wire carries the
                     # full stream head (bit-identical to the fused fold).
                     hidden_states = residual + hidden_states
+                    proxy_tensors["hidden_states"] = hidden_states
                 residual = attn_res.block_residual  # raw bank across ranks
-            return PPProxyTensors(
-                {"hidden_states": hidden_states, "residual": residual}
-            )
+                proxy_tensors["residual"] = residual
+            return PPProxyTensors(proxy_tensors)
 
         if hidden_states.shape[0] != 0:
             if attn_res is not None:
@@ -2760,18 +2773,17 @@ class KimiK3LinearForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
-        if self.pp_group.world_size > 1:
-            # Capture layers living on non-last PP ranks would be silently
-            # skipped (the flag is only set on the last rank).
-            raise NotImplementedError("DSPARK aux hidden capture requires PP=1.")
-        if not self.pp_group.is_last_rank:
-            return
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
-        self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        local_layer_ids = [
+            int(layer_id)
+            for layer_id in layer_ids
+            if self.model.start_layer <= int(layer_id) < self.model.end_layer
+        ]
+        self.capture_aux_hidden_states = bool(local_layer_ids)
+        self.model.dspark_layers_to_capture = local_layer_ids or None
 
     @torch.no_grad()
     def forward(
@@ -2887,6 +2899,35 @@ class KimiK3LinearForCausalLM(nn.Module):
         loaded_params: set[str] = set()
 
         num_hidden_layers = self.config.num_hidden_layers
+
+        def maybe_load_truncated_moe_gate(
+            param_name: str, param: torch.Tensor, loaded_weight: torch.Tensor
+        ) -> bool:
+            if self.config.num_experts is None:
+                return False
+            if not (
+                param_name.endswith(".mlp.gate.weight")
+                or param_name.endswith(".mlp.gate.e_score_correction_bias")
+            ):
+                return False
+            if loaded_weight.shape == param.data.shape:
+                return False
+            keep_num_experts = int(self.config.num_experts)
+            if loaded_weight.shape[0] < keep_num_experts:
+                raise ValueError(
+                    f"Cannot truncate Kimi-K3 MoE gate weight {param_name}: "
+                    f"checkpoint has {loaded_weight.shape[0]} experts, "
+                    f"requested {keep_num_experts}."
+                )
+            truncated_weight = loaded_weight.narrow(0, 0, keep_num_experts)
+            if truncated_weight.shape != param.data.shape:
+                raise ValueError(
+                    f"Unexpected truncated Kimi-K3 MoE gate shape for {param_name}: "
+                    f"{truncated_weight.shape=} {param.data.shape=}."
+                )
+            param.data.copy_(truncated_weight)
+            return True
+
         for args in weights:
             name, loaded_weight = args[:2]
             kwargs = args[2] if len(args) > 2 else {}
@@ -3004,6 +3045,9 @@ class KimiK3LinearForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight, **kwargs)
+                    if maybe_load_truncated_moe_gate(name, param, loaded_weight):
+                        loaded_params.add(name)
+                        continue
             loaded_params.add(name)
 
         self.post_load_weights()

--- a/python/sglang/srt/models/kimi_linear.py
+++ b/python/sglang/srt/models/kimi_linear.py
@@ -623,12 +623,20 @@ class KimiLinearModel(nn.Module):
                 )
 
         if not self.pp_group.is_last_rank:
-            return PPProxyTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                }
-            )
+            proxy_tensors = {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+            if self.dspark_layers_to_capture is not None:
+                if aux_hidden_states:
+                    proxy_tensors["dspark_aux_hidden_states"] = torch.cat(
+                        aux_hidden_states, dim=-1
+                    )
+                else:
+                    proxy_tensors["dspark_aux_hidden_states"] = hidden_states.new_empty(
+                        hidden_states.shape[0], 0
+                    )
+            return PPProxyTensors(proxy_tensors)
         else:
             if hidden_states.shape[0] != 0:
                 if residual is None:
@@ -674,16 +682,17 @@ class KimiLinearForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
-        if self.pp_group.world_size > 1:
-            raise NotImplementedError("DSPARK aux hidden capture requires PP=1.")
-        if not self.pp_group.is_last_rank:
-            return
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
-        self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        local_layer_ids = [
+            int(layer_id)
+            for layer_id in layer_ids
+            if self.model.start_layer <= int(layer_id) < self.model.end_layer
+        ]
+        self.capture_aux_hidden_states = bool(local_layer_ids)
+        self.model.dspark_layers_to_capture = local_layer_ids or None
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9923,9 +9923,17 @@ class ServerArgs:
         )
 
         if self.pp_size > 1:
-            assert (
-                self.disable_overlap_schedule and self.speculative_algorithm is None
-            ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+            assert self.disable_overlap_schedule, (
+                "Pipeline parallelism is not compatible with overlap schedule"
+            )
+            pp_dspark_prefill = (
+                (self.speculative_algorithm or "").upper() == "DSPARK"
+                and self.disaggregation_mode == "prefill"
+            )
+            assert self.speculative_algorithm is None or pp_dspark_prefill, (
+                "Pipeline parallelism with speculative decoding is only supported "
+                "for DSPARK on a PD prefill server"
+            )
             assert self.min_free_slots_delay is None, (
                 "--min-free-slots-delay is not supported with pipeline "
                 "parallelism: allocatable slots per microbatch are bounded by "

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -42,6 +42,45 @@ def draft_is_deepseek_v4(*, server_args: ServerArgs) -> bool:
     return draft_hf_config is not None and is_deepseek_v4(draft_hf_config)
 
 
+def resolve_single_owner_pp_rank(
+    *, target_layer_ids: List[int], num_hidden_layers: int, pp_size: int
+) -> Optional[int]:
+    from sglang.srt.distributed.utils import get_pp_indices
+
+    if not target_layer_ids:
+        return None
+    for pp_rank in range(pp_size):
+        start_layer, end_layer = get_pp_indices(
+            num_hidden_layers=num_hidden_layers,
+            pp_rank=pp_rank,
+            pp_size=pp_size,
+        )
+        if all(start_layer <= layer_id < end_layer for layer_id in target_layer_ids):
+            return pp_rank
+    return None
+
+
+def use_empty_draft_model_for_pp_prefill(
+    *,
+    disaggregation_mode: str,
+    pp_rank: int,
+    pp_size: int,
+    target_layer_ids: List[int],
+    num_hidden_layers: int,
+) -> bool:
+    owner_pp_rank = resolve_single_owner_pp_rank(
+        target_layer_ids=target_layer_ids,
+        num_hidden_layers=num_hidden_layers,
+        pp_size=pp_size,
+    )
+    return (
+        disaggregation_mode == "prefill"
+        and pp_size > 1
+        and owner_pp_rank == pp_size - 1
+        and pp_rank != owner_pp_rank
+    )
+
+
 def dspark_gamma_from_num_draft_tokens(num_draft_tokens: int) -> int:
     gamma = int(num_draft_tokens) - 1
     if gamma < 1:

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -11,6 +11,7 @@ from sglang.kernels.ops.speculative.dspark.dspark_verify_window import (
     build_unified_commit_inject_layout,
 )
 from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 
@@ -113,6 +114,84 @@ class TargetHiddenKvInjector:
         event = torch.cuda.Event()
         event.record(torch.cuda.current_stream(device))
         return event
+
+    def inject_projected_context(
+        self,
+        *,
+        projected_context: torch.Tensor,
+        cache_loc: torch.Tensor,
+        positions: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+        state_slot: Optional[torch.Tensor] = None,
+        final_pos: Optional[torch.Tensor] = None,
+    ) -> None:
+        if projected_context is None or projected_context.numel() == 0:
+            return
+        device = self.model_runner.device
+        cache_loc = cache_loc.to(device=device, dtype=torch.int64, non_blocking=True)
+        positions = positions.to(device=device, dtype=torch.int64, non_blocking=True)
+        projected_context = projected_context.to(device=device, non_blocking=True)
+        n_real = positions.shape[0]
+        if projected_context.shape[0] > n_real:
+            projected_context = projected_context[:n_real]
+        if cache_loc_2d is not None:
+            cache_loc_2d = cache_loc_2d.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+        if commit_lens is not None:
+            commit_lens = commit_lens.to(
+                device=device, dtype=torch.int32, non_blocking=True
+            )
+        if state_slot is not None:
+            state_slot = state_slot.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+        if final_pos is not None:
+            final_pos = final_pos.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+
+        pool = self.draft_model_runner.token_to_kv_pool
+        if isinstance(pool, DeepSeekV4TokenToKVPool):
+            if is_unified_kv_triton():
+                swa_loc = self._unified_inject_loc(
+                    pool=pool,
+                    positions=positions,
+                    cache_loc_2d=cache_loc_2d,
+                    commit_lens=commit_lens,
+                    state_slot=state_slot,
+                    final_pos=final_pos,
+                )
+            else:
+                swa_loc = pool.translate_loc_from_full_to_swa(cache_loc).to(torch.int32)
+                if commit_lens is not None and cache_loc_2d is not None:
+                    bs, verify_len = cache_loc_2d.shape
+                    col = torch.arange(verify_len, device=cache_loc.device).view(1, -1)
+                    committed_mask = (
+                        col < commit_lens.to(torch.long).view(-1, 1)
+                    ).reshape(-1)
+                    swa_loc = torch.where(
+                        committed_mask, swa_loc, torch.full_like(swa_loc, -1)
+                    )
+            with torch.inference_mode():
+                self.draft_model.write_projected_context_kv(
+                    projected_context=projected_context,
+                    swa_loc=swa_loc,
+                    positions=positions,
+                    pool=pool,
+                )
+            return
+
+        with torch.inference_mode():
+            self.draft_model.write_projected_context_kv(
+                projected_context=projected_context,
+                pool=pool,
+                positions=positions,
+                cache_loc=cache_loc,
+                cache_loc_2d=cache_loc_2d,
+                commit_lens=commit_lens,
+            )
 
     def _inject_mla(
         self,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -45,6 +45,7 @@ from sglang.srt.speculative.dspark_components.dspark_config import (
     DSV4_DRAFT_ATTENTION_BACKEND,
     draft_is_deepseek_v4,
     resolve_runtime_config,
+    resolve_single_owner_pp_rank,
 )
 from sglang.srt.speculative.dspark_components.dspark_draft import (
     DraftBlockProposer,
@@ -85,6 +86,12 @@ logger = logging.getLogger(__name__)
 _is_npu = is_npu()
 
 
+def _is_context_only_pp_prefill_rank(
+    *, disaggregation_mode: str, pp_rank: int, pp_size: int
+) -> bool:
+    return disaggregation_mode == "prefill" and pp_size > 1 and pp_rank < pp_size - 1
+
+
 class DSparkWorkerV2(BaseSpecWorker):
 
     def __init__(
@@ -111,7 +118,29 @@ class DSparkWorkerV2(BaseSpecWorker):
         self._draft_dp_context_enabled = (
             get_parallel().enable_dp_attention and not self._draft_is_moe
         )
-        self._is_pd_prefill = get_disagg().disaggregation_mode == "prefill"
+        disaggregation_mode = get_disagg().disaggregation_mode
+        self._is_pd_prefill = disaggregation_mode == "prefill"
+        self._is_context_only_pp_prefill_rank = _is_context_only_pp_prefill_rank(
+            disaggregation_mode=disaggregation_mode,
+            pp_rank=ps.pp_rank,
+            pp_size=ps.pp_size,
+        )
+        self._use_full_projection_prefill = False
+        if self._is_pd_prefill and self._draft_is_moe and ps.pp_size > 1:
+            target_layer_ids = [
+                int(layer_id)
+                for layer_id in (
+                    self.model_runner.spec_aux_config.dflash_target_layer_ids or []
+                )
+            ]
+            owner_pp_rank = resolve_single_owner_pp_rank(
+                target_layer_ids=target_layer_ids,
+                num_hidden_layers=self.model_runner.model_config.num_hidden_layers,
+                pp_size=ps.pp_size,
+            )
+            self._use_full_projection_prefill = (
+                owner_pp_rank == ps.pp_size - 1 and ps.pp_rank == owner_pp_rank
+            )
         self._decode_graph_allowed = (
             not get_exec().graph.disable_cuda_graph and not self._is_pd_prefill
         )
@@ -130,7 +159,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             bundle = build_draft_tp_worker(
                 server_args=server_args,
                 gpu_id=gpu_id,
-                ps=replace(ps, pp_rank=0),
+                ps=ps,
                 nccl_port=nccl_port,
                 target_model_config=target_worker.model_runner.model_config,
                 algo_label="DSPARK",
@@ -143,6 +172,10 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.draft_model_runner = bundle.draft_model_runner
         self.draft_model = bundle.draft_model
         self._draft_sampler = None
+        self._is_lifecycle_only_pp_prefill_rank = (
+            self._draft_is_moe and self.draft_model.is_lifecycle_only
+        )
+        self._linear_accept_index_cache = None
 
         # The mask token is input-only (it is embedded, never sampled), so its
         # bound is the embedding-table row count: the PADDED vocab when the
@@ -168,6 +201,12 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.verify_num_draft_tokens = runtime_config.verify_num_draft_tokens
         self.speculative_num_draft_tokens = self.verify_num_draft_tokens
         self._mask_token_id = runtime_config.mask_token_id
+        self._pp_context_feature_indices: Optional[list[int]] = None
+        self._next_pp_proxy_tensors = None
+
+        if self._is_lifecycle_only_pp_prefill_rank:
+            self._init_lifecycle_only_prefill()
+            return
 
         if self.ps.tp_rank == 0:
             logger.info(
@@ -293,8 +332,23 @@ class DSparkWorkerV2(BaseSpecWorker):
             simulate_acc_len=self._simulate_acc_len,
         )
 
-        if self._is_pd_prefill and not self._draft_is_moe:
-            self.draft_model.prune_to_ctx_kv_injection()
+        if self._is_pd_prefill:
+            if self._draft_is_moe and self._is_context_only_pp_prefill_rank:
+                self.draft_model.prune_to_ctx_projection()
+            elif not self._draft_is_moe:
+                self.draft_model.prune_to_ctx_kv_injection()
+            self._init_pp_context_feature_indices()
+
+    def _init_lifecycle_only_prefill(self) -> None:
+        self._verify_planner = None
+        self._kv_injector = None
+        self._proposer = None
+        self._verify_epilogue = None
+        self._verify_executor = None
+        self._simulate_acc_len = float(envs.SGLANG_SIMULATE_ACC_LEN.get())
+        self._forced_budget_frac = None
+        self._need_mamba_verify_commit = False
+        self._observers = None
 
     def _attach_shared_modules(self) -> None:
         if getattr(self.draft_model, "uses_own_vocab_modules", False):
@@ -302,6 +356,11 @@ class DSparkWorkerV2(BaseSpecWorker):
                 logger.info(
                     "DSpark draft uses its checkpoint-local embedding and LM head."
                 )
+            return
+
+        # Non-final PP prefill ranks only compute their partial context
+        # projection. They do not own the target embedding or LM head.
+        if self._is_context_only_pp_prefill_rank:
             return
 
         target_model = self.target_worker.model_runner.model
@@ -322,12 +381,61 @@ class DSparkWorkerV2(BaseSpecWorker):
             return target_model.get_input_embeddings()
         return target_model.model.get_input_embeddings()
 
+    def _init_pp_context_feature_indices(self) -> None:
+        if self.ps.pp_size <= 1:
+            return
+
+        target_layer_ids = self.model_runner.spec_aux_config.dflash_target_layer_ids
+        if not target_layer_ids:
+            return
+
+        target_model = self.target_worker.model_runner.model
+        start_layer = int(target_model.start_layer)
+        end_layer = int(target_model.end_layer)
+        target_layer_to_feature = {
+            int(layer_id): idx for idx, layer_id in enumerate(target_layer_ids)
+        }
+        local_feature_indices = [
+            target_layer_to_feature[layer_id]
+            for layer_id in range(start_layer, end_layer)
+            if layer_id in target_layer_to_feature
+        ]
+        if not local_feature_indices:
+            return
+
+        self._pp_context_feature_indices = local_feature_indices
+        if self._draft_is_moe and not self._use_full_projection_prefill:
+            self.draft_model.prepare_target_hidden_partial(local_feature_indices)
+        if self.ps.tp_rank == 0:
+            logger.info(
+                "DSpark PP-local context projection will accumulate feature indices %s "
+                "from target layers %s for PP rank %s local layers [%s, %s).",
+                local_feature_indices,
+                list(target_layer_ids),
+                self.ps.pp_rank,
+                start_layer,
+                end_layer,
+            )
+
     @property
     def carries_confidence(self) -> bool:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return False
         return self._verify_planner.carries_confidence
 
     @property
+    def is_lifecycle_only_pp_prefill_rank(self) -> bool:
+        return self._is_lifecycle_only_pp_prefill_rank
+
+    def _draft_model_runners(self) -> tuple:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return ()
+        return super()._draft_model_runners()
+
+    @property
     def spec_v2_attn_backends(self) -> tuple:
+        if self._is_context_only_pp_prefill_rank:
+            return (self._target_worker.model_runner.attn_backend,)
         return (
             self._target_worker.model_runner.attn_backend,
             self.draft_model_runner.attn_backend,
@@ -353,6 +461,26 @@ class DSparkWorkerV2(BaseSpecWorker):
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
     ):
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return
+        if memory_pool_config is not None and self._is_context_only_pp_prefill_rank:
+            page_size = int(self.page_size)
+
+            def _minimal_capacity(capacity):
+                if capacity is None or capacity == 0:
+                    return capacity
+                return page_size
+
+            memory_pool_config = replace(
+                memory_pool_config,
+                max_total_num_tokens=page_size,
+                full_max_total_num_tokens=_minimal_capacity(
+                    memory_pool_config.full_max_total_num_tokens
+                ),
+                swa_max_total_num_tokens=_minimal_capacity(
+                    memory_pool_config.swa_max_total_num_tokens
+                ),
+            )
         self._draft_worker.alloc_memory_pool(
             memory_pool_config=memory_pool_config,
             req_to_token_pool=req_to_token_pool,
@@ -360,6 +488,9 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
 
     def init_attention_backends(self):
+        if self._is_context_only_pp_prefill_rank:
+            self._need_mamba_verify_commit = False
+            return
         with self._draft_context():
             if _is_npu:
                 from sglang.srt.hardware_backend.npu.extra_ops_loader import (
@@ -376,6 +507,8 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
 
     def init_cuda_graphs(self):
+        if self._is_context_only_pp_prefill_rank:
+            return
         capture_decode_cuda_graph = self._decode_graph_allowed
         if is_cuda() and capture_decode_cuda_graph:
             available_mem = get_available_gpu_memory(self.device, self.gpu_id)
@@ -431,59 +564,150 @@ class DSparkWorkerV2(BaseSpecWorker):
     def clear_cache_pool(self):
         pass
 
+    def _refresh_partial_projection(self) -> None:
+        if (
+            self._draft_is_moe
+            and not self._is_lifecycle_only_pp_prefill_rank
+            and not self._use_full_projection_prefill
+            and self._pp_context_feature_indices is not None
+        ):
+            self.draft_model.prepare_target_hidden_partial(
+                self._pp_context_feature_indices
+            )
+
+    def update_weights_from_disk(self, recv_req):
+        success, message = super().update_weights_from_disk(recv_req)
+        if success:
+            self._refresh_partial_projection()
+        return success, message
+
+    def update_weights_from_ipc(self, recv_req):
+        success, message = super().update_weights_from_ipc(recv_req)
+        if success:
+            self._refresh_partial_projection()
+        return success, message
+
     def set_dspark_forced_budget_frac(self, frac: Optional[float]) -> None:
         self._forced_budget_frac = frac
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return
         self._verify_planner.set_forced_budget_frac(frac)
 
     def dump_info_records(self) -> Optional[dict]:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return None
         return self._observers.dump_info_records()
 
     def clear_info_records(self) -> None:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return
         self._observers.clear_info_records()
 
     def block_accept_estimate_log_suffix(self) -> Optional[str]:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return None
         return self._observers.block_accept_estimate_log_suffix()
 
     def note_request_finished(self, *, rid: str, natural_stop: bool) -> None:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return
         self._observers.note_request_finished(rid=rid, natural_stop=natural_stop)
+
+    def set_pp_proxy_tensors_for_next_forward(self, pp_proxy_tensors) -> None:
+        self._next_pp_proxy_tensors = pp_proxy_tensors
 
     def forward_batch_generation(
         self,
         batch: ScheduleBatch,
         on_publish=None,
         grammar_barrier=None,
+        pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
+        if pp_proxy_tensors is None:
+            pp_proxy_tensors = self._next_pp_proxy_tensors
+        self._next_pp_proxy_tensors = None
+
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return self._forward_lifecycle_only_prefill(
+                batch=batch,
+                on_publish=on_publish,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
-            return self._forward_prefill(batch, on_publish)
+            return self._forward_prefill(batch, on_publish, pp_proxy_tensors)
 
         return self._forward_decode(batch, on_publish, grammar_barrier)
 
-    def _forward_prefill(
-        self, batch: ScheduleBatch, on_publish
+    def _forward_lifecycle_only_prefill(
+        self, *, batch: ScheduleBatch, on_publish, pp_proxy_tensors
     ) -> GenerationBatchResult:
         if batch.forward_mode.is_idle():
-            if get_parallel().enable_dp_attention:
-                self.target_worker.forward_batch_generation(
-                    batch, capture_hidden_mode=CaptureHiddenMode.FULL
-                )
-            return self._decode_idle_result(on_publish=on_publish)
+            return self._forward_idle_prefill(
+                batch=batch,
+                on_publish=on_publish,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=CaptureHiddenMode.NULL,
+            )
+        if not (batch.forward_mode.is_extend() or batch.is_extend_in_batch):
+            raise RuntimeError(
+                "Lifecycle-only DSpark worker only supports prefill batches."
+            )
 
         batch_output = self.target_worker.forward_batch_generation(
-            batch, capture_hidden_mode=CaptureHiddenMode.FULL
+            batch,
+            pp_proxy_tensors=pp_proxy_tensors,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+        )
+        batch_output.new_seq_lens = batch.seq_lens
+        if on_publish is not None:
+            on_publish(batch_output.new_seq_lens)
+        if batch_output.logits_output is not None:
+            batch_output.logits_output.hidden_states = None
+        return batch_output
+
+    def _forward_prefill(
+        self, batch: ScheduleBatch, on_publish, pp_proxy_tensors=None
+    ) -> GenerationBatchResult:
+        if batch.forward_mode.is_idle():
+            return self._forward_idle_prefill(
+                batch=batch,
+                on_publish=on_publish,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+            )
+
+        batch_output = self.target_worker.forward_batch_generation(
+            batch,
+            pp_proxy_tensors=pp_proxy_tensors,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
         )
         logits_output = batch_output.logits_output
+        output_pp_proxy_tensors = batch_output.pp_hidden_states_proxy_tensors
+        target_hidden = (
+            logits_output.hidden_states
+            if logits_output is not None
+            else (
+                output_pp_proxy_tensors.tensors.get("dspark_aux_hidden_states")
+                if output_pp_proxy_tensors is not None
+                else None
+            )
+        )
         next_token_ids = batch_output.next_token_ids
         batch_output.new_seq_lens = batch.seq_lens
         if on_publish is not None:
             on_publish(batch_output.new_seq_lens)
 
-        if logits_output.hidden_states is None:
+        if target_hidden is None and self.ps.pp_size <= 1:
             raise RuntimeError(
                 "DSpark requires target aux hidden capture for prefill, but got None. "
                 "Make sure the target model has DFlash layers-to-capture configured."
             )
+        has_local_target_hidden = (
+            target_hidden is not None and target_hidden.numel() > 0
+        )
 
         if batch.extend_lens is None or batch.prefix_lens is None:
             raise RuntimeError(
@@ -494,7 +718,7 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         # Must inject before prefill returns: the scheduler may update radix
         # afterward, invalidating out_cache_loc.
-        device = next_token_ids.device
+        device = self.device
         ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
         draft_seq_lens = torch.tensor(
             batch.prefix_lens, dtype=torch.int32, device=device
@@ -505,10 +729,6 @@ class DSparkWorkerV2(BaseSpecWorker):
             ctx_lens,
             int(sum(batch.extend_lens)),
         )
-        # unified_kv injects into the SWA ring keyed by (draft req slot, position);
-        # thread the per-token state_slot + the req's final position so the
-        # injector keeps only the last SWA window (older prefill tokens share a
-        # ring slot and would race). Cheap; only consumed under unified_kv.
         state_slot = final_pos = None
         if is_unified_kv_triton():
             repeats = ctx_lens.to(torch.int64)
@@ -518,21 +738,96 @@ class DSparkWorkerV2(BaseSpecWorker):
             final_pos = torch.repeat_interleave(
                 (draft_seq_lens + ctx_lens - 1).to(torch.int64), repeats
             )
-        self._kv_injector.inject_target_hidden(
-            target_hidden=logits_output.hidden_states,
-            cache_loc=batch.out_cache_loc,
-            positions=positions,
-            state_slot=state_slot,
-            final_pos=final_pos,
-        )
-        # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
-        logits_output.hidden_states = None
+        if self._use_full_projection_prefill:
+            if not has_local_target_hidden or output_pp_proxy_tensors is not None:
+                raise RuntimeError(
+                    "Single-owner DSpark prefill requires target hidden states "
+                    "on the final PP rank."
+                )
+            self._kv_injector.inject_target_hidden(
+                target_hidden=target_hidden,
+                cache_loc=batch.out_cache_loc,
+                positions=positions,
+                state_slot=state_slot,
+                final_pos=final_pos,
+            )
+        else:
+            incoming_ctx = (
+                pp_proxy_tensors.tensors.get("dspark_ctx_acc")
+                if pp_proxy_tensors is not None
+                else None
+            )
+            local_ctx = None
+            if (
+                self.ps.pp_size > 1
+                and has_local_target_hidden
+                and self._pp_context_feature_indices is not None
+            ):
+                local_ctx = self.draft_model.project_target_hidden_partial(
+                    target_hidden, self._pp_context_feature_indices
+                )
+            if output_pp_proxy_tensors is not None:
+                output_pp_proxy_tensors.tensors.pop("dspark_aux_hidden_states", None)
+            ctx_acc = None
+            if incoming_ctx is not None and local_ctx is not None:
+                ctx_acc = (
+                    incoming_ctx.to(device=local_ctx.device, dtype=local_ctx.dtype)
+                    + local_ctx
+                )
+            elif incoming_ctx is not None:
+                ctx_acc = incoming_ctx.to(device=self.device, non_blocking=True)
+            elif local_ctx is not None:
+                ctx_acc = local_ctx
 
-        batch_output.next_draft_input = make_next_draft_input(
-            bonus_tokens=next_token_ids,
-            new_seq_lens=batch.seq_lens,
-        )
+            if output_pp_proxy_tensors is not None:
+                if ctx_acc is not None:
+                    output_pp_proxy_tensors.tensors["dspark_ctx_acc"] = ctx_acc
+            elif ctx_acc is not None:
+                self._kv_injector.inject_projected_context(
+                    projected_context=ctx_acc,
+                    cache_loc=batch.out_cache_loc,
+                    positions=positions,
+                    state_slot=state_slot,
+                    final_pos=final_pos,
+                )
+            elif has_local_target_hidden and not (
+                self.ps.pp_size > 1 and not self._draft_is_moe
+            ):
+                self._kv_injector.inject_target_hidden(
+                    target_hidden=target_hidden,
+                    cache_loc=batch.out_cache_loc,
+                    positions=positions,
+                    state_slot=state_slot,
+                    final_pos=final_pos,
+                )
+        # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
+        if logits_output is not None:
+            logits_output.hidden_states = None
+
+        if next_token_ids is not None:
+            batch_output.next_draft_input = make_next_draft_input(
+                bonus_tokens=next_token_ids,
+                new_seq_lens=batch.seq_lens,
+            )
         return batch_output
+
+    def _forward_idle_prefill(
+        self,
+        *,
+        batch: ScheduleBatch,
+        on_publish,
+        pp_proxy_tensors,
+        capture_hidden_mode: CaptureHiddenMode,
+    ) -> GenerationBatchResult:
+        if get_parallel().enable_dp_attention:
+            batch_output = self.target_worker.forward_batch_generation(
+                batch,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=capture_hidden_mode,
+            )
+            if self._is_context_only_pp_prefill_rank:
+                return batch_output
+        return self._decode_idle_result(on_publish=on_publish)
 
     def _idle_verify_ragged_layout(self, batch: ScheduleBatch):
         if batch.global_num_tokens is None or not self._verify_planner.is_compact_mode:
@@ -893,4 +1188,6 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
 
     def get_confidence_budget_prepare(self):
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return None
         return self._verify_planner.confidence_budget_prepare()

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -27,8 +27,13 @@ from sglang.srt.disaggregation.mooncake.conn import (
 )
 from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
+    build_kv_layer_ids,
+    build_transfer_entry_pairs,
     get_dsv4_c128_state_indices,
+    pack_state_types,
+    resolve_state_component_dst_index,
     setup_state_kv_args,
+    unpack_state_types,
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import should_use_dsa_fused_topk
@@ -136,6 +141,46 @@ class TestDisaggregationWire(unittest.TestCase):
     def test_list_of_buffers_roundtrip(self):
         bufs = [b"abc", b"", b"de", b"x" * 17]
         self.assertEqual(unpack_list_of_buffers(pack_list_of_buffers(bufs)), bufs)
+
+    def test_state_component_matching_uses_type_occurrence(self):
+        src_state_types = [StateType.SWA, StateType.SWA]
+        dst_state_types = [StateType.SWA, StateType.C128_STATE, StateType.SWA]
+
+        self.assertEqual(
+            resolve_state_component_dst_index(src_state_types, dst_state_types, 0),
+            0,
+        )
+        self.assertEqual(
+            resolve_state_component_dst_index(src_state_types, dst_state_types, 1),
+            2,
+        )
+
+    def test_state_types_roundtrip(self):
+        state_types = [StateType.SWA, StateType.C128_STATE, StateType.SWA_RING]
+
+        self.assertEqual(unpack_state_types(pack_state_types(state_types)), state_types)
+
+    def test_layer_shard_kv_layer_ids_use_shard_start(self):
+        kv_pool = SimpleNamespace(
+            layer_shard_enabled=True,
+            layer_shard_start=20,
+            start_layer=0,
+            end_layer=40,
+            get_kv_layer_ids=lambda: [20, 21, 22],
+        )
+
+        kv_pool.get_contiguous_buf_infos = lambda: ([1, 2, 3], [1, 1, 1], [1, 1, 1])
+
+        src_layer_ids = build_kv_layer_ids(
+            token_to_kv_pool=kv_pool,
+            draft_token_to_kv_pool=None,
+            num_draft_entries=0,
+            num_hidden_layers=40,
+        )
+        pairs = build_transfer_entry_pairs(src_layer_ids, list(range(40)), 3, 40)
+
+        self.assertEqual(src_layer_ids, [20, 21, 22])
+        self.assertEqual(pairs, [(0, 20), (1, 21), (2, 22)])
 
 
 class TestGroupConcurrentContiguous(unittest.TestCase):

--- a/test/registered/unit/disaggregation/test_pp_pd_consensus.py
+++ b/test/registered/unit/disaggregation/test_pp_pd_consensus.py
@@ -1,0 +1,297 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.base import KVPoll  # noqa: E402
+from sglang.srt.disaggregation.prefill import (  # noqa: E402
+    PrefillBootstrapQueue,
+    SchedulerDisaggregationPrefillMixin,
+)
+from sglang.srt.disaggregation.utils import (  # noqa: E402
+    build_transfer_entry_pairs,
+)
+from sglang.srt.managers.schedule_batch import FINISH_ABORT  # noqa: E402
+from sglang.srt.managers.scheduler_pp_mixin import (  # noqa: E402
+    _pp_merge_transfer_status,
+)
+from sglang.srt.runtime_context import get_context  # noqa: E402
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestPPPDConsensus(CustomTestCase):
+    @staticmethod
+    def _make_prefill_queue(pp_rank):
+        class FakeKVArgs:
+            pass
+
+        class FakeManager:
+            def __init__(self, kv_args, *_args):
+                self.kv_args = kv_args
+
+        class FakePool:
+            start_layer = 4
+            end_layer = 6
+            head_num = 1
+            page_size = 64
+            layer_shard_enabled = False
+
+            @staticmethod
+            def get_contiguous_buf_infos():
+                return [10, 11], [100, 100], [10, 10]
+
+            @staticmethod
+            def get_kv_layer_ids():
+                return [4, 5]
+
+        class FakeDraftPool:
+            start_layer = 0
+            end_layer = 1
+            layer_num = 1
+
+            @staticmethod
+            def get_contiguous_buf_infos():
+                return [20], [100], [10]
+
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.transfer_backend = "mooncake"
+        queue.tp_rank = 0
+        queue.pp_rank = pp_rank
+        queue.pp_size = 2
+        queue.scheduler = SimpleNamespace(
+            ps=SimpleNamespace(dp_rank=0, gpu_id=0),
+            server_args=SimpleNamespace(disaggregation_ib_device=None),
+            tp_worker=SimpleNamespace(
+                model_runner=SimpleNamespace(kv_cache_dtype_str="auto")
+            ),
+            model_config=SimpleNamespace(
+                num_hidden_layers=8,
+                get_total_num_kv_heads=lambda: 1,
+            ),
+            req_to_token_pool=None,
+        )
+        queue.token_to_kv_pool = FakePool()
+        queue.draft_token_to_kv_pool = FakeDraftPool()
+        queue.metadata_buffers = SimpleNamespace(get_buf_infos=lambda: ([], [], []))
+        queue.is_mla_backend = False
+        return queue, FakeKVArgs, FakeManager
+
+    def test_transfer_failure_overrides_ordered_success_intersection(self):
+        status = _pp_merge_transfer_status(
+            previous=(["req-a", "req-b", "req-c"], ["req-x"]),
+            current=(["req-c", "req-a", "req-b"], ["req-b", "req-y"]),
+        )
+
+        self.assertEqual(
+            status,
+            (["req-a", "req-c"], ["req-x", "req-b", "req-y"]),
+        )
+
+    def test_bootstrap_probe_respects_local_metadata_credit_prefix(self):
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.queue = [
+            SimpleNamespace(
+                rid="req-failed",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-ready",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-blocked",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+        ]
+        queue.scheduler = SimpleNamespace(
+            attn_cp_cpu_group=object(),
+            attn_tp_cpu_group=object(),
+        )
+        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(
+            available_size=lambda: 1
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.prefill." "poll_and_all_reduce_attn_cp_tp_group",
+            return_value=[
+                KVPoll.Failed,
+                KVPoll.WaitingForInput,
+                KVPoll.WaitingForInput,
+            ],
+        ):
+            good_rids, failed_rids = queue.get_ready_bootstrapped_rids_for_pp()
+
+        self.assertEqual(good_rids, ["req-ready"])
+        self.assertEqual(failed_rids, ["req-failed"])
+        self.assertEqual(
+            [req.metadata_buffer_index for req in queue.queue],
+            [-1, -1, -1],
+        )
+
+    def test_bootstrap_probe_reports_failures_after_metadata_backpressure(self):
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.queue = [
+            SimpleNamespace(
+                rid="req-blocked",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-failed",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-ready-after-block",
+                metadata_buffer_index=0,
+                disagg_kv_sender=object(),
+            ),
+        ]
+        queue.scheduler = SimpleNamespace(
+            attn_cp_cpu_group=object(),
+            attn_tp_cpu_group=object(),
+        )
+        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(
+            available_size=lambda: 0
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.prefill." "poll_and_all_reduce_attn_cp_tp_group",
+            return_value=[
+                KVPoll.WaitingForInput,
+                KVPoll.Failed,
+                KVPoll.WaitingForInput,
+            ],
+        ):
+            good_rids, failed_rids = queue.get_ready_bootstrapped_rids_for_pp()
+
+        self.assertEqual(good_rids, [])
+        self.assertEqual(failed_rids, ["req-failed"])
+
+    def test_remote_failure_waits_for_local_transfer_terminal_state(self):
+        sender = SimpleNamespace()
+        req = SimpleNamespace(
+            rid="req-race",
+            disagg_kv_sender=sender,
+            finished_reason=None,
+            pending_bootstrap=False,
+            return_logprob=False,
+            time_stats=SimpleNamespace(set_completion_time=Mock()),
+        )
+        handle_failure = Mock()
+        scheduler = SimpleNamespace(
+            disagg_prefill_inflight_queue=[req],
+            attn_cp_cpu_group=object(),
+            attn_tp_cpu_group=object(),
+            ps=SimpleNamespace(pp_rank=1),
+            handle_inflight_transfer_failure=handle_failure,
+            output_streamer=SimpleNamespace(stream_output=Mock()),
+            req_to_metadata_buffer_idx_allocator=object(),
+        )
+
+        def mark_abort(target_req, message, status_code):
+            del message, status_code
+            target_req.finished_reason = FINISH_ABORT("remote PP failure")
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill."
+                "poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.Transferring],
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.prepare_abort",
+                side_effect=mark_abort,
+            ),
+        ):
+            done_reqs = SchedulerDisaggregationPrefillMixin.process_disagg_prefill_inflight_queue(
+                scheduler,
+                transfer_status=([], ["req-race"]),
+            )
+
+        self.assertEqual(done_reqs, [])
+        self.assertEqual(scheduler.disagg_prefill_inflight_queue, [req])
+        handle_failure.assert_not_called()
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill."
+                "poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.Success],
+            ),
+            patch("sglang.srt.disaggregation.prefill.maybe_release_metadata_buffer"),
+        ):
+            done_reqs = SchedulerDisaggregationPrefillMixin.process_disagg_prefill_inflight_queue(
+                scheduler,
+                transfer_status=([], []),
+            )
+
+        self.assertEqual(done_reqs, [req])
+        self.assertEqual(scheduler.disagg_prefill_inflight_queue, [])
+        handle_failure.assert_called_once_with(req)
+
+    def test_only_last_pp_registers_draft_kv_for_transfer(self):
+        layer_ids_by_rank = []
+        for pp_rank in (0, 1):
+            queue, fake_args, fake_manager = self._make_prefill_queue(pp_rank)
+
+            def get_kv_class(_backend, class_type):
+                return fake_args if class_type.value == "kvargs" else fake_manager
+
+            with (
+                patch(
+                    "sglang.srt.disaggregation.prefill.get_kv_class",
+                    side_effect=get_kv_class,
+                ),
+                patch(
+                    "sglang.srt.disaggregation.prefill.setup_state_kv_args",
+                ),
+                get_context().override_server_args(disaggregation_ib_device=None),
+            ):
+                manager = queue._init_kv_manager()
+            layer_ids_by_rank.append(manager.kv_args.kv_layer_ids)
+
+        self.assertEqual(layer_ids_by_rank[0], [4, 5])
+        self.assertEqual(
+            layer_ids_by_rank[1],
+            [4, 5, 8],
+        )
+
+    def test_pp_prefill_entries_pair_with_pp1_decode_entries(self):
+        decode_layer_ids = [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            8,
+        ]
+
+        rank_0_pairs = build_transfer_entry_pairs(
+            src_layer_ids=[0, 1, 2, 3],
+            dst_layer_ids=decode_layer_ids,
+            n_src=4,
+            n_dst=7,
+        )
+        rank_1_pairs = build_transfer_entry_pairs(
+            src_layer_ids=[4, 5, 8],
+            dst_layer_ids=decode_layer_ids,
+            n_src=3,
+            n_dst=7,
+        )
+
+        self.assertEqual(rank_0_pairs, [(0, 0), (1, 1), (2, 2), (3, 3)])
+        self.assertEqual(rank_1_pairs, [(0, 4), (1, 5), (2, 6)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dspark_pp_context.py
+++ b/test/registered/unit/spec/test_dspark_pp_context.py
@@ -1,0 +1,370 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.layernorm import RMSNorm  # noqa: E402
+from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod  # noqa: E402
+from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig  # noqa: E402
+from sglang.srt.model_executor.runner.base_runner import (  # noqa: E402
+    _allocate_decode_buffers,
+)
+from sglang.srt.model_executor.runner_utils.buffers import (  # noqa: E402
+    DecodeInputBuffers,
+)
+from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM  # noqa: E402
+from sglang.srt.models.deepseek_v4_dspark import (  # noqa: E402
+    DeepseekV4ForCausalLMDSpark,
+    _BlockFp8LinearSlice,
+)
+from sglang.srt.models.dflash import DFlashDraftModel  # noqa: E402
+from sglang.srt.speculative.dspark_components.dspark_config import (  # noqa: E402
+    resolve_single_owner_pp_rank,
+    use_empty_draft_model_for_pp_prefill,
+)
+from sglang.srt.speculative.dspark_components.dspark_worker_v2 import (  # noqa: E402
+    DSparkWorkerV2,
+    _is_context_only_pp_prefill_rank,
+)
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _TupleLinear(torch.nn.Module):
+    def __init__(self, input_size: int, output_size: int):
+        super().__init__()
+        self.linear = torch.nn.Linear(input_size, output_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor):
+        return self.linear(hidden_states), None
+
+
+def _make_deepseek_v4_dspark_projection_model(
+    *, hidden_size: int, num_target_features: int
+) -> DeepseekV4ForCausalLMDSpark:
+    model = DeepseekV4ForCausalLMDSpark.__new__(DeepseekV4ForCausalLMDSpark)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=hidden_size)
+    model.num_target_features = num_target_features
+    stage = torch.nn.Module()
+    stage.main_proj = _TupleLinear(hidden_size * num_target_features, hidden_size)
+    stage.main_norm = RMSNorm(hidden_size, eps=1e-6)
+    model.stages = torch.nn.ModuleList([stage])
+    model.markov_head = torch.nn.Identity()
+    model.confidence_head = torch.nn.Identity()
+    model.embed_tokens = None
+    model.lm_head = None
+    model._partial_feature_indices = ()
+    model._partial_main_proj = None
+    return model
+
+
+class TestDSparkPPContext(CustomTestCase):
+    def test_full_projection_fast_path_requires_final_pp_owner(self):
+        with patch.dict(
+            os.environ,
+            {"SGLANG_PP_LAYER_PARTITION": "6,5,6,5,6,5,5,5"},
+        ):
+            self.assertEqual(
+                resolve_single_owner_pp_rank(
+                    target_layer_ids=[40, 41, 42],
+                    num_hidden_layers=43,
+                    pp_size=8,
+                ),
+                7,
+            )
+            self.assertIsNone(
+                resolve_single_owner_pp_rank(
+                    target_layer_ids=[35, 40],
+                    num_hidden_layers=43,
+                    pp_size=8,
+                )
+            )
+
+    def test_empty_draft_model_is_limited_to_non_owner_pp_prefill_ranks(self):
+        common = dict(
+            disaggregation_mode="prefill",
+            pp_size=8,
+            target_layer_ids=[40, 41, 42],
+            num_hidden_layers=43,
+        )
+        for pp_rank in range(7):
+            self.assertTrue(
+                use_empty_draft_model_for_pp_prefill(pp_rank=pp_rank, **common)
+            )
+        self.assertFalse(use_empty_draft_model_for_pp_prefill(pp_rank=7, **common))
+        self.assertFalse(
+            use_empty_draft_model_for_pp_prefill(
+                pp_rank=0,
+                **{**common, "target_layer_ids": [35, 40]},
+            )
+        )
+
+    def test_lifecycle_only_model_does_not_consume_checkpoint_weights(self):
+        model = DeepseekV4ForCausalLMDSpark.__new__(DeepseekV4ForCausalLMDSpark)
+        torch.nn.Module.__init__(model)
+        model.is_lifecycle_only = True
+
+        def weights():
+            raise AssertionError("lifecycle-only model consumed checkpoint weights")
+            yield
+
+        model.load_weights(weights())
+
+    def test_block_fp8_projection_slice_selects_matching_weight_and_scale_blocks(self):
+        feature_width = 128
+        output_size = 2
+        quant_method = Fp8LinearMethod(
+            Fp8Config(
+                is_checkpoint_fp8_serialized=True,
+                activation_scheme="dynamic",
+                weight_block_size=[128, 128],
+            )
+        )
+        weight = torch.arange(
+            output_size * feature_width * 3, dtype=torch.float32
+        ).reshape(output_size, feature_width * 3)
+        weight_scale = torch.tensor([[11.0, 22.0, 33.0]])
+        source = SimpleNamespace(
+            quant_method=quant_method,
+            weight=torch.nn.Parameter(weight, requires_grad=False),
+            weight_scale_inv=torch.nn.Parameter(weight_scale, requires_grad=False),
+        )
+        source.weight_scale_inv.format_ue8m0 = False
+
+        projection_slice = _BlockFp8LinearSlice(
+            source=source,
+            feature_indices=[0, 2],
+            feature_width=feature_width,
+        )
+
+        expected_weight = torch.cat(
+            [weight[:, :feature_width], weight[:, 2 * feature_width :]], dim=1
+        )
+        self.assertTrue(torch.equal(projection_slice.weight, expected_weight))
+        self.assertTrue(
+            torch.equal(
+                projection_slice.weight_scale_inv,
+                torch.tensor([[11.0, 33.0]]),
+            )
+        )
+
+    def test_partial_projection_uses_prepared_quantized_slice(self):
+        model = _make_deepseek_v4_dspark_projection_model(
+            hidden_size=4, num_target_features=3
+        )
+        expected = torch.randn(2, 4)
+        projection_slice = Mock(return_value=expected)
+        model._partial_feature_indices = (1,)
+        model._partial_main_proj = projection_slice
+        local_hidden = torch.randn(2, 4)
+
+        actual = model.project_target_hidden_partial(local_hidden, [1])
+
+        projection_slice.assert_called_once_with(local_hidden)
+        self.assertIs(actual, expected)
+
+    def test_pp_spec_verify_buffers_use_token_axis(self):
+        max_bs = 64
+        num_tokens_per_req = 6
+        max_num_token = max_bs * num_tokens_per_req
+        common_kwargs = dict(
+            device=torch.device("cpu"),
+            max_bs=max_bs,
+            max_num_token=max_num_token,
+            hidden_size=4,
+            dtype=torch.float32,
+            dp_size=1,
+            pp_size=8,
+            is_encoder_decoder=False,
+            require_mlp_tp_gather=False,
+            seq_len_fill_value=1,
+            encoder_len_fill_value=0,
+            num_tokens_per_req=num_tokens_per_req,
+            cache_loc_dtype=torch.int64,
+            enable_mamba_track=False,
+            hc_hidden_size=16,
+        )
+        eager_buffers = _allocate_decode_buffers(vocab_size=8, **common_kwargs)
+        graph_buffers = DecodeInputBuffers.create(
+            next_token_logits_buffer=torch.zeros((max_num_token, 8)),
+            **common_kwargs,
+        )
+
+        self.assertEqual(
+            eager_buffers.pp_proxy_tensors["hidden_states"].shape,
+            (max_num_token, 16),
+        )
+        self.assertEqual(
+            graph_buffers.pp_proxy_tensors["hidden_states"].shape,
+            (max_num_token, 16),
+        )
+
+    def test_partial_projection_sum_matches_full_projection(self):
+        torch.manual_seed(0)
+        hidden_size = 4
+        model = DFlashDraftModel.__new__(DFlashDraftModel)
+        torch.nn.Module.__init__(model)
+        model.config = SimpleNamespace(hidden_size=hidden_size)
+        model.num_context_features = 3
+        model.fc = torch.nn.Linear(3 * hidden_size, hidden_size, bias=False)
+        model.hidden_norm = RMSNorm(hidden_size, eps=1e-6)
+
+        feature_hidden = [
+            torch.randn(5, hidden_size, dtype=torch.float32) for _ in range(3)
+        ]
+        full_hidden = torch.cat(feature_hidden, dim=-1)
+        full_projected = model.project_target_hidden(full_hidden)
+
+        stage_0 = model.project_target_hidden_partial(
+            torch.cat([feature_hidden[0], feature_hidden[2]], dim=-1),
+            [0, 2],
+        )
+        stage_1 = model.project_target_hidden_partial(feature_hidden[1], [1])
+        pp_projected = model.hidden_norm(stage_0 + stage_1)
+
+        torch.testing.assert_close(pp_projected, full_projected)
+
+    def test_deepseek_v4_partial_projection_survives_context_only_pruning(self):
+        torch.manual_seed(1)
+        hidden_size = 4
+        model = _make_deepseek_v4_dspark_projection_model(
+            hidden_size=hidden_size, num_target_features=3
+        )
+        features = [torch.randn(5, hidden_size, dtype=torch.float32) for _ in range(3)]
+        full_projected = model.project_target_hidden(torch.cat(features, dim=-1))
+
+        stage_0 = model.project_target_hidden_partial(
+            torch.cat([features[0], features[2]], dim=-1),
+            [0, 2],
+        )
+        model.prune_to_ctx_projection()
+        stage_1 = model.project_target_hidden_partial(features[1], [1])
+        pp_projected = model.stages[0].main_norm(stage_0 + stage_1)
+        write_context_hidden_kv = Mock()
+        model._write_context_hidden_kv = write_context_hidden_kv
+        model.write_projected_context_kv(
+            projected_context=stage_0 + stage_1,
+            swa_loc=torch.arange(5),
+            positions=torch.arange(5),
+            pool=object(),
+        )
+
+        self.assertEqual(list(model.stages[0]._modules), ["main_proj", "main_norm"])
+        torch.testing.assert_close(pp_projected, full_projected)
+        torch.testing.assert_close(
+            write_context_hidden_kv.call_args.kwargs["main_x"],
+            full_projected,
+        )
+
+    def test_deepseek_v4_capture_is_local_to_each_pp_rank(self):
+        model = DeepseekV4ForCausalLM.__new__(DeepseekV4ForCausalLM)
+        torch.nn.Module.__init__(model)
+        model.pp_group = SimpleNamespace(is_last_rank=False)
+        model.model = SimpleNamespace(
+            start_layer=10,
+            end_layer=20,
+            dspark_layers_to_capture=None,
+        )
+        model.capture_aux_hidden_states = False
+
+        model.set_dspark_layers_to_capture([5, 12, 18, 25])
+
+        self.assertTrue(model.capture_aux_hidden_states)
+        self.assertEqual(model.model.dspark_layers_to_capture, [12, 18])
+
+    def test_non_last_pp_prefill_does_not_require_target_lm_head(self):
+        self.assertTrue(
+            _is_context_only_pp_prefill_rank(
+                disaggregation_mode="prefill",
+                pp_rank=0,
+                pp_size=8,
+            )
+        )
+        self.assertFalse(
+            _is_context_only_pp_prefill_rank(
+                disaggregation_mode="prefill",
+                pp_rank=7,
+                pp_size=8,
+            )
+        )
+
+    def test_context_only_rank_does_not_require_draft_attention_backend(self):
+        target_backend = object()
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._is_context_only_pp_prefill_rank = True
+        worker._target_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(attn_backend=target_backend)
+        )
+        worker.draft_model_runner = SimpleNamespace()
+
+        self.assertEqual(worker.spec_v2_attn_backends, (target_backend,))
+
+    def test_lifecycle_only_rank_does_not_allocate_draft_pool(self):
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._draft_worker = Mock()
+        worker._is_lifecycle_only_pp_prefill_rank = True
+
+        worker.alloc_memory_pool(memory_pool_config=Mock())
+
+        worker._draft_worker.alloc_memory_pool.assert_not_called()
+
+    def test_lifecycle_only_rank_does_not_publish_draft_pool(self):
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._is_lifecycle_only_pp_prefill_rank = True
+        self.assertEqual(worker._draft_model_runners(), ())
+
+    def test_non_last_pp_prefill_uses_minimal_draft_kv_pool(self):
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._draft_worker = Mock()
+        worker._is_pd_prefill = True
+        worker._draft_is_moe = True
+        worker._is_context_only_pp_prefill_rank = True
+        worker._is_lifecycle_only_pp_prefill_rank = False
+        worker.ps = SimpleNamespace(pp_rank=0, pp_size=2)
+        worker.page_size = 64
+        full_config = MemoryPoolConfig(
+            max_total_num_tokens=4096,
+            max_running_requests=32,
+        )
+
+        worker.alloc_memory_pool(memory_pool_config=full_config)
+
+        passed_config = worker._draft_worker.alloc_memory_pool.call_args.kwargs[
+            "memory_pool_config"
+        ]
+        self.assertEqual(passed_config.max_total_num_tokens, 64)
+        self.assertEqual(passed_config.max_running_requests, 32)
+        self.assertEqual(full_config.max_total_num_tokens, 4096)
+
+    def test_last_pp_prefill_keeps_full_draft_kv_pool(self):
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._draft_worker = Mock()
+        worker._is_pd_prefill = True
+        worker._draft_is_moe = True
+        worker._is_context_only_pp_prefill_rank = False
+        worker._is_lifecycle_only_pp_prefill_rank = False
+        worker.ps = SimpleNamespace(pp_rank=1, pp_size=2)
+        worker.page_size = 64
+        full_config = MemoryPoolConfig(
+            max_total_num_tokens=4096,
+            max_running_requests=32,
+        )
+
+        worker.alloc_memory_pool(memory_pool_config=full_config)
+
+        passed_config = worker._draft_worker.alloc_memory_pool.call_args.kwargs[
+            "memory_pool_config"
+        ]
+        self.assertIs(passed_config, full_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR contains four changes for DeepSeek-V4 serving on HCU:

1. Fix CP-sharded position handling in the PP proxy.
2. Backport and adapt upstream PP + PD + DSpark support.
3. Add CP support to sparse prefill.
4. Include the HCU MLA concat kernel in HIP AOT builds.

The complete configuration was validated with:

- Prefill: CP8 + EP8 + PP2 + DSpark
- Decode: DP16 + EP16 + DSpark
- PD disaggregation with Mooncake
- DeepSeek-V4 Flash W4A8
- Radix cache disabled during accuracy evaluation

## 1. Fix CP-sharded positions in the PP proxy

Commit: [`e7b78f4`](https://github.com/aivictor0901-tech/sglang-das/commit/e7b78f4)  
`fix(pp): allow CP-sharded positions in DeepSeek V4 proxy`

### Purpose

When PP and CP are enabled together, PP proxy hidden states can still represent the complete flattened token batch while `positions` has already been sharded according to the CP interleave layout.

For CP interleave, rank `r` owns query rows following:

```text
r::cp_size
```

For example, with CP8:

```text
rank0: 0, 8, 16, ...
rank1: 1, 9, 17, ...
...
rank7: 7, 15, 23, ...
```

Therefore, the following intermediate tensor layout is valid:

```text
hidden_states: full PP token layout
positions:     CP-rank-local layout
```

The previous code compared the row counts before restoring the PP tensor layout. This caused a valid PP + CP request to fail with a hidden-state/position shape mismatch.

This commit removes the premature validation and allows the existing PP tensor restoration and CP reindexing logic to process the tensors in the correct order.

### Required environment variables

None.

The fix is used automatically when PP and CP are enabled:

```bash
--pp-size 2 \
--enable-prefill-cp \
--cp-strategy interleave
```

## 2. Backport PP + PD + DSpark support

Commit: [`1a5e724`](https://github.com/aivictor0901-tech/sglang-das/commit/1a5e724)  
`feat(dspark): support pipeline parallelism`

Upstream source:

```text
https://github.com/sgl-project/sglang/pull/33863
```

### Purpose

This commit backports and adapts the PP + PD + DSpark implementation from SGLang upstream PR #33863 to the `release/20260825_v0.5.18` HCU branch.

The upstream PR is currently still open, so this is a backport of an upstream proposed implementation rather than code already merged into upstream `main`.

Without PP, the prefill worker can collect all required target hidden states, generate the DSpark draft KV, and transfer target KV plus draft KV to the decode worker.

With PP, the required target hidden states are distributed across pipeline stages. The DSpark context projection must therefore be accumulated across the PP stages before RMSNorm and draft KV projection:

```text
PP rank i:
    local_context_i = local_hidden_i @ local_weight_i.T

Across PP ranks:
    accumulated_context += local_context_i

Final PP rank:
    normalized_context = RMSNorm(accumulated_context)
    draft_K, draft_V = KVProj(normalized_context)
```

### Upstream implementation and optimizations

This commit includes the following upstream changes:

- Each PP rank captures only the target hidden states owned by that rank.
- Each PP rank computes only its local context-projection contribution.
- A fixed-size `[num_tokens, hidden_size]` context tensor is accumulated across PP stages.
- Matching block-FP8 weight columns and scale blocks are sliced according to PP ownership.
- Repeated zero-padded full-K GEMMs on every PP rank are avoided.
- RMSNorm and draft KV projection are executed once on the final PP rank.
- Non-owner PP ranks use lightweight lifecycle-only DSpark workers.
- Non-owner ranks avoid unnecessary draft stages, heads, weights, KV pools, planners, proposers, and injectors.
- Hidden states are not transferred across the P/D boundary.
- Every PP rank transfers its local target KV.
- Only the final PP rank generates and transfers draft KV.
- Bootstrap, request admission, transfer completion, failure propagation, and KV release are synchronized across PP ranks.
- State components are matched by `(StateType, occurrence)` instead of list position.
- Optional C128/SWA state-layout differences no longer cause draft KV to be written into the wrong destination buffer.
- Mooncake and NIXL state registration and transfer metadata are made PP-aware.

The original upstream PR does not support DSpark + CP directly. The other commits in this PR provide the additional CP position and sparse-prefill adaptations used by the validated CP8 + PP2 configuration.

### Required environment variables

This commit does not introduce a dedicated environment-variable switch.

PP + PD + DSpark is enabled through the launch arguments.

Prefill:

```bash
--pp-size 2 \
--disaggregation-mode prefill \
--disaggregation-transfer-backend mooncake \
--speculative-algorithm DSPARK \
--speculative-num-steps 1 \
--speculative-eagle-topk 1
```

Decode:

```bash
--disaggregation-mode decode \
--speculative-algorithm DSPARK \
--speculative-num-steps 1 \
--speculative-eagle-topk 1
```

## 3. Add CP support to sparse prefill

Commit: [`b9fb0a5`](https://github.com/aivictor0901-tech/sglang-das/commit/b9fb0a5)  
`fix(dsv4): support sparse prefill with context parallelism`

### Purpose

The original sparse-prefill workspace builder assumes that query rows are globally contiguous.

That assumption is invalid after CP interleave sharding because every CP rank owns non-contiguous rows from the global flattened query stream.

For CP8:

```text
rank0: 0, 8, 16, ...
rank1: 1, 9, 17, ...
...
rank7: 7, 15, 23, ...
```

The old workspace builder could associate a CP-local query row with the wrong request or request-local position, resulting in incorrect SWA/C4/C128 workspace indices.

This commit introduces a separate Triton metadata kernel that constructs CP-local sparse-prefill metadata entirely on the device, without adding H2D or D2H synchronization.

For every request and CP rank, it calculates:

- The number of real local query rows.
- The number of physical local rows after CP padding.
- The real request-local position of every CP-local query row.
- A sanitized `-1` position for physical dummy rows.

The sparse workspace mapping becomes:

```text
CP-local Q row
    -> request
    -> real query position
    -> SWA/C4/C128 workspace indices
```

This fixes:

- Mixed batches whose requests start at different CP phases.
- Requests with zero real query rows on a CP rank.
- Non-divisible query chunks.
- Physical CP padding rows.
- Negative SWA indices generated by dummy rows.
- Incorrect C4/C128 source-row selection after round-robin sharding.

The existing chunk-level sparse-prefill optimization remains unchanged:

```text
collect KV rows selected by a query chunk
    -> build a shared BF16 KV workspace
    -> construct per-query workspace indices
    -> call sparse FlashMLA
```

The CP adaptation changes only the query metadata and workspace-address mapping. It does not truncate the logical KV context and does not change the KV rows selected by the indexer.

### Required environment variables

The CP sparse-prefill path requires:

```bash
export SGLANG_OPT_FLASHMLA_SPARSE_PREFILL=1
export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA=1
```

The variables have different responsibilities:

- `SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA=1`

  Enables the independent prefill MLA path. Without it, extend/prefill requests remain on the original unified MLA path and do not enter the sparse-prefill implementation.

- `SGLANG_OPT_FLASHMLA_SPARSE_PREFILL=1`

  Selects sparse prefill after entering the independent prefill path. It also explicitly keeps sparse prefill enabled with CP on HIP/ROCm.

Both variables are required for the CP sparse-prefill path in this SGLang 0.5.18 implementation.

The prefill worker must also enable CP through the launch arguments:

```bash
--enable-prefill-cp \
--cp-strategy interleave
```

For the validated multi-rank CP P-to-D transfer, the following independent CP transfer setting was also enabled:

```bash
export SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER=1
```

## 4. Include the HCU MLA concat kernel in HIP AOT builds

Commit: [`4be45be`](https://github.com/aivictor0901-tech/sglang-das/commit/4be45be)  
`[FIX] Include HCU MLA concat kernel in HIP AOT build`

### Purpose

This commit adds:

```text
csrc/elementwise/concat_mla_absorb_q_hcu.cu
```

to the HIP AOT source list in:

```text
python/sglang/kernels/aot/setup_hip.py
```

The HCU MLA concat kernel already existed in the source tree but was not included in the HIP AOT build.

Without this source entry, the generated HCU kernel package may not contain the optimized MLA concat implementation, resulting in an unavailable kernel or missing runtime symbol.

After applying this commit, the HCU kernel extension or wheel must be rebuilt and reinstalled.

## Accuracy Test Summary

Accuracy was evaluated with EvalScope through the PD router.

Test configuration:

- Model: `dpsk-v4-flash-w4a8-0518`
- Prefill: CP8 + EP8 + PP2 + DSpark
- Decode: DP16 + EP16 + DSpark
- Temperature: `0.0`
- Maximum output tokens: `10240`
- Evaluation concurrency: `32`
- HumanEval: 0-shot
- MATH-500: 0-shot
- GSM8K: 4-shot
- Radix cache: disabled

| Dataset | Samples | Metric | Score |
|---|---:|---|---:|
| HumanEval | 164 | Pass@1 | 90.9% |
| MATH-500 | 500 | Accuracy | 94.8% |
| GSM8K | 1319 | Accuracy | 96.7% |

All three EvalScope evaluations completed successfully.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->