### PR TITLE
Feat/bolt recompute w u

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/wy_fast.py
+++ b/python/sglang/kernels/ops/attention/fla/wy_fast.py
@@ -9,6 +9,16 @@ import triton
 import triton.language as tl
 
 from sglang.kernels.ops.attention.fla.index import prepare_chunk_indices
+from sglang.srt.utils import get_bool_env_var, is_hcu
+
+
+_is_hcu = is_hcu()
+_use_bolt_recompute_w_u = get_bool_env_var("SGLANG_USE_BOLT_RECOMPUTE_W_U")
+
+if _is_hcu and _use_bolt_recompute_w_u:
+    from boltops.fla.gdn.triton.recompute_w_u import (
+        recompute_w_u_fwd_gdn as _bolt_recompute_w_u_fwd,
+    )
 
 
 # @triton.autotune(
@@ -153,4 +163,9 @@ def recompute_w_u_fwd(
     return w, u
 
 
+# HCU 且环境变量开启时，替换公共函数。
+if _is_hcu and _use_bolt_recompute_w_u:
+    recompute_w_u_fwd = _bolt_recompute_w_u_fwd
+
+# 该别名也必须在完成替换后再赋值。
 fwd_recompute_w_u = recompute_w_u_fwd

--- a/python/sglang/kernels/ops/attention/fla/wy_fast.py
+++ b/python/sglang/kernels/ops/attention/fla/wy_fast.py
@@ -163,9 +163,7 @@ def recompute_w_u_fwd(
     return w, u
 
 
-# HCU 且环境变量开启时，替换公共函数。
 if _is_hcu and _use_bolt_recompute_w_u:
     recompute_w_u_fwd = _bolt_recompute_w_u_fwd
 
-# 该别名也必须在完成替换后再赋值。
 fwd_recompute_w_u = recompute_w_u_fwd


### PR DESCRIPTION
## Motivation

在 HCU 环境下，FLA/GDN attention 的 `recompute_w_u` 路径存在进一步优化空间。本 PR 将该重计算操作接入 BoltOPs，在保持默认行为不变的前提下，为 HCU 提供可选的 BoltOPs 加速实现，从而降低推理过程中的算子开销并提升整体推理性能。

该优化通过环境变量控制，仅在 HCU 环境且显式开启 `SGLANG_USE_BOLT_RECOMPUTE_W_U=1` 时生效，不影响其他硬件平台和默认执行路径。

## Modifications

- 在 `wy_fast.py` 中增加 HCU 和环境变量判断。
- 当满足以下条件时，将 `recompute_w_u_fwd` 替换为 BoltOPs 实现：
  - 当前运行环境为 HCU；
  - `SGLANG_USE_BOLT_RECOMPUTE_W_U` 设置为 `1`、`true` 或其他受支持的布尔值。
- 保持 `fwd_recompute_w_u` 与最终生效的 `recompute_w_u_fwd` 指向一致。
- 未开启环境变量时，继续使用原有 Triton 实现。
- 非 HCU 环境不加载 BoltOPs 依赖，不改变原有行为。

## Accuracy Tests
<img width="1196" height="924" alt="image" src="https://github.com/user-attachments/assets/3863b947-bf14-4cba-9417-d68e6c3a06f4" />

## Speed Tests and Profiling
<img width="820" height="640" alt="image" src="https://github.com/user-attachments/assets/c738e6d6-05cd-47f8-9832-c142699354eb" />



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->