### PR TITLE
fix(hcu): sample linear MTP target verification

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -6,6 +6,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 
 from sglang.kernels.ops.speculative.spec_tree import (
     sgl_build_tree_kernel_efficient_triton,
@@ -14,6 +15,7 @@ from sglang.kernels.ops.speculative.spec_tree import (
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_build_dsv4_verify_bundle,
 )
+from sglang.srt.layers.sampler import top_k_top_p_min_p_sampling_from_probs_torch
 from sglang.srt.mem_cache.allocation import alloc_for_spec_decode
 from sglang.srt.mem_cache.allocation_sizing import (
     get_alloc_reserve_per_decode,
@@ -24,6 +26,7 @@ from sglang.srt.runtime_context import get_parallel, get_spec
 from sglang.srt.utils import (
     is_cpu,
     is_cuda,
+    is_hcu,
     is_hip,
     is_musa,
     is_npu,
@@ -42,6 +45,7 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_info import EagleVerifyInput
 
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_musa = is_musa()
@@ -49,6 +53,15 @@ _is_xpu = is_xpu()
 _is_cpu = is_cpu()
 
 logger = logging.getLogger(__name__)
+
+lightop_top_k_top_p_sampling_from_probs = None
+if _is_hcu:
+    try:
+        from lightop.sampling import (
+            top_k_top_p_sampling_from_probs as lightop_top_k_top_p_sampling_from_probs,
+        )
+    except (ImportError, AttributeError):
+        pass
 
 if _is_cuda or _is_hip or _is_musa:
     from sgl_kernel import (
@@ -59,6 +72,60 @@ elif _is_cpu:
         build_tree_kernel_efficient_cpu as sgl_build_tree_kernel_efficient_cpu,
     )
     from sgl_kernel import verify_tree_greedy_cpu as sgl_verify_tree_greedy_cpu
+
+
+def sample_mtp_target_ids(
+    next_token_logits: torch.Tensor,
+    sampling_info: SamplingBatchInfo,
+    draft_token_num: int,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Sample linear MTP target tokens on HCU before tree verification."""
+    expanded_temperature = torch.repeat_interleave(
+        sampling_info.temperatures, draft_token_num, dim=0
+    )
+    target_probs = F.softmax(next_token_logits / expanded_temperature, dim=-1)
+    expanded_top_ks = torch.repeat_interleave(
+        sampling_info.top_ks, draft_token_num, dim=0
+    )
+    expanded_top_ps = torch.repeat_interleave(
+        sampling_info.top_ps, draft_token_num, dim=0
+    )
+
+    # LightOp implements the common top-k-first/top-p path. Keep the PyTorch
+    # path for min-p and request-specific seeds.
+    if (
+        lightop_top_k_top_p_sampling_from_probs is None
+        or sampling_info.sampling_seed is not None
+        or sampling_info.need_min_p_sampling
+    ):
+        expanded_min_ps = torch.repeat_interleave(
+            sampling_info.min_ps, draft_token_num, dim=0
+        )
+        expanded_sampling_seed = (
+            None
+            if sampling_info.sampling_seed is None
+            else torch.repeat_interleave(
+                sampling_info.sampling_seed, draft_token_num, dim=0
+            )
+        )
+        return top_k_top_p_min_p_sampling_from_probs_torch(
+            target_probs,
+            expanded_top_ks,
+            expanded_top_ps,
+            expanded_min_ps,
+            sampling_info.need_min_p_sampling,
+            expanded_sampling_seed,
+            positions,
+        ).to(torch.long)
+
+    return lightop_top_k_top_p_sampling_from_probs(
+        target_probs.contiguous(),
+        expanded_top_ks,
+        expanded_top_ps,
+        filter_apply_order="top_k_first",
+        deterministic=True,
+    ).to(torch.long)
 
 
 def per_step_draft_out_cache_loc(
@@ -725,10 +792,33 @@ def eagle_sample(
     )
     num_correct_drafts = torch.empty((bs,), dtype=torch.int32, device=device)
 
-    # Sample tokens
+    # Sample tokens. HCU has no target-only tree-sampling kernel yet, so for
+    # linear MTP sample the target rows before reusing the greedy tree walk.
+    # This mirrors the target-only kernel's output for topk=1 while retaining
+    # the existing TP rank-0 broadcast below.
+    sampled_target_ids = None
+    if not sampling_info.is_all_greedy and _is_hcu and verify_input.tree_topk == 1:
+        sampled_target_ids = sample_mtp_target_ids(
+            next_token_logits,
+            sampling_info,
+            verify_input.draft_token_num,
+            verify_input.positions,
+        )
+
     target_predict = None
-    if sampling_info.is_all_greedy or _is_cpu or _is_npu or _is_hip or _is_xpu:
-        target_predict = torch.argmax(next_token_logits, dim=-1)
+    if (
+        sampling_info.is_all_greedy
+        or _is_cpu
+        or _is_npu
+        or (_is_hip and not _is_hcu)
+        or _is_xpu
+        or sampled_target_ids is not None
+    ):
+        target_predict = (
+            torch.argmax(next_token_logits, dim=-1)
+            if sampled_target_ids is None
+            else sampled_target_ids
+        )
         target_predict = target_predict.reshape(bs, verify_input.draft_token_num)
         predict, accept_index, num_correct_drafts = verify_tree_greedy_func(
             predicts=predict,  # mutable


### PR DESCRIPTION
## Summary

- Fix linear MTP target-token verification for non-greedy sampling on HCU.
- Preserve request-aware top-k/top-p/min-p and sampling-seed behavior before tree verification.
- Keep existing greedy and non-HCU paths unchanged.

## Testing

- Not run locally; HCU runtime validation is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->