### PR TITLE
fix(hcu): include MLA absorb q kernel in HIP build

### DIFF
--- a/benchmark/kernels/elementwise/benchmark_concat_mla_absorb_q_hcu.py
+++ b/benchmark/kernels/elementwise/benchmark_concat_mla_absorb_q_hcu.py
@@ -1,0 +1,26 @@
+import argparse
+
+import torch
+from sgl_kernel import concat_mla_absorb_q
+
+from sglang.benchmark.bench_utils import run_bench
+
+
+def benchmark(dim_0: int, dim_1: int):
+    q_nope = torch.randn(dim_0, dim_1, 512, device="cuda", dtype=torch.bfloat16)
+    q_rope = torch.randn(dim_0, dim_1, 64, device="cuda", dtype=torch.bfloat16)
+
+    custom_ms, _, _ = run_bench(lambda: concat_mla_absorb_q(q_nope, q_rope))
+    torch_ms, _, _ = run_bench(lambda: torch.cat((q_nope, q_rope), dim=-1))
+    print(
+        f"shape=({dim_0}, {dim_1}) custom={custom_ms:.6f} ms "
+        f"torch={torch_ms:.6f} ms speedup={torch_ms / custom_ms:.2f}x"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dim-0", type=int, default=16)
+    parser.add_argument("--dim-1", type=int, default=128)
+    args = parser.parse_args()
+    benchmark(args.dim_0, args.dim_1)

--- a/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
@@ -42,6 +42,9 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
   m.impl("gelu_and_mul", torch::kCUDA, &gelu_and_mul);
 
+  m.def("concat_mla_absorb_q(Tensor a, Tensor b, Tensor! out) -> ()");
+  m.impl("concat_mla_absorb_q", torch::kCUDA, &concat_mla_absorb_q);
+
   m.def("l2norm(Tensor input, float eps) -> Tensor");
   m.impl("l2norm", torch::kCUDA, &l2norm);
 

--- a/python/sglang/kernels/aot/csrc/elementwise/concat_mla_absorb_q_hcu.cu
+++ b/python/sglang/kernels/aot/csrc/elementwise/concat_mla_absorb_q_hcu.cu
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <hip/hip_runtime.h>
+#include <torch/all.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+constexpr int64_t kALastDim = 512;
+constexpr int64_t kBLastDim = 64;
+constexpr int64_t kOutLastDim = kALastDim + kBLastDim;
+constexpr int64_t kBf16PerVec = 8;
+constexpr int64_t kAVecsPerRow = kALastDim / kBf16PerVec;
+constexpr int64_t kBVecsPerRow = kBLastDim / kBf16PerVec;
+constexpr int kWaveSize = 64;
+constexpr int kThreads = 256;
+constexpr int kWavesPerBlock = kThreads / kWaveSize;
+constexpr int kRowsPerWave = 8;
+constexpr int kRowsPerBlock = kWavesPerBlock * kRowsPerWave;
+
+static_assert(sizeof(uint4) == 16, "uint4 must be a 16-byte vector");
+static_assert(kAVecsPerRow == kWaveSize, "one wave must cover one a row");
+static_assert(kWavesPerBlock == 4, "one block must contain four waves");
+
+__global__ void concat_mla_absorb_q_hcu_kernel(
+    const at::BFloat16* __restrict__ a,
+    const at::BFloat16* __restrict__ b,
+    at::BFloat16* __restrict__ out,
+    int64_t num_rows,
+    int64_t dim_1,
+    int64_t a_stride_0,
+    int64_t a_stride_1,
+    int64_t b_stride_0,
+    int64_t b_stride_1,
+    int64_t out_stride_0,
+    int64_t out_stride_1) {
+  const int lane = threadIdx.x & (kWaveSize - 1);
+  const int wave = threadIdx.x / kWaveSize;
+  const int64_t first_row = static_cast<int64_t>(blockIdx.x) * kRowsPerBlock + wave * kRowsPerWave;
+
+#pragma unroll
+  for (int row_in_wave = 0; row_in_wave < kRowsPerWave; ++row_in_wave) {
+    const int64_t row = first_row + row_in_wave;
+    if (row >= num_rows) return;
+
+    const int64_t idx_0 = row / dim_1;
+    const int64_t idx_1 = row - idx_0 * dim_1;
+    const auto* a_row = a + idx_0 * a_stride_0 + idx_1 * a_stride_1;
+    auto* out_row = out + idx_0 * out_stride_0 + idx_1 * out_stride_1;
+    reinterpret_cast<uint4*>(out_row)[lane] = reinterpret_cast<const uint4*>(a_row)[lane];
+
+    if (lane < kBVecsPerRow) {
+      const auto* b_row = b + idx_0 * b_stride_0 + idx_1 * b_stride_1;
+      reinterpret_cast<uint4*>(out_row)[kAVecsPerRow + lane] = reinterpret_cast<const uint4*>(b_row)[lane];
+    }
+  }
+}
+
+void check_concat_tensor(const at::Tensor& tensor, const char* name, int64_t expected_last_dim) {
+  TORCH_CHECK(tensor.is_cuda(), name, " must be on an HCU device");
+  TORCH_CHECK(tensor.dim() == 3, name, " must be a 3D tensor");
+  TORCH_CHECK(tensor.scalar_type() == at::ScalarType::BFloat16, name, " must have dtype torch.bfloat16");
+  TORCH_CHECK(tensor.size(2) == expected_last_dim, name, ".size(2) must be ", expected_last_dim);
+  TORCH_CHECK(tensor.stride(2) == 1, name, " must be contiguous in its last dimension");
+  TORCH_CHECK(
+      tensor.stride(0) % kBf16PerVec == 0 && tensor.stride(1) % kBf16PerVec == 0,
+      name,
+      " row addresses must be 16-byte aligned");
+  TORCH_CHECK(
+      reinterpret_cast<uintptr_t>(tensor.data_ptr()) % alignof(uint4) == 0,
+      name,
+      " base address must be 16-byte aligned");
+}
+
+}  // namespace
+
+void concat_mla_absorb_q(at::Tensor a, at::Tensor b, at::Tensor out) {
+  check_concat_tensor(a, "a", kALastDim);
+  check_concat_tensor(b, "b", kBLastDim);
+  check_concat_tensor(out, "out", kOutLastDim);
+  TORCH_CHECK(a.device() == b.device() && a.device() == out.device(), "all tensors must be on the same device");
+  TORCH_CHECK(
+      a.size(0) == b.size(0) && a.size(0) == out.size(0) && a.size(1) == b.size(1) && a.size(1) == out.size(1),
+      "a, b, and out leading dimensions must match");
+
+  const int64_t num_rows = a.size(0) * a.size(1);
+  if (num_rows == 0) return;
+
+  const int64_t num_blocks = (num_rows + kRowsPerBlock - 1) / kRowsPerBlock;
+  TORCH_CHECK(num_blocks <= std::numeric_limits<uint32_t>::max(), "concat_mla_absorb_q input is too large");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  concat_mla_absorb_q_hcu_kernel<<<static_cast<uint32_t>(num_blocks), kThreads, 0, stream>>>(
+      static_cast<const at::BFloat16*>(a.data_ptr()),
+      static_cast<const at::BFloat16*>(b.data_ptr()),
+      static_cast<at::BFloat16*>(out.data_ptr()),
+      num_rows,
+      a.size(1),
+      a.stride(0),
+      a.stride(1),
+      b.stride(0),
+      b.stride(1),
+      out.stride(0),
+      out.stride(1));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}

--- a/python/sglang/kernels/aot/setup_hip.py
+++ b/python/sglang/kernels/aot/setup_hip.py
@@ -47,6 +47,7 @@ sources = [
     "csrc/attention/decode_metadata.cu",
     "csrc/common_extension_rocm.cc",
     "csrc/elementwise/activation.cu",
+    "csrc/elementwise/concat_mla_absorb_q_hcu.cu",
     "csrc/elementwise/deepseek_v4_topk.cu",
     "csrc/elementwise/dsv4_norm_rope.cu",
     "csrc/elementwise/l2norm_kernel.cu",

--- a/python/sglang/kernels/aot/setup_rocm.py
+++ b/python/sglang/kernels/aot/setup_rocm.py
@@ -50,6 +50,7 @@ sources = [
     "csrc/attention/decode_metadata.cu",
     "csrc/common_extension_rocm.cc",
     "csrc/elementwise/activation.cu",
+    "csrc/elementwise/concat_mla_absorb_q_hcu.cu",
     "csrc/elementwise/deepseek_v4_topk.cu",
     "csrc/elementwise/dsv4_norm_rope.cu",
     "csrc/elementwise/l2norm_kernel.cu",

--- a/python/sglang/kernels/jit/csrc/elementwise/fused_metadata_copy.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/fused_metadata_copy.cuh
@@ -334,7 +334,7 @@ __global__ void fused_metadata_copy_multi_kernel(const FusedMetadataCopyMultiPar
   }
 
   // Copy real page table to all 3 backends
-  if (src.real_page_table != nullptr && dst0.real_page_table != nullptr) {
+  if constexpr (HAS_REAL_PAGE_TABLE) {
     int real_table_elements = bs * real_page_table_cols;
 #pragma unroll 2
     for (int i = tid; i < real_table_elements; i += total_threads) {
@@ -415,44 +415,38 @@ inline T* unwrap_data_ptr_mut(const tvm::ffi::TensorView& tensor, const char* na
 }
 
 /**
- * Helper function to extract a typed data pointer from an Optional TensorView.
- * Returns nullptr if the optional has no value, otherwise performs type checking.
+ * Helper function to extract a typed data pointer from a TensorView used for an
+ * optional template branch.
  *
  * @tparam T The expected element type (e.g., int32_t)
- * @param optional_tensor The Optional TensorView to extract the pointer from
+ * @param tensor The TensorView to extract the pointer from
  * @param name The name of the tensor (for error reporting)
- * @return Typed pointer to the tensor data, or nullptr if optional has no value
+ * @return Typed pointer to the tensor data
  */
 template <typename T>
-inline const T*
-unwrap_optional_data_ptr(const tvm::ffi::Optional<tvm::ffi::TensorView>& optional_tensor, const char* name) {
+inline const T* unwrap_optional_data_ptr(const tvm::ffi::TensorView& tensor, const char* name) {
   using namespace host;
-  if (!optional_tensor.has_value()) {
-    return nullptr;
+  if (tensor.data_ptr()) {
+    RuntimeCheck(is_type<T>(tensor.dtype()), "Tensor ", name, " must have dtype int32");
   }
-  const auto& tensor = optional_tensor.value();
-  RuntimeCheck(is_type<T>(tensor.dtype()), "Tensor ", name, " must have dtype int32");
   return static_cast<const T*>(tensor.data_ptr());
 }
 
 /**
- * Helper function to extract a typed mutable data pointer from an Optional TensorView.
- * Returns nullptr if the optional has no value, otherwise performs type checking.
+ * Helper function to extract a typed mutable data pointer from a TensorView used
+ * for an optional template branch.
  *
  * @tparam T The expected element type (e.g., int32_t)
- * @param optional_tensor The Optional TensorView to extract the pointer from
+ * @param tensor The TensorView to extract the pointer from
  * @param name The name of the tensor (for error reporting)
- * @return Typed mutable pointer to the tensor data, or nullptr if optional has no value
+ * @return Typed mutable pointer to the tensor data
  */
 template <typename T>
-inline T*
-unwrap_optional_data_ptr_mut(const tvm::ffi::Optional<tvm::ffi::TensorView>& optional_tensor, const char* name) {
+inline T* unwrap_optional_data_ptr_mut(const tvm::ffi::TensorView& tensor, const char* name) {
   using namespace host;
-  if (!optional_tensor.has_value()) {
-    return nullptr;
+  if (tensor.data_ptr()) {
+    RuntimeCheck(is_type<T>(tensor.dtype()), "Tensor ", name, " must have dtype int32");
   }
-  const auto& tensor = optional_tensor.value();
-  RuntimeCheck(is_type<T>(tensor.dtype()), "Tensor ", name, " must have dtype int32");
   return static_cast<T*>(tensor.data_ptr());
 }
 
@@ -498,20 +492,20 @@ struct FusedMetadataCopyKernel {
       const tvm::ffi::TensorView cu_seqlens_k_src,
       const tvm::ffi::TensorView page_indices_src,
       const tvm::ffi::TensorView dsa_cache_seqlens_src,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> seqlens_expanded_src,
+      const tvm::ffi::TensorView seqlens_expanded_src,
       const tvm::ffi::TensorView dsa_cu_seqlens_k_src,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> real_page_table_src,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_num_splits_src,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_metadata_src,
+      const tvm::ffi::TensorView real_page_table_src,
+      const tvm::ffi::TensorView flashmla_num_splits_src,
+      const tvm::ffi::TensorView flashmla_metadata_src,
       const tvm::ffi::TensorView cache_seqlens_dst,
       const tvm::ffi::TensorView cu_seqlens_k_dst,
       const tvm::ffi::TensorView page_table_1_dst,
       const tvm::ffi::TensorView dsa_cache_seqlens_dst,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> seqlens_expanded_dst,
+      const tvm::ffi::TensorView seqlens_expanded_dst,
       const tvm::ffi::TensorView dsa_cu_seqlens_k_dst,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> real_page_table_dst,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_num_splits_dst,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_metadata_dst,
+      const tvm::ffi::TensorView real_page_table_dst,
+      const tvm::ffi::TensorView flashmla_num_splits_dst,
+      const tvm::ffi::TensorView flashmla_metadata_dst,
       int bs,
       int max_len,
       int max_seqlen_k,
@@ -555,18 +549,16 @@ struct FusedMetadataCopyKernel {
         .seqlens_expanded_size = seqlens_expanded_size,
         .page_indices_rows = static_cast<int>(page_indices_src.shape()[0]),
         .page_table_1_stride = static_cast<int>(page_table_1_dst.shape()[1]),
-        .real_page_table_cols =
-            real_page_table_src.has_value() ? static_cast<int>(real_page_table_src.value().shape()[1]) : 0,
-        .real_page_table_dst_stride =
-            real_page_table_dst.has_value() ? static_cast<int>(real_page_table_dst.value().stride(0)) : 0,
-        .flashmla_metadata_size =
-            flashmla_metadata_src.has_value() ? static_cast<int>(flashmla_metadata_src.value().numel()) : 0,
+        .real_page_table_cols = HAS_REAL_PAGE_TABLE ? static_cast<int>(real_page_table_src.shape()[1]) : 0,
+        .real_page_table_dst_stride = HAS_REAL_PAGE_TABLE ? static_cast<int>(real_page_table_dst.stride(0)) : 0,
+        .flashmla_metadata_size = HAS_FLASHMLA ? static_cast<int>(flashmla_metadata_src.numel()) : 0,
     };
 
     // Calculate grid configuration
     int max_elements = std::max(
         {bs,
          params.page_indices_rows * max_seqlen_k,
+         HAS_REAL_PAGE_TABLE ? params.page_indices_rows * params.real_page_table_cols : 0,
          seqlens_expanded_size,
          HAS_FLASHMLA ? (seqlens_expanded_size + 1) : 0,
          HAS_FLASHMLA ? params.flashmla_metadata_size : 0});
@@ -611,33 +603,33 @@ struct FusedMetadataCopyMultiKernel {
       const tvm::ffi::TensorView page_indices_src,
       const tvm::ffi::TensorView dsa_cache_seqlens_src,
       const tvm::ffi::TensorView dsa_cu_seqlens_k_src,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> real_page_table_src,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_num_splits_src,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_metadata_src,
+      const tvm::ffi::TensorView real_page_table_src,
+      const tvm::ffi::TensorView flashmla_num_splits_src,
+      const tvm::ffi::TensorView flashmla_metadata_src,
       const tvm::ffi::TensorView cache_seqlens_dst0,
       const tvm::ffi::TensorView cu_seqlens_k_dst0,
       const tvm::ffi::TensorView page_table_1_dst0,
       const tvm::ffi::TensorView dsa_cache_seqlens_dst0,
       const tvm::ffi::TensorView dsa_cu_seqlens_k_dst0,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> real_page_table_dst0,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_num_splits_dst0,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_metadata_dst0,
+      const tvm::ffi::TensorView real_page_table_dst0,
+      const tvm::ffi::TensorView flashmla_num_splits_dst0,
+      const tvm::ffi::TensorView flashmla_metadata_dst0,
       const tvm::ffi::TensorView cache_seqlens_dst1,
       const tvm::ffi::TensorView cu_seqlens_k_dst1,
       const tvm::ffi::TensorView page_table_1_dst1,
       const tvm::ffi::TensorView dsa_cache_seqlens_dst1,
       const tvm::ffi::TensorView dsa_cu_seqlens_k_dst1,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> real_page_table_dst1,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_num_splits_dst1,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_metadata_dst1,
+      const tvm::ffi::TensorView real_page_table_dst1,
+      const tvm::ffi::TensorView flashmla_num_splits_dst1,
+      const tvm::ffi::TensorView flashmla_metadata_dst1,
       const tvm::ffi::TensorView cache_seqlens_dst2,
       const tvm::ffi::TensorView cu_seqlens_k_dst2,
       const tvm::ffi::TensorView page_table_1_dst2,
       const tvm::ffi::TensorView dsa_cache_seqlens_dst2,
       const tvm::ffi::TensorView dsa_cu_seqlens_k_dst2,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> real_page_table_dst2,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_num_splits_dst2,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> flashmla_metadata_dst2,
+      const tvm::ffi::TensorView real_page_table_dst2,
+      const tvm::ffi::TensorView flashmla_num_splits_dst2,
+      const tvm::ffi::TensorView flashmla_metadata_dst2,
       int bs,
       int max_len,
       int seqlens_expanded_size) {
@@ -705,15 +697,13 @@ struct FusedMetadataCopyMultiKernel {
         .max_len = max_len,
         .seqlens_expanded_size = seqlens_expanded_size,
         .page_table_1_stride = static_cast<int>(page_table_1_dst0.shape()[1]),
-        .real_page_table_cols =
-            real_page_table_src.has_value() ? static_cast<int>(real_page_table_src.value().shape()[1]) : 0,
-        .real_page_table_dst_stride =
-            real_page_table_dst0.has_value() ? static_cast<int>(real_page_table_dst0.value().stride(0)) : 0,
-        .flashmla_metadata_size =
-            flashmla_metadata_src.has_value() ? static_cast<int>(flashmla_metadata_src.value().numel()) : 0,
+        .real_page_table_cols = HAS_REAL_PAGE_TABLE ? static_cast<int>(real_page_table_src.shape()[1]) : 0,
+        .real_page_table_dst_stride = HAS_REAL_PAGE_TABLE ? static_cast<int>(real_page_table_dst0.stride(0)) : 0,
+        .flashmla_metadata_size = HAS_FLASHMLA ? static_cast<int>(flashmla_metadata_src.numel()) : 0,
     };
 
-    dim3 grid = get_launch_config(bs * max_len);
+    int max_elements = std::max(bs * max_len, HAS_REAL_PAGE_TABLE ? bs * params.real_page_table_cols : 0);
+    dim3 grid = get_launch_config(max_elements);
     dim3 block(THREADS_PER_BLOCK);
     DLDevice device = cache_seqlens_src.device();
 

--- a/python/sglang/kernels/ops/attention/fused_metadata_copy.py
+++ b/python/sglang/kernels/ops/attention/fused_metadata_copy.py
@@ -18,6 +18,36 @@ import torch
 from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
 
 logger = logging.getLogger(__name__)
+_DUMMY_OPTIONAL_TENSOR_CACHE: dict[
+    tuple[torch.device, tuple[int, ...]], torch.Tensor
+] = {}
+
+
+def _dummy_optional_tensor_like(ref: torch.Tensor, *shape: int) -> torch.Tensor:
+    key = (ref.device, tuple(shape))
+    dummy = _DUMMY_OPTIONAL_TENSOR_CACHE.get(key)
+    if dummy is None:
+        dummy = torch.empty(shape, dtype=torch.int32, device=ref.device)
+        _DUMMY_OPTIONAL_TENSOR_CACHE[key] = dummy
+    return dummy
+
+
+def _as_optional_tensor(
+    tensor: Optional[torch.Tensor], ref: torch.Tensor, *dummy_shape: int
+) -> torch.Tensor:
+    if tensor is None:
+        return _dummy_optional_tensor_like(ref, *dummy_shape)
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(
+            "Optional fused metadata arguments must be torch.Tensor or None, "
+            f"got {type(tensor).__name__}"
+        )
+    return tensor
+
+
+def _all_or_none(*tensors: Optional[torch.Tensor]) -> bool:
+    present = [tensor is not None for tensor in tensors]
+    return all(present) or not any(present)
 
 
 # ============================================================================
@@ -150,7 +180,25 @@ def fused_metadata_copy_cuda(
         max_seqlen_k: Maximum sequence length for target_verify mode
         seqlens_expanded_size: Size of expanded sequence lengths
     """
-    # Determine template parameters for kernel specialization
+    uses_seqlens_expanded = forward_mode != 0
+    if uses_seqlens_expanded and (
+        seqlens_expanded_src is None or seqlens_expanded_dst is None
+    ):
+        raise ValueError(
+            "seqlens_expanded tensors are required for TARGET_VERIFY/DRAFT_EXTEND"
+        )
+
+    if not _all_or_none(real_page_table_src, real_page_table_dst):
+        raise ValueError("real_page_table source/destination tensors must match")
+    if not _all_or_none(
+        flashmla_num_splits_src,
+        flashmla_metadata_src,
+        flashmla_num_splits_dst,
+        flashmla_metadata_dst,
+    ):
+        raise ValueError("FlashMLA metadata source/destination tensors must match")
+
+    # Determine template parameters for kernel specialization.
     has_real_page_table = real_page_table_src is not None
     has_flashmla = flashmla_num_splits_src is not None
 
@@ -169,26 +217,54 @@ def fused_metadata_copy_cuda(
         seqlens_expanded_src = seqlens_expanded_src.contiguous()
     dsa_cu_seqlens_k_src = dsa_cu_seqlens_k_src.contiguous()
 
-    # Call JIT-compiled kernel (None values are passed as Optional with no value)
+    # tvm-ffi 0.1.x does not reliably convert Python None to TensorView
+    # arguments on every backend. Disabled template branches receive tiny
+    # int32 tensors that are never read.
+    real_page_table_src_arg = _as_optional_tensor(
+        real_page_table_src, cache_seqlens_src, 1, 1
+    )
+    real_page_table_dst_arg = _as_optional_tensor(
+        real_page_table_dst, cache_seqlens_dst, 1, 1
+    )
+    flashmla_num_splits_src_arg = _as_optional_tensor(
+        flashmla_num_splits_src, cache_seqlens_src, 1
+    )
+    flashmla_num_splits_dst_arg = _as_optional_tensor(
+        flashmla_num_splits_dst, cache_seqlens_dst, 1
+    )
+    flashmla_metadata_src_arg = _as_optional_tensor(
+        flashmla_metadata_src, cache_seqlens_src, 1
+    )
+    flashmla_metadata_dst_arg = _as_optional_tensor(
+        flashmla_metadata_dst, cache_seqlens_dst, 1
+    )
+    seqlens_expanded_src_arg = _as_optional_tensor(
+        seqlens_expanded_src, cache_seqlens_src, 1
+    )
+    seqlens_expanded_dst_arg = _as_optional_tensor(
+        seqlens_expanded_dst, cache_seqlens_dst, 1
+    )
+
+    # Call JIT-compiled kernel.
     module.fused_metadata_copy(
         cache_seqlens_src,
         cu_seqlens_k_src,
         page_indices_src,
         dsa_cache_seqlens_src,
-        seqlens_expanded_src,
+        seqlens_expanded_src_arg,
         dsa_cu_seqlens_k_src,
-        real_page_table_src,
-        flashmla_num_splits_src,
-        flashmla_metadata_src,
+        real_page_table_src_arg,
+        flashmla_num_splits_src_arg,
+        flashmla_metadata_src_arg,
         cache_seqlens_dst,
         cu_seqlens_k_dst,
         page_table_1_dst,
         dsa_cache_seqlens_dst,
-        seqlens_expanded_dst,
+        seqlens_expanded_dst_arg,
         dsa_cu_seqlens_k_dst,
-        real_page_table_dst,
-        flashmla_num_splits_dst,
-        flashmla_metadata_dst,
+        real_page_table_dst_arg,
+        flashmla_num_splits_dst_arg,
+        flashmla_metadata_dst_arg,
         bs,
         max_len,
         max_seqlen_k,
@@ -261,7 +337,28 @@ def fused_metadata_copy_multi_cuda(
         max_len: Maximum length for decode mode
         seqlens_expanded_size: Size of expanded sequence lengths
     """
-    # Determine template parameters for kernel specialization
+    real_page_table_tensors = (
+        real_page_table_src,
+        real_page_table_dst0,
+        real_page_table_dst1,
+        real_page_table_dst2,
+    )
+    flashmla_tensors = (
+        flashmla_num_splits_src,
+        flashmla_metadata_src,
+        flashmla_num_splits_dst0,
+        flashmla_metadata_dst0,
+        flashmla_num_splits_dst1,
+        flashmla_metadata_dst1,
+        flashmla_num_splits_dst2,
+        flashmla_metadata_dst2,
+    )
+    if not _all_or_none(*real_page_table_tensors):
+        raise ValueError("real_page_table source/destination tensors must match")
+    if not _all_or_none(*flashmla_tensors):
+        raise ValueError("FlashMLA metadata source/destination tensors must match")
+
+    # Determine template parameters for kernel specialization.
     has_real_page_table = real_page_table_src is not None
     has_flashmla = flashmla_num_splits_src is not None
 
@@ -276,40 +373,77 @@ def fused_metadata_copy_multi_cuda(
     dsa_cache_seqlens_src = dsa_cache_seqlens_src.contiguous()
     dsa_cu_seqlens_k_src = dsa_cu_seqlens_k_src.contiguous()
 
-    # Call JIT-compiled kernel (None values are passed as Optional with no value)
+    real_page_table_src_arg = _as_optional_tensor(
+        real_page_table_src, cache_seqlens_src, 1, 1
+    )
+    flashmla_num_splits_src_arg = _as_optional_tensor(
+        flashmla_num_splits_src, cache_seqlens_src, 1
+    )
+    flashmla_metadata_src_arg = _as_optional_tensor(
+        flashmla_metadata_src, cache_seqlens_src, 1
+    )
+    real_page_table_dst0_arg = _as_optional_tensor(
+        real_page_table_dst0, cache_seqlens_dst0, 1, 1
+    )
+    flashmla_num_splits_dst0_arg = _as_optional_tensor(
+        flashmla_num_splits_dst0, cache_seqlens_dst0, 1
+    )
+    flashmla_metadata_dst0_arg = _as_optional_tensor(
+        flashmla_metadata_dst0, cache_seqlens_dst0, 1
+    )
+    real_page_table_dst1_arg = _as_optional_tensor(
+        real_page_table_dst1, cache_seqlens_dst1, 1, 1
+    )
+    flashmla_num_splits_dst1_arg = _as_optional_tensor(
+        flashmla_num_splits_dst1, cache_seqlens_dst1, 1
+    )
+    flashmla_metadata_dst1_arg = _as_optional_tensor(
+        flashmla_metadata_dst1, cache_seqlens_dst1, 1
+    )
+    real_page_table_dst2_arg = _as_optional_tensor(
+        real_page_table_dst2, cache_seqlens_dst2, 1, 1
+    )
+    flashmla_num_splits_dst2_arg = _as_optional_tensor(
+        flashmla_num_splits_dst2, cache_seqlens_dst2, 1
+    )
+    flashmla_metadata_dst2_arg = _as_optional_tensor(
+        flashmla_metadata_dst2, cache_seqlens_dst2, 1
+    )
+
+    # Call JIT-compiled kernel.
     module.fused_metadata_copy_multi(
         cache_seqlens_src,
         cu_seqlens_k_src,
         page_indices_src,
         dsa_cache_seqlens_src,
         dsa_cu_seqlens_k_src,
-        real_page_table_src,
-        flashmla_num_splits_src,
-        flashmla_metadata_src,
+        real_page_table_src_arg,
+        flashmla_num_splits_src_arg,
+        flashmla_metadata_src_arg,
         cache_seqlens_dst0,
         cu_seqlens_k_dst0,
         page_table_1_dst0,
         dsa_cache_seqlens_dst0,
         dsa_cu_seqlens_k_dst0,
-        real_page_table_dst0,
-        flashmla_num_splits_dst0,
-        flashmla_metadata_dst0,
+        real_page_table_dst0_arg,
+        flashmla_num_splits_dst0_arg,
+        flashmla_metadata_dst0_arg,
         cache_seqlens_dst1,
         cu_seqlens_k_dst1,
         page_table_1_dst1,
         dsa_cache_seqlens_dst1,
         dsa_cu_seqlens_k_dst1,
-        real_page_table_dst1,
-        flashmla_num_splits_dst1,
-        flashmla_metadata_dst1,
+        real_page_table_dst1_arg,
+        flashmla_num_splits_dst1_arg,
+        flashmla_metadata_dst1_arg,
         cache_seqlens_dst2,
         cu_seqlens_k_dst2,
         page_table_1_dst2,
         dsa_cache_seqlens_dst2,
         dsa_cu_seqlens_k_dst2,
-        real_page_table_dst2,
-        flashmla_num_splits_dst2,
-        flashmla_metadata_dst2,
+        real_page_table_dst2_arg,
+        flashmla_num_splits_dst2_arg,
+        flashmla_metadata_dst2_arg,
         bs,
         max_len,
         seqlens_expanded_size,

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -51,12 +51,18 @@ from sglang.kernels.ops.kvcache.kv_indices import (
 from sglang.kernels.ops.kvcache.rope_cache import (
     fused_qk_rope_reshape_and_cache as fused_qk_rope_reshape_and_cache,
 )
-from sglang.srt.utils import is_cuda
+from sglang.srt.environ import envs
+from sglang.srt.utils import is_cuda, is_hcu
 
 _is_cuda = is_cuda()
+_use_hcu_concat_mla_absorb_q = (
+    is_hcu() and envs.SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q.get()
+)
 
 if _is_cuda:
     from sglang.kernels.ops.attention.concat_mla import concat_mla_absorb_q
+elif _use_hcu_concat_mla_absorb_q:
+    from sgl_kernel import concat_mla_absorb_q
 
 
 # When num_kv_heads=1, we have tensors with degenerate strides,
@@ -193,10 +199,22 @@ def mla_quantize_without_rope_for_fp8(
 
 
 def concat_mla_absorb_q_general(q_nope, q_rope):
-    if _is_cuda and q_nope.shape[-1] == 512 and q_rope.shape[-1] == 64:
+    can_use_custom_op = (
+        (_is_cuda or _use_hcu_concat_mla_absorb_q)
+        and q_nope.ndim == q_rope.ndim == 3
+        and q_nope.shape[:-1] == q_rope.shape[:-1]
+        and (q_nope.shape[-1], q_rope.shape[-1]) == (512, 64)
+        and q_nope.dtype == q_rope.dtype == torch.bfloat16
+        and q_nope.is_cuda
+        and q_rope.is_cuda
+        and q_nope.device == q_rope.device
+        and q_nope.stride(-1) == q_rope.stride(-1) == 1
+        and all(stride % 8 == 0 for stride in q_nope.stride()[:-1])
+        and all(stride % 8 == 0 for stride in q_rope.stride()[:-1])
+    )
+    if can_use_custom_op:
         return concat_mla_absorb_q(q_nope, q_rope)
-    else:
-        return torch.cat([q_nope, q_rope], dim=-1)
+    return torch.cat([q_nope, q_rope], dim=-1)
 
 
 @triton.jit

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -671,7 +671,6 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
                 model,
                 positive,
                 device=device,
-                shared_conditioning=emb,
             )
             _precompute_rope_cache(
                 model,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -36,6 +36,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     VerificationResult,
 )
 from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.srt.utils import is_hcu
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.nvtx_pytorch_hooks import maybe_nvtx_range
@@ -620,8 +621,12 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
 
         ctx = _resolve_full_loop_context(batch)
 
-        if not (current_platform.is_cuda() or current_platform.is_mps()):
-            raise RuntimeError("MiniMax H3 full-loop denoise requires CUDA or MPS")
+        if not (
+            current_platform.is_cuda() or is_hcu() or current_platform.is_mps()
+        ):
+            raise RuntimeError(
+                "MiniMax H3 full-loop denoise requires CUDA, HCU, or MPS"
+            )
         device = current_platform.get_local_torch_device()
         sigmas_video = [float(v) for v in ctx.sigmas["video"]]
         self._maybe_enable_cache_dit_and_torch_compile(

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -245,6 +245,24 @@ def dsa_layer_skips_topk(config: PretrainedConfig, layer_id: int) -> bool:
     return max(layer_id - 1, 0) % freq != 0
 
 
+def get_dsa_full_indexer_layer_ids(
+    config: PretrainedConfig,
+    start_layer: int = 0,
+    end_layer: Optional[int] = None,
+) -> List[int]:
+    """Return DSA layers that run an indexer instead of reusing top-k."""
+    if end_layer is None:
+        end_layer = config.num_hidden_layers
+    assert 0 <= start_layer <= end_layer
+    if not is_deepseek_dsa(config):
+        return list(range(start_layer, end_layer))
+    return [
+        layer_id
+        for layer_id in range(start_layer, end_layer)
+        if not dsa_layer_skips_topk(config, layer_id)
+    ]
+
+
 def get_dsa_index_n_heads(config: PretrainedConfig) -> int:
     assert is_deepseek_dsa(config)
     return config.index_n_heads

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -58,6 +58,9 @@ class KVArgs:
     state_data_ptrs: List[List[int]]
     state_data_lens: List[List[int]]
     state_item_lens: List[List[int]]
+    # Transfer ABI identifier parallel to state_types. It distinguishes state
+    # layouts that have the same item size but different byte semantics.
+    state_data_formats: List[str]
     state_layer_ids: List[List[int]]
     # Per-tensor TP slice dim, used when prefill/decode attn_tp_size differ.
     state_dim_per_tensor: List[List[int]]

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -30,7 +30,11 @@ import torch.distributed as dist
 import zmq
 from aiohttp import web
 
-from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.configs.model_config import (
+    ModelConfig,
+    get_dsa_full_indexer_layer_ids,
+    is_deepseek_dsa,
+)
 from sglang.srt.disaggregation.base.conn import (
     BaseKVBootstrapServer,
     BaseKVManager,
@@ -1180,6 +1184,53 @@ class CommonKVManager(BaseKVManager):
         # Fast path: both sides use exactly the same PP layout
         if len(src_kv_ptrs) == len(dst_kv_ptrs):
             return src_kv_ptrs, dst_kv_ptrs, len(src_kv_ptrs)
+
+        if state_type == StateType.DSA:
+            hf_config = getattr(self.model_config, "hf_config", None)
+            if hf_config is not None and is_deepseek_dsa(hf_config):
+                end_layer = self.kv_args.prefill_end_layer
+                if end_layer is None:
+                    raise ValueError(
+                        "prefill_end_layer is required for compact DSA state transfer"
+                    )
+
+                compact_indexer_layer_ids = get_dsa_full_indexer_layer_ids(hf_config)
+                total_layers = hf_config.num_hidden_layers
+                # HiCache/HiSparse deliberately retain the dense main layout.
+                # Infer the decode registration layout from its pointer count;
+                # compact GLM layouts are smaller than num_hidden_layers.
+                indexer_layer_ids = (
+                    list(range(total_layers))
+                    if len(dst_kv_ptrs) >= total_layers
+                    else compact_indexer_layer_ids
+                )
+                start_index = sum(
+                    layer_id < self.kv_args.prefill_start_layer
+                    for layer_id in indexer_layer_ids
+                )
+                end_index = sum(
+                    layer_id < end_layer for layer_id in indexer_layer_ids
+                )
+                src_main_layers = end_index - start_index
+                src_draft_layers = len(src_kv_ptrs) - src_main_layers
+                if src_draft_layers < 0:
+                    raise ValueError(
+                        "DSA PP state pointer count is smaller than the number of "
+                        "full-indexer layers in this stage"
+                    )
+
+                sliced_dst_kv_ptrs = list(dst_kv_ptrs[start_index:end_index])
+                if src_draft_layers:
+                    draft_start = len(indexer_layer_ids)
+                    sliced_dst_kv_ptrs.extend(
+                        dst_kv_ptrs[draft_start : draft_start + src_draft_layers]
+                    )
+                if len(sliced_dst_kv_ptrs) != len(src_kv_ptrs):
+                    raise ValueError(
+                        "DSA PP state pointer mismatch after compact indexer mapping: "
+                        f"src={len(src_kv_ptrs)}, dst={len(sliced_dst_kv_ptrs)}"
+                    )
+                return src_kv_ptrs, sliced_dst_kv_ptrs, len(src_kv_ptrs)
 
         mla_ratios = getattr(self.kv_args, "mla_compression_ratios", None)
         if mla_ratios:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -469,9 +469,7 @@ class CommonKVManager(BaseKVManager):
     ) -> None:
         """Validate request-state page layouts advertised by a decode peer."""
         state_types = getattr(self.kv_args, "state_types", []) or []
-        src_state_data_formats = (
-            getattr(self.kv_args, "state_data_formats", []) or []
-        )
+        src_state_data_formats = getattr(self.kv_args, "state_data_formats", []) or []
         src_state_item_lens = getattr(self.kv_args, "state_item_lens", []) or []
 
         for i, state_type in enumerate(state_types):
@@ -1272,9 +1270,7 @@ class CommonKVManager(BaseKVManager):
                     layer_id < self.kv_args.prefill_start_layer
                     for layer_id in indexer_layer_ids
                 )
-                end_index = sum(
-                    layer_id < end_layer for layer_id in indexer_layer_ids
-                )
+                end_index = sum(layer_id < end_layer for layer_id in indexer_layer_ids)
                 src_main_layers = end_index - start_index
                 src_draft_layers = len(src_kv_ptrs) - src_main_layers
                 if src_draft_layers < 0:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -71,6 +71,35 @@ from sglang.srt.utils.network import (
 logger = logging.getLogger(__name__)
 
 
+def validate_dsa_state_transfer_abi(
+    src_format: str,
+    dst_format: str,
+    src_item_lens: List[int],
+    dst_item_lens: List[int],
+) -> None:
+    """Validate the page ABI before transferring a DSA index-K cache."""
+    if src_format != dst_format:
+        raise RuntimeError(
+            "DSA index-K cache transfer ABI mismatch between prefill and decode: "
+            f"prefill_format={src_format!r}, decode_format={dst_format!r}. "
+            "Ensure P and D use the same SGLANG_DSA_HCU_INT8_INDEX_K_CACHE "
+            "setting, page size, model, and SGLang revision."
+        )
+
+    src_sizes = {int(item_len) for item_len in src_item_lens}
+    dst_sizes = {int(item_len) for item_len in dst_item_lens}
+    if len(src_sizes) == 1 and src_sizes == dst_sizes:
+        return
+
+    raise RuntimeError(
+        "DSA index-K cache page layout mismatch between prefill and decode: "
+        f"prefill_item_lens={sorted(src_sizes)}, "
+        f"decode_item_lens={sorted(dst_sizes)}. Ensure P and D use the same "
+        "SGLANG_DSA_HCU_INT8_INDEX_K_CACHE setting, page size, model, and "
+        "SGLang revision."
+    )
+
+
 # Reuse a keep-alive session per bootstrap_addr for decode-side bootstrap queries
 # so we don't open a fresh TCP connection per query (that churns short-lived
 # sockets and can exhaust ephemeral ports under high concurrency). Thread-local
@@ -432,6 +461,41 @@ class CommonKVManager(BaseKVManager):
         room Failed FIRST -- registering while it still accepts chunks lets the
         worker ack, then a new chunk writes pages the decode already released."""
         self._deferred_ack_targets[room] = (decode_ip, decode_port)
+
+    def validate_remote_state_transfer_abis(
+        self,
+        dst_state_data_formats: List[str],
+        dst_state_item_lens: List[List[int]],
+    ) -> None:
+        """Validate request-state page layouts advertised by a decode peer."""
+        state_types = getattr(self.kv_args, "state_types", []) or []
+        src_state_data_formats = (
+            getattr(self.kv_args, "state_data_formats", []) or []
+        )
+        src_state_item_lens = getattr(self.kv_args, "state_item_lens", []) or []
+
+        for i, state_type in enumerate(state_types):
+            if state_type != StateType.DSA:
+                continue
+
+            src_format = (
+                src_state_data_formats[i] if i < len(src_state_data_formats) else ""
+            )
+            dst_format = (
+                dst_state_data_formats[i] if i < len(dst_state_data_formats) else ""
+            )
+            src_item_lens = (
+                src_state_item_lens[i] if i < len(src_state_item_lens) else []
+            )
+            dst_item_lens = (
+                dst_state_item_lens[i] if i < len(dst_state_item_lens) else []
+            )
+            validate_dsa_state_transfer_abi(
+                src_format,
+                dst_format,
+                src_item_lens,
+                dst_item_lens,
+            )
 
     def get_kv_replica_factor(self) -> int:
         if self._kv_replica_factor is None:

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -67,6 +67,14 @@ def unpack_int_lists(buf: bytes, fmt: str) -> List[List[int]]:
     ]
 
 
+def pack_string_list(values: List[str]) -> bytes:
+    return pack_list_of_buffers([value.encode("utf-8") for value in values])
+
+
+def unpack_string_list(buf: bytes) -> List[str]:
+    return [value.decode("utf-8") for value in unpack_list_of_buffers(buf)]
+
+
 class FastQueue:
     def __init__(self):
         self._buf = deque()

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -512,6 +512,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             transfer_kv_pool.get_contiguous_buf_infos()
         )
+        has_kv_layer_ids = hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
+        kv_layer_ids = (
+            self.token_to_kv_pool.get_kv_layer_ids() if has_kv_layer_ids else []
+        )
         kv_data_mem_kinds = (
             ["DRAM"] * len(kv_data_ptrs)
             if self.scheduler.enable_hisparse
@@ -538,16 +542,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
             kv_data_mem_kinds += ["VRAM"] * len(draft_kv_data_ptrs)
+            if has_kv_layer_ids:
+                target_layer_num = self.scheduler.model_config.num_hidden_layers
+                kv_layer_ids += [
+                    target_layer_num + i for i in range(len(draft_kv_data_ptrs))
+                ]
 
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
-        )
+        kv_args.kv_layer_ids = kv_layer_ids
         if self.transfer_backend == TransferBackend.NIXL:
             kv_args.kv_data_mem_kinds = kv_data_mem_kinds
         kv_args.page_size = self.token_to_kv_pool.page_size

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1391,6 +1391,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
                         state_type=st,
+                        src_layer_ids=src_state_layer_ids,
+                        dst_layer_ids=dst_state_layer_ids,
                     )
                     or rc
                 )

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -184,9 +184,7 @@ class KVArgsRegisterInfo:
                 else []
             ),
             dst_state_data_formats=(
-                unpack_string_list(msg[18])
-                if len(msg) > 18 and msg[18] != b""
-                else []
+                unpack_string_list(msg[18]) if len(msg) > 18 and msg[18] != b"" else []
             ),
             staging_base_ptr=(
                 struct.unpack("Q", msg[14])[0]

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -39,7 +39,9 @@ from sglang.srt.disaggregation.common.utils import (
     build_dcp_token_transfer_plan,
     group_concurrent_contiguous,
     pack_int_lists,
+    pack_string_list,
     unpack_int_lists,
+    unpack_string_list,
 )
 from sglang.srt.disaggregation.mooncake.utils import (
     check_mooncake_custom_mem_pool_enabled,
@@ -142,6 +144,9 @@ class KVArgsRegisterInfo:
     dst_state_dim_per_tensor: List[List[int]]
     dst_kv_layer_ids: List[int]
     dst_state_layer_ids: List[List[int]]
+    dst_state_data_formats: List[str] = dataclasses.field(default_factory=list)
+    # Local-only validation result; this is never serialized on the wire.
+    registration_error: Optional[str] = dataclasses.field(default=None, repr=False)
     dst_dcp_size: int = 1
     dst_dcp_rank: int = 0
     requires_dcp_relayout: bool = False
@@ -176,6 +181,11 @@ class KVArgsRegisterInfo:
             dst_state_layer_ids=(
                 unpack_int_lists(msg[13], "I")
                 if len(msg) > 13 and msg[13] != b""
+                else []
+            ),
+            dst_state_data_formats=(
+                unpack_string_list(msg[18])
+                if len(msg) > 18 and msg[18] != b""
                 else []
             ),
             staging_base_ptr=(
@@ -1626,25 +1636,75 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         self._maybe_ack_drained_abort(kv_chunk.room)
                     continue
 
-                if (
-                    self.enable_staging
-                    and staging_strategy is None
-                    and staging_buffer is not None
-                ):
-                    staging_strategy = self._try_create_staging_strategy(staging_buffer)
-                reqs_to_be_processed = (
+                reqs_to_be_processed = list(
                     self.transfer_infos[kv_chunk.room].values()
                     if kv_chunk.room in self.transfer_infos
                     else []
                 )
-                polls = []
-                dst_ranks_infos = []
                 # Unique id per prefill sender so decode's response set size matches expected_response_num.
                 prefill_unique_rank = (
                     self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
                     + self.pp_rank * self.attn_cp_size
                     + self.attn_cp_rank
                 )
+
+                registration_error = None
+                for req in reqs_to_be_processed:
+                    if req.is_dummy:
+                        continue
+                    registration_info = self.decode_kv_args_table.get(
+                        req.mooncake_session_id
+                    )
+                    if registration_info is None:
+                        registration_error = (
+                            "Decode peer registration is missing for Mooncake "
+                            f"session {req.mooncake_session_id!r}"
+                        )
+                        break
+                    if registration_info.registration_error is not None:
+                        registration_error = (
+                            f"Decode peer {req.mooncake_session_id!r} is "
+                            f"incompatible: {registration_info.registration_error}"
+                        )
+                        break
+
+                if registration_error is not None:
+                    logger.error(
+                        "Rejecting PD transfer for room %s: %s",
+                        kv_chunk.room,
+                        registration_error,
+                    )
+                    self.record_failure(kv_chunk.room, registration_error)
+                    self.update_status(kv_chunk.room, KVPoll.Failed)
+                    for req in reqs_to_be_processed:
+                        if not req.is_dummy:
+                            self.sync_status_to_decode_endpoint(
+                                req.endpoint,
+                                req.dst_port,
+                                req.room,
+                                KVPoll.Failed,
+                                prefill_unique_rank,
+                            )
+                    if self.enable_trace:
+                        kv_chunk.trace_ctx.trace_slice_end(
+                            MooncakeRequestStage.MOONCAKE_WORKER_SEND.stage_name,
+                            MooncakeRequestStage.MOONCAKE_WORKER_SEND.level,
+                            thread_finish_flag=True,
+                        )
+                    self._staging_outstanding[kv_chunk.room] -= 1
+                    if self._staging_outstanding[kv_chunk.room] <= 0:
+                        self._staging_outstanding.pop(kv_chunk.room, None)
+                    if self.enable_deferred_decode_kv_release:
+                        self._maybe_ack_drained_abort(kv_chunk.room)
+                    continue
+                if (
+                    self.enable_staging
+                    and staging_strategy is None
+                    and staging_buffer is not None
+                ):
+                    staging_strategy = self._try_create_staging_strategy(staging_buffer)
+                polls = []
+                dst_ranks_infos = []
                 # When staging transfer is not yet ready (watermark/allocation pending),
                 # the chunk is re-enqueued and we break out of the req loop to retry later.
                 staging_deferred = False
@@ -2015,6 +2075,18 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 mooncake_session_id = waiting_req_bytes[3].decode("ascii")
                 if room == "None":
                     decode_kv_args = KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
+                    try:
+                        self.validate_remote_state_transfer_abis(
+                            decode_kv_args.dst_state_data_formats,
+                            decode_kv_args.dst_state_item_lens,
+                        )
+                    except RuntimeError as error:
+                        decode_kv_args.registration_error = str(error)
+                        logger.error(
+                            "Decode peer %s registered an incompatible state ABI: %s",
+                            mooncake_session_id,
+                            error,
+                        )
                     decode_kv_args.requires_dcp_relayout = self.requires_dcp_relayout(
                         decode_kv_args.dst_dcp_size,
                         decode_kv_args.dst_dcp_rank,
@@ -2033,7 +2105,13 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         if mooncake_session_id in self.session_failures:
                             del self.session_failures[mooncake_session_id]
                     logger.debug(
-                        f"Register KVArgs from {mooncake_session_id} successfully"
+                        "Registered KVArgs from %s%s",
+                        mooncake_session_id,
+                        (
+                            " with an incompatible state ABI"
+                            if decode_kv_args.registration_error is not None
+                            else " successfully"
+                        ),
                     )
                     continue
                 else:
@@ -2391,6 +2469,9 @@ class MooncakeKVReceiver(MooncakeFailureExceptionMixin, CommonKVReceiver):
             packed_state_dim_per_tensor = pack_int_lists(
                 getattr(self.kv_mgr.kv_args, "state_dim_per_tensor", []) or [], "I"
             )
+            packed_state_data_formats = pack_string_list(
+                getattr(self.kv_mgr.kv_args, "state_data_formats", []) or []
+            )
             packed_state_layer_ids = pack_int_lists(
                 self.kv_mgr.kv_args.state_layer_ids, "I"
             )
@@ -2446,6 +2527,7 @@ class MooncakeKVReceiver(MooncakeFailureExceptionMixin, CommonKVReceiver):
                             staging_total_size_str,
                             dst_dcp_size,
                             dst_dcp_rank,
+                            packed_state_data_formats,
                         ]
                     )
             except zmq.ZMQError:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -238,6 +238,10 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
+        has_kv_layer_ids = hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
+        kv_layer_ids = (
+            self.token_to_kv_pool.get_kv_layer_ids() if has_kv_layer_ids else []
+        )
         kv_args.prefill_end_layer = (
             kv_args.prefill_start_layer + len(kv_data_ptrs)
             if layer_shard_enabled
@@ -253,16 +257,16 @@ class PrefillBootstrapQueue:
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
+            if has_kv_layer_ids:
+                target_layer_num = self.scheduler.model_config.num_hidden_layers
+                kv_layer_ids += [
+                    target_layer_num + i for i in range(len(draft_kv_data_ptrs))
+                ]
 
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
-        )
+        kv_args.kv_layer_ids = kv_layer_ids
         if not self.is_mla_backend:
             kv_args.kv_head_num = self.token_to_kv_pool.head_num
             kv_args.total_kv_head_num = (

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1116,7 +1116,7 @@ def setup_state_kv_args(
                     len(kv_args.kv_data_ptrs) // token_to_kv_pool.layer_num
                 )
                 kv_args.total_kv_layers = total_kv_layers
-            else:
+            elif data_ptrs:
                 append_state_component(
                     kv_args, StateType.DSA, data_ptrs, data_lens, item_lens
                 )

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1108,6 +1108,10 @@ def setup_state_kv_args(
                 if isinstance(token_to_kv_pool, DSATokenToKVPool)
                 else ""
             )
+            has_state_layer_ids = hasattr(token_to_kv_pool, "get_state_layer_ids")
+            state_layer_ids = (
+                token_to_kv_pool.get_state_layer_ids() if has_state_layer_ids else []
+            )
             if draft_token_to_kv_pool is not None and isinstance(
                 draft_token_to_kv_pool, DSATokenToKVPool
             ):
@@ -1119,6 +1123,14 @@ def setup_state_kv_args(
                 data_ptrs = data_ptrs + draft_data_ptrs
                 data_lens = data_lens + draft_data_lens
                 item_lens = item_lens + draft_item_lens
+                if has_state_layer_ids:
+                    if total_kv_layers is None:
+                        raise ValueError(
+                            "total_kv_layers is required for DSA draft state metadata"
+                        )
+                    state_layer_ids += [
+                        total_kv_layers + i for i in range(len(draft_data_ptrs))
+                    ]
                 draft_data_format = (
                     draft_token_to_kv_pool.get_index_k_cache_transfer_abi()
                 )
@@ -1139,6 +1151,7 @@ def setup_state_kv_args(
                     data_ptrs,
                     data_lens,
                     item_lens,
+                    layer_ids=state_layer_ids,
                     data_format=data_format,
                 )
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -950,6 +950,7 @@ def append_state_component(
     conv_shard_groups: Optional[List[Optional[List[int]]]] = None,
     slice_outer_counts: Optional[List[int]] = None,
     layer_ids: Optional[List[int]] = None,
+    data_format: str = "",
 ) -> None:
     """Append one state component. Caller orders state_types consistently
     on prefill and decode sides."""
@@ -957,6 +958,7 @@ def append_state_component(
     kv_args.state_data_ptrs.append(data_ptrs)
     kv_args.state_data_lens.append(data_lens)
     kv_args.state_item_lens.append(item_lens)
+    kv_args.state_data_formats.append(data_format)
     kv_args.state_dim_per_tensor.append(dim_per_tensor or [])
     kv_args.state_conv_shard_groups.append(conv_shard_groups or [])
     kv_args.state_slice_outer_counts.append(slice_outer_counts or [])
@@ -990,6 +992,7 @@ def setup_state_kv_args(
     kv_args.state_data_ptrs = []
     kv_args.state_data_lens = []
     kv_args.state_item_lens = []
+    kv_args.state_data_formats = []
     kv_args.state_dim_per_tensor = []
     kv_args.state_slice_outer_counts = []
     kv_args.state_layer_ids = []
@@ -1100,6 +1103,11 @@ def setup_state_kv_args(
                 layer_ids,
             )
         elif isinstance(token_to_kv_pool, (DSATokenToKVPool, NPUMLATokenToKVPool)):
+            data_format = (
+                token_to_kv_pool.get_index_k_cache_transfer_abi()
+                if isinstance(token_to_kv_pool, DSATokenToKVPool)
+                else ""
+            )
             if draft_token_to_kv_pool is not None and isinstance(
                 draft_token_to_kv_pool, DSATokenToKVPool
             ):
@@ -1111,6 +1119,14 @@ def setup_state_kv_args(
                 data_ptrs = data_ptrs + draft_data_ptrs
                 data_lens = data_lens + draft_data_lens
                 item_lens = item_lens + draft_item_lens
+                draft_data_format = (
+                    draft_token_to_kv_pool.get_index_k_cache_transfer_abi()
+                )
+                if draft_data_format != data_format:
+                    raise ValueError(
+                        "Target and draft DSA index-K cache transfer ABIs differ: "
+                        f"target={data_format!r}, draft={draft_data_format!r}"
+                    )
             if isinstance(token_to_kv_pool, NPUMLATokenToKVPool):
                 kv_args.kv_buf_groups = (
                     len(kv_args.kv_data_ptrs) // token_to_kv_pool.layer_num
@@ -1118,7 +1134,12 @@ def setup_state_kv_args(
                 kv_args.total_kv_layers = total_kv_layers
             elif data_ptrs:
                 append_state_component(
-                    kv_args, StateType.DSA, data_ptrs, data_lens, item_lens
+                    kv_args,
+                    StateType.DSA,
+                    data_ptrs,
+                    data_lens,
+                    item_lens,
+                    data_format=data_format,
                 )
 
     if is_npu() and isinstance(token_to_kv_pool, DSV4NPUTokenToKVPool):

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1484,6 +1484,10 @@ class Envs:
         False, deprecated_name="SGLANG_NSA_HIP_DISABLE_PRESHUFFLE"
     )
     SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
+    # Paired gfx938 LightOp sparse Page-MQA and mask-aware paged TopK.
+    SGLANG_DSA_HCU_LIGHTOP_MASK_TOPK = EnvBoolWithAlias(
+        False, deprecated_name="SGLANG_USE_LIGHTOP_MASK_TOPK"
+    )
     # Opt-in HCU AOT kernel for concatenating absorbed MLA Q components.
     SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q = EnvBool(False)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1491,6 +1491,10 @@ class Envs:
     SGLANG_DSA_HCU_REUSE_SORTED_TOPK = EnvBoolWithAlias(
         False, deprecated_name="SGLANG_NSA_HCU_REUSE_SORTED_TOPK"
     )
+    # gfx936-only: page-planar INT8 K plus one FP32 scale per token.
+    SGLANG_DSA_HCU_INT8_INDEX_K_CACHE = EnvBoolWithAlias(
+        False, deprecated_name="SGLANG_NSA_HCU_INT8_INDEX_K_CACHE"
+    )
     # Opt-in HCU AOT kernel for concatenating absorbed MLA Q components.
     SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q = EnvBool(False)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1488,6 +1488,9 @@ class Envs:
     SGLANG_DSA_HCU_LIGHTOP_MASK_TOPK = EnvBoolWithAlias(
         False, deprecated_name="SGLANG_USE_LIGHTOP_MASK_TOPK"
     )
+    SGLANG_DSA_HCU_REUSE_SORTED_TOPK = EnvBoolWithAlias(
+        False, deprecated_name="SGLANG_NSA_HCU_REUSE_SORTED_TOPK"
+    )
     # Opt-in HCU AOT kernel for concatenating absorbed MLA Q components.
     SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q = EnvBool(False)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1484,6 +1484,8 @@ class Envs:
         False, deprecated_name="SGLANG_NSA_HIP_DISABLE_PRESHUFFLE"
     )
     SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
+    # Opt-in HCU AOT kernel for concatenating absorbed MLA Q components.
+    SGLANG_ENABLE_HCU_CONCAT_MLA_ABSORB_Q = EnvBool(False)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)
     SGLANG_DISABLE_DSA_INDEXER_FUSION = EnvBool(False)

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -637,9 +637,12 @@ def compute_logical_to_rank_dispatch_physical_map(
     ep_rank: int,
     seed: int = 42,
 ):
-    from sglang.srt.runtime_context import get_parallel
+    from sglang.srt.runtime_context import get_exec, get_parallel
 
     r = random.Random(seed)
+    dispatch_policy = get_exec().moe.ep_static_dispatch_policy
+    if dispatch_policy not in ("nearest", "locality_fair"):
+        raise ValueError(f"Unknown static expert dispatch policy: {dispatch_policy}")
 
     device = logical_to_all_physical_map.device
     logical_to_all_physical_map = logical_to_all_physical_map.cpu()
@@ -666,6 +669,19 @@ def compute_logical_to_rank_dispatch_physical_map(
             candidate_physical_expert_ids = _logical_to_all_physical_raw(
                 logical_to_all_physical_map, layer_id, logical_expert_id
             )
+
+            if dispatch_policy == "locality_fair":
+                choices = _assign_locality_fair_experts(
+                    candidate_physical_expert_ids=candidate_physical_expert_ids,
+                    ep_size=ep_size,
+                    num_local_gpu_physical_experts=num_local_gpu_physical_experts,
+                    num_gpus_per_node=num_gpus_per_node,
+                    num_local_node_physical_experts=num_local_node_physical_experts,
+                    r=r,
+                )
+                for moe_ep_rank, choice in enumerate(choices):
+                    result_list[moe_ep_rank][layer_id][logical_expert_id] = choice
+                continue
 
             remaining_ranks = []
             for moe_ep_rank in range(ep_size):
@@ -757,6 +773,135 @@ def _find_nearest_expert(
 
     # 4. At last, leave it as -1 to indicate not found.
     return -1
+
+
+def _assign_locality_fair_experts(
+    candidate_physical_expert_ids: List[int],
+    ep_size: int,
+    num_local_gpu_physical_experts: int,
+    num_gpus_per_node: Optional[int],
+    num_local_node_physical_experts: Optional[int],
+    r: random.Random,
+) -> List[int]:
+    """Build one deterministic static source-rank-to-replica assignment.
+
+    Locality is prioritized before fairness: same GPU, then same node when the
+    topology exposes node boundaries, then remote. Assignment counts are local
+    to this logical expert; they balance static source-rank bindings, not live
+    token or queue load.
+    """
+    if ep_size <= 0:
+        raise ValueError(f"ep_size must be positive, got {ep_size}")
+    if num_local_gpu_physical_experts <= 0:
+        raise ValueError(
+            "num_local_gpu_physical_experts must be positive, got "
+            f"{num_local_gpu_physical_experts}"
+        )
+    if not candidate_physical_expert_ids:
+        raise ValueError("locality_fair requires at least one physical replica")
+    if (num_gpus_per_node is None) != (num_local_node_physical_experts is None):
+        raise ValueError(
+            "num_gpus_per_node and num_local_node_physical_experts must either "
+            "both be set or both be None"
+        )
+
+    num_nodes = None
+    if num_gpus_per_node is not None:
+        if num_gpus_per_node <= 0 or ep_size % num_gpus_per_node != 0:
+            raise ValueError(
+                f"ep_size ({ep_size}) must be divisible by positive "
+                f"num_gpus_per_node ({num_gpus_per_node})"
+            )
+        expected_node_experts = num_local_gpu_physical_experts * num_gpus_per_node
+        if num_local_node_physical_experts != expected_node_experts:
+            raise ValueError(
+                "num_local_node_physical_experts must equal "
+                "num_local_gpu_physical_experts * num_gpus_per_node, got "
+                f"{num_local_node_physical_experts} != {expected_node_experts}"
+            )
+        num_nodes = ep_size // num_gpus_per_node
+
+    assignments = [-1] * ep_size
+    assignment_counts = {
+        physical_expert_id: 0 for physical_expert_id in candidate_physical_expert_ids
+    }
+
+    candidates_by_gpu = [[] for _ in range(ep_size)]
+    candidates_by_node = [[] for _ in range(num_nodes or 0)]
+    for physical_expert_id in candidate_physical_expert_ids:
+        gpu_id = _compute_gpu_id_of_physical_expert(
+            physical_expert_id, num_local_gpu_physical_experts
+        )
+        if physical_expert_id < 0 or gpu_id >= ep_size:
+            max_physical_expert_id = ep_size * num_local_gpu_physical_experts - 1
+            raise ValueError(
+                f"physical expert {physical_expert_id} is outside topology "
+                f"range [0, {max_physical_expert_id}]"
+            )
+        candidates_by_gpu[gpu_id].append(physical_expert_id)
+        if num_nodes is not None:
+            node_id = _compute_node_id_of_physical_expert(
+                physical_expert_id, num_local_node_physical_experts
+            )
+            candidates_by_node[node_id].append(physical_expert_id)
+
+    # A same-GPU replica is always the strongest locality choice.
+    for moe_ep_rank in range(ep_size):
+        if candidates_by_gpu[moe_ep_rank]:
+            choice = _choose_least_assigned_expert(
+                candidates_by_gpu[moe_ep_rank], assignment_counts, r
+            )
+            assignments[moe_ep_rank] = choice
+            assignment_counts[choice] += 1
+
+    # Include same-GPU counts while balancing unassigned ranks within a node.
+    if num_gpus_per_node is not None:
+        for node_id, same_node_physical_expert_ids in enumerate(candidates_by_node):
+            if not same_node_physical_expert_ids:
+                continue
+
+            node_rank_begin = node_id * num_gpus_per_node
+            remaining_ranks = [
+                moe_ep_rank
+                for moe_ep_rank in range(
+                    node_rank_begin, node_rank_begin + num_gpus_per_node
+                )
+                if assignments[moe_ep_rank] == -1
+            ]
+            r.shuffle(remaining_ranks)
+            for moe_ep_rank in remaining_ranks:
+                choice = _choose_least_assigned_expert(
+                    same_node_physical_expert_ids, assignment_counts, r
+                )
+                assignments[moe_ep_rank] = choice
+                assignment_counts[choice] += 1
+
+    # Nodes without a replica, or flat topologies without node affinity, fall
+    # back to all replicas while preserving counts from the locality passes.
+    remaining_ranks = [
+        moe_ep_rank
+        for moe_ep_rank, assignment in enumerate(assignments)
+        if assignment == -1
+    ]
+    r.shuffle(remaining_ranks)
+    for moe_ep_rank in remaining_ranks:
+        choice = _choose_least_assigned_expert(
+            candidate_physical_expert_ids, assignment_counts, r
+        )
+        assignments[moe_ep_rank] = choice
+        assignment_counts[choice] += 1
+
+    return assignments
+
+
+def _choose_least_assigned_expert(
+    candidate_physical_expert_ids: List[int],
+    assignment_counts: dict[int, int],
+    r: random.Random,
+) -> int:
+    candidates = candidate_physical_expert_ids.copy()
+    r.shuffle(candidates)
+    return min(candidates, key=assignment_counts.__getitem__)
 
 
 def _fair_choices(arr: List, k: int, r: random.Random) -> List:

--- a/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 import torch
+import triton
+import triton.language as tl
 
 from sglang.kernels.ops.attention.utils import seqlens_expand_triton
 from sglang.srt.layers.attention.dsa.utils import compute_dsa_seqlens
@@ -59,6 +61,59 @@ def compute_cu_seqlens(seqlens: torch.Tensor) -> torch.Tensor:
     assert seqlens.dtype == torch.int32
     return torch.nn.functional.pad(
         torch.cumsum(seqlens, dim=0, dtype=torch.int32), (1, 0)
+    )
+
+
+@triton.jit
+def _fill_decode_page_table_kernel(
+    req_to_token,
+    req_pool_indices,
+    seq_lens,
+    page_table,
+    req_to_token_stride: tl.constexpr,
+    page_table_stride: tl.constexpr,
+    max_len: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    block = tl.program_id(1)
+    cols = block * BLOCK + tl.arange(0, BLOCK)
+    req_idx = tl.load(req_pool_indices + row)
+    seq_len = tl.load(seq_lens + row)
+    in_bounds = cols < max_len
+    valid = in_bounds & (cols < seq_len)
+    vals = tl.load(
+        req_to_token + req_idx * req_to_token_stride + cols,
+        mask=valid,
+        other=0,
+    ).to(tl.int32)
+    tl.store(page_table + row * page_table_stride + cols, vals, mask=in_bounds)
+
+
+def fill_decode_page_table_gpu(
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    bs: int,
+) -> None:
+    """Fill active decode entries and clear the captured table's stale tail."""
+    if bs == 0:
+        return
+    max_len = page_table.shape[1]
+    if max_len == 0:
+        return
+    block = 1024
+    _fill_decode_page_table_kernel[(bs, triton.cdiv(max_len, block))](
+        req_to_token,
+        req_pool_indices,
+        seq_lens,
+        page_table,
+        req_to_token.shape[1],
+        page_table.stride(0),
+        max_len,
+        BLOCK=block,
+        num_warps=8,
     )
 
 
@@ -188,8 +243,19 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
         cache_seqlens = seq_lens.to(torch.int32)
         cu_seqlens_k = compute_cu_seqlens(cache_seqlens)
 
-        # Get page indices from cache
-        page_indices = self.req_to_token[req_pool_indices, :max_len].contiguous()
+        # Request-pool rows are reused without clearing. Copy the active prefix
+        # on device and zero the captured-width tail before it is transformed
+        # and replayed by every draft backend.
+        page_indices = torch.empty(
+            (bs, max_len), dtype=torch.int32, device=seq_lens.device
+        )
+        fill_decode_page_table_gpu(
+            self.req_to_token,
+            req_pool_indices,
+            seq_lens,
+            page_indices,
+            bs,
+        )
 
         # Compute DSA seqlens
         dsa_cache_seqlens = compute_dsa_seqlens(

--- a/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
@@ -389,17 +389,17 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
         # Page indices (repeated for each draft token)
         page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
         page_indices = torch.repeat_interleave(
-            page_indices, repeats=self.speculative_num_draft_tokens, dim=0
+            page_indices,
+            repeats=self.speculative_num_draft_tokens,
+            dim=0,
+            output_size=seqlens_expanded_size,
         ).contiguous()
 
-        # Generate expanded seqlens on device. seq_lens_cpu is optional for DSA
-        # CUDA graph replay, so this fallback must not require a host mirror.
-        extend_seq_lens = torch.full(
-            (bs,),
-            self.speculative_num_draft_tokens,
-            dtype=torch.int32,
-            device=self.device,
-        )
+        # seq_lens_cpu is optional for DSA CUDA graph replay, so this fallback
+        # reuses the graph-state tensor and does not require a host mirror.
+        extend_seq_lens = self.decode_cuda_graph_metadata[
+            "target_verify_extend_seq_lens"
+        ][:bs]
         seqlens_expanded = seqlens_expand_triton(
             extend_seq_lens,
             cache_seqlens,

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -78,6 +78,10 @@ if _is_hcu:
     from lightop import attention as lightop_attention
     from lightop import kvcache as lightop_kvcache
 
+    from sglang.srt.layers.attention.dsa.hcu_sparse_mqa import (
+        lightop_sparse_mask_api_available,
+        select_lightop_sparse_mqa_route,
+    )
     from sglang.kernels.ops.attention.dsa.triton_kernel import (
         fused_get_logits_head_gate_triton,
         hadamard_transform_optimized,
@@ -306,6 +310,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             and not is_neox_style
         )
         self.alt_stream = alt_stream
+        self.hcu_arch_name: Optional[str] = None
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         if self.dsa_enable_prefill_cp:
             self.cp_size = get_parallel().attn_cp_size
@@ -314,6 +319,16 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if _is_cuda:
             self.sm_count = deep_gemm.get_num_sms()
             self.half_device_sm_count = ceil_align(self.sm_count // 2, 8)
+            pp_size = configured_pp_size()
+            self.logits_with_pp_recv = pp_size > 1 and not get_pp_group().is_last_rank
+        elif _is_hcu:
+            device_props = torch.cuda.get_device_properties(0)
+            self.hcu_arch_name = (
+                device_props.gcnArchName.split(":")[0]
+                if hasattr(device_props, "gcnArchName")
+                else device_props.name
+            )
+            self.sm_count = device_props.multi_processor_count
             pp_size = configured_pp_size()
             self.logits_with_pp_recv = pp_size > 1 and not get_pp_group().is_last_rank
         else:
@@ -1077,6 +1092,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
+        sparse_mask: Optional[torch.Tensor] = None
 
         if self.paged_mqa_logits_backend.is_lightop():
             kv_cache, use_bf16_index_cache = self._get_hcu_paged_index_k_cache(
@@ -1086,15 +1102,89 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 active_weights = weights[:q_offset].to(torch.float32)
             else:
                 active_weights = weights[:q_offset]
-            logits = _hcu_paged_mqa_logits(
-                q_fp8[:q_offset],
-                kv_cache,
-                active_weights,
-                seqlens_32,
-                block_tables,
-                schedule_metadata,
-                max_seq_len,
+            active_q = q_fp8[:q_offset].unsqueeze(1)
+            use_mask_topk = envs.SGLANG_DSA_HCU_LIGHTOP_MASK_TOPK.get()
+            sparse_route = select_lightop_sparse_mqa_route(
+                enabled=(
+                    use_mask_topk
+                    and not use_bf16_index_cache
+                    and metadata.topk_backend.is_sgl_kernel()
+                    and metadata.attn_metadata.page_table_1 is not None
+                    and self.num_init_tokens == 0
+                    and self.num_local_tokens == 0
+                ),
+                api_available=(
+                    use_mask_topk and lightop_sparse_mask_api_available()
+                ),
+                is_hcu=_is_hcu,
+                arch_name=self.hcu_arch_name or "",
+                num_cus=self.sm_count,
+                page_size=page_size,
+                topk=self.index_topk,
+                fuse_topk=envs.SGLANG_DSA_FUSE_TOPK.get(),
+                force_unfused_topk=metadata.force_unfused_topk,
+                topk_transform_method_name=metadata.topk_transform_method.name,
+                q=active_q,
+                fused_kv_cache=kv_cache,
+                weights=active_weights,
+                context_lens=seqlens_32,
+                block_table=block_tables,
+                max_context_len=max_seq_len,
+                batch_size=forward_batch.batch_size,
+                is_target_verify=forward_mode.is_target_verify(),
+                is_draft_extend_v2=forward_mode.is_draft_extend_v2(),
+                mtp_group_size=getattr(
+                    getattr(forward_batch, "spec_info", None),
+                    "num_tokens_per_req",
+                    None,
+                ),
+                grouping_lens_cpu=(
+                    forward_batch.extend_seq_lens_cpu
+                    if forward_batch.extend_seq_lens_cpu is not None
+                    else metadata.get_dsa_extend_len_cpu()
+                ),
             )
+            if sparse_route is None:
+                logits = _hcu_paged_mqa_logits(
+                    q_fp8[:q_offset],
+                    kv_cache,
+                    active_weights,
+                    seqlens_32,
+                    block_tables,
+                    schedule_metadata,
+                    max_seq_len,
+                )
+            elif sparse_route.group_size == 1:
+                from lightop.gemmopt import page_mqa_logits_sparse_mask
+
+                logits, sparse_mask = page_mqa_logits_sparse_mask(
+                    active_q,
+                    kv_cache,
+                    active_weights,
+                    seqlens_32,
+                    block_tables,
+                    None,
+                    max_seq_len,
+                    clean_logits=True,
+                    num_warps=4,
+                )
+            else:
+                from lightop.gemmopt import page_mqa_logits_sparse_mask_grouped
+
+                logits, sparse_mask = (
+                    page_mqa_logits_sparse_mask_grouped(
+                        active_q,
+                        kv_cache,
+                        active_weights,
+                        seqlens_32,
+                        block_tables,
+                        None,
+                        max_seq_len,
+                        clean_logits=True,
+                        num_warps=4,
+                        group_size=sparse_route.group_size,
+                    )
+                )
         else:
             kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
             assert len(kv_cache_fp8.shape) == 2
@@ -1162,9 +1252,14 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 q_offset=q_offset,
             )
 
-        # NOTE(dark): logits should be cleaned in topk_transform
-        self._mask_init_and_local_tokens(logits, seqlens_32)
-        topk_result = metadata.topk_transform(logits, self.index_topk)
+        if sparse_mask is None:
+            # NOTE(dark): logits should be cleaned in topk_transform.
+            self._mask_init_and_local_tokens(logits, seqlens_32)
+            topk_result = metadata.topk_transform(logits, self.index_topk)
+        else:
+            topk_result = metadata.topk_transform_sparse_mask(
+                logits, sparse_mask, self.index_topk
+            )
         # Restore possible padding exist in the hidden states.
         if not _is_hip and q_offset < q_fp8.shape[0]:
             pad_len = q_fp8.shape[0] - q_offset

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -465,11 +465,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         out_cache_loc: torch.Tensor,
         weights: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        if hasattr(pool, "invalidate_index_buffer_for_layer"):
-            pool.invalidate_index_buffer_for_layer(layer_id)
-
         hadamard_scale = self.head_dim**-0.5
-        return lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
+        result = lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
             query,
             key,
             pool.get_index_k_with_scale_write_buffer(layer_id=layer_id),
@@ -482,6 +479,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             False,
             not _is_fp8_fnuz,
         )
+        commit_write = getattr(pool, "commit_index_k_with_scale_write_buffer", None)
+        if commit_write is not None:
+            commit_write(layer_id, out_cache_loc)
+        return result
 
     @contextlib.contextmanager
     def _with_real_sm_count(self):
@@ -1944,10 +1945,12 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             out_cache_loc = forward_batch.out_cache_loc
 
         pool = get_token_to_kv_pool()
-        if hasattr(pool, "invalidate_index_buffer_for_layer"):
-            pool.invalidate_index_buffer_for_layer(layer_id)
-        if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
-            return
+        hcu_layer_split = _is_hcu and getattr(pool, "layer_shard_enabled", False)
+        if not hcu_layer_split:
+            if hasattr(pool, "invalidate_index_buffer_for_layer"):
+                pool.invalidate_index_buffer_for_layer(layer_id)
+            if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
+                return
 
         if _is_hcu:
             if self._use_hcu_int8_index_cache(pool):
@@ -1965,15 +1968,19 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 )
                 return
 
+            write_buffer = pool.get_index_k_with_scale_write_buffer(layer_id=layer_id)
             lightop_kvcache.fuse_act_quant_and_store_index_k_cache(
                 key,
-                pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+                write_buffer,
                 out_cache_loc.contiguous(),
                 pool.page_size,
                 1e-5,
                 False,
                 not _is_fp8_fnuz,
             )
+            commit_write = getattr(pool, "commit_index_k_with_scale_write_buffer", None)
+            if commit_write is not None:
+                commit_write(layer_id, out_cache_loc)
             return
 
         if (

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -472,7 +472,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         return lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
             query,
             key,
-            pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+            pool.get_index_k_with_scale_write_buffer(layer_id=layer_id),
             out_cache_loc.contiguous(),
             pool.page_size,
             weights,

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -23,6 +23,9 @@ from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
     bcg_dsa_indexer_prefill_split,
     pcg_dsa_indexer_prefill_split,
 )
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
     DSAPagedMQALogitsBackend,
 )
@@ -403,15 +406,16 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         # the decode skip is not decided per-step during capture; it is driven by
         # which graph variant is being captured instead.
         fb = forward_batch
+        forward_mode = effective_forward_mode(fb)
 
         # Prefill/extend: original per-step gate (host sync on seq_lens_cpu is fine).
-        if fb.forward_mode.is_extend_without_speculative():
+        if forward_mode.is_extend_without_speculative():
             if fb.seq_lens_cpu is None or fb.seq_lens_cpu.numel() == 0:
                 return False
             return int(fb.seq_lens_cpu.max().item()) <= self.index_topk
 
         # Decode/idle.
-        if fb.forward_mode.is_decode_or_idle():
+        if forward_mode.is_decode_or_idle():
             # Decode k-only skip (both the captured dual-graph "dense" variant
             # and the eager per-step skip below) is currently HIP-only. On CUDA
             # this common code keeps the original behavior (decode never skips
@@ -823,10 +827,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         kv_cache_fp8 = self._get_index_k_read_buffer(get_token_to_kv_pool(), layer_id)
 
         blocksize = page_size
-        if (
-            forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
-        ):
+        forward_mode = effective_forward_mode(forward_batch)
+        if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
             seqlens_32 = metadata.get_seqlens_expanded()
         else:
             seqlens_32 = metadata.get_seqlens_int32()
@@ -842,14 +844,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         next_n = q_offset // B if B > 0 else 0
         use_cute_dsl = (
             self.paged_mqa_logits_backend.is_cutedsl()
-            and not forward_batch.forward_mode.is_draft_extend_v2()
+            and not forward_mode.is_draft_extend_v2()
         )
         dsl_expand_factor, dsl_atom = 1, 1
-        if (
-            use_cute_dsl
-            and forward_batch.forward_mode.is_target_verify()
-            and next_n >= 2
-        ):
+        if use_cute_dsl and forward_mode.is_target_verify() and next_n >= 2:
             assert pick_dsl_expand is not None, "CuTe DSL paged MQA is CUDA-only."
             dsl_expand_factor, dsl_atom = pick_dsl_expand(
                 next_n,
@@ -863,7 +861,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         use_dg_native = (
             not use_cute_dsl
             and _is_cuda
-            and forward_batch.forward_mode.is_target_verify()
+            and forward_mode.is_target_verify()
             and next_n >= 2
             and ctx_2d is not None
             and ctx_2d.shape == (B, next_n)
@@ -914,7 +912,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 q_offset=q_offset,
                 B=B,
                 next_n=next_n,
-                is_target_verify=forward_batch.forward_mode.is_target_verify(),
+                is_target_verify=forward_mode.is_target_verify(),
                 dsl_expand_factor=dsl_expand_factor,
                 dsl_atom=dsl_atom,
                 blocksize=blocksize,
@@ -1029,7 +1027,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        assert forward_batch.forward_mode.is_extend_without_speculative()
+        assert effective_forward_mode(forward_batch).is_extend_without_speculative()
 
         page_size = get_token_to_kv_pool().page_size
         if _is_hip:
@@ -1241,9 +1239,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         #   - topk_result: pre-allocated padded buffer to fill in place (a downstream
         #     captured graph reads it at a fixed address). None => return a fresh,
         #     naturally-sized tensor.
+        forward_mode = effective_forward_mode(forward_batch)
         assert (
-            forward_batch.forward_mode.is_extend_without_speculative()
-            or forward_batch.forward_mode.is_decode_or_idle()
+            forward_mode.is_extend_without_speculative()
+            or forward_mode.is_decode_or_idle()
         )
         x_meta = x[0] if isinstance(x, tuple) else x
 
@@ -1604,6 +1603,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             and q_lora.shape[0] <= DUAL_STREAM_TOKEN_THRESHOLD
         )
 
+        # MLP-sync can temporarily expose decode/verify/draft batches as
+        # EXTEND. Indexer routing must stay tied to the algorithmic mode.
+        forward_mode = effective_forward_mode(forward_batch)
+
         # Determine if should skip topk based on sequence length
         # We can only skip the logits computation if cuda graph is not involved
         skip_logits_computation = False
@@ -1680,7 +1683,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             )
             return maybe_capture_indexer_topk(layer_id, result)
 
-        elif enable_dual_stream and forward_batch.forward_mode.is_decode_or_idle():
+        elif enable_dual_stream and forward_mode.is_decode_or_idle():
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
             if not self.use_dsa_indexer_fusion:
@@ -1829,9 +1832,9 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     return maybe_capture_indexer_topk(layer_id, topk_result)
 
             if (
-                forward_batch.forward_mode.is_decode_or_idle()
-                or forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             ):
                 topk_result = self._get_topk_paged(
                     forward_batch, layer_id, q_fp8, weights, metadata

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -23,10 +23,10 @@ from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
     bcg_dsa_indexer_prefill_split,
     pcg_dsa_indexer_prefill_split,
 )
-from sglang.srt.layers.attention.dsa.hcu_int8_index_k_cache import IndexKCacheMode
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
     effective_forward_mode,
 )
+from sglang.srt.layers.attention.dsa.hcu_int8_index_k_cache import IndexKCacheMode
 from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
     DSAPagedMQALogitsBackend,
 )
@@ -79,13 +79,13 @@ if _is_hcu:
     from lightop import attention as lightop_attention
     from lightop import kvcache as lightop_kvcache
 
-    from sglang.srt.layers.attention.dsa.hcu_sparse_mqa import (
-        lightop_sparse_mask_api_available,
-        select_lightop_sparse_mqa_route,
-    )
     from sglang.kernels.ops.attention.dsa.triton_kernel import (
         fused_get_logits_head_gate_triton,
         hadamard_transform_optimized,
+    )
+    from sglang.srt.layers.attention.dsa.hcu_sparse_mqa import (
+        lightop_sparse_mask_api_available,
+        select_lightop_sparse_mqa_route,
     )
 
     if _use_fast_hadamard_transform:
@@ -398,22 +398,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
     @staticmethod
     def _use_hcu_bf16_index_cache(pool) -> bool:
-        return _is_hcu and getattr(
-            pool, "index_k_cache_mode", IndexKCacheMode.FP8_SCALED
-        ) is IndexKCacheMode.BF16
+        return (
+            _is_hcu
+            and getattr(pool, "index_k_cache_mode", IndexKCacheMode.FP8_SCALED)
+            is IndexKCacheMode.BF16
+        )
 
     @staticmethod
     def _use_hcu_int8_index_cache(pool) -> bool:
-        return _is_hcu and getattr(
-            pool, "index_k_cache_mode", IndexKCacheMode.FP8_SCALED
-        ) is IndexKCacheMode.INT8_SCALED
+        return (
+            _is_hcu
+            and getattr(pool, "index_k_cache_mode", IndexKCacheMode.FP8_SCALED)
+            is IndexKCacheMode.INT8_SCALED
+        )
 
     @classmethod
     def _use_hcu_bf16_indexer_compute(cls, pool) -> bool:
         """Whether LightOp must consume BF16 K with FP32 gate weights."""
-        return cls._use_hcu_bf16_index_cache(
+        return cls._use_hcu_bf16_index_cache(pool) or cls._use_hcu_int8_index_cache(
             pool
-        ) or cls._use_hcu_int8_index_cache(pool)
+        )
 
     @staticmethod
     def _get_gate_input_tensor(
@@ -1144,9 +1148,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     and self.num_init_tokens == 0
                     and self.num_local_tokens == 0
                 ),
-                api_available=(
-                    use_mask_topk and lightop_sparse_mask_api_available()
-                ),
+                api_available=(use_mask_topk and lightop_sparse_mask_api_available()),
                 is_hcu=_is_hcu,
                 arch_name=self.hcu_arch_name or "",
                 num_cus=self.sm_count,
@@ -1202,19 +1204,17 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             else:
                 from lightop.gemmopt import page_mqa_logits_sparse_mask_grouped
 
-                logits, sparse_mask = (
-                    page_mqa_logits_sparse_mask_grouped(
-                        active_q,
-                        kv_cache,
-                        active_weights,
-                        seqlens_32,
-                        block_tables,
-                        None,
-                        max_seq_len,
-                        clean_logits=True,
-                        num_warps=4,
-                        group_size=sparse_route.group_size,
-                    )
+                logits, sparse_mask = page_mqa_logits_sparse_mask_grouped(
+                    active_q,
+                    kv_cache,
+                    active_weights,
+                    seqlens_32,
+                    block_tables,
+                    None,
+                    max_seq_len,
+                    clean_logits=True,
+                    num_warps=4,
+                    group_size=sparse_route.group_size,
                 )
         else:
             kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -433,7 +433,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
 
-        hadamard_scale = self.hidden_size**-0.5
+        hadamard_scale = self.head_dim**-0.5
         return lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
             query,
             key,

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -72,6 +72,21 @@ _is_hcu = is_hcu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
+_use_fast_hadamard_transform = get_bool_env_var("SGLANG_USE_FAST_HADAMARD_TRANSFORM")
+
+if _is_hcu:
+    from lightop import attention as lightop_attention
+    from lightop import kvcache as lightop_kvcache
+
+    from sglang.kernels.ops.attention.dsa.triton_kernel import (
+        fused_get_logits_head_gate_triton,
+        hadamard_transform_optimized,
+    )
+
+    if _use_fast_hadamard_transform:
+        from fast_hadamard_transform import (
+            hadamard_transform as hcu_fast_hadamard_transform,
+        )
 
 if not _is_npu:
     from sglang.kernels.ops.attention.dsa import (
@@ -91,13 +106,13 @@ if _is_cuda:
 else:
     pick_dsl_expand = None
 
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip and not _is_hcu
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
 # Whether the aiter preshuffle paged-MQA path (page_size=64 + Preshuffle=True +
 # KVBlockSize=64) can be used. Falls back to the legacy page_size=1 / KVBlockSize=1
 # path when the gluon kernel is unavailable (Triton<3.5 and no AOT bundle).
-_use_aiter_preshuffle = aiter_can_use_preshuffle_paged_mqa()
+_use_aiter_preshuffle = not _is_hcu and aiter_can_use_preshuffle_paged_mqa()
 if _use_aiter and not _use_aiter_preshuffle:
     logger.warning(
         "ROCm DSA indexer: aiter preshuffle paged-MQA path is unavailable "
@@ -186,9 +201,49 @@ def _broadcast_indexer_topk_from_rank0(
     return topk_indices
 
 
-def rotate_activation(x: torch.Tensor) -> torch.Tensor:
+def _hcu_paged_mqa_logits(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    seqlens: torch.Tensor,
+    block_tables: torch.Tensor,
+    schedule_metadata: Optional[torch.Tensor],
+    max_seq_len: int,
+) -> torch.Tensor:
+    return lightop_attention.paged_mqa_logits(
+        q.unsqueeze(1),
+        kv_cache,
+        weights,
+        seqlens,
+        block_tables,
+        schedule_metadata,
+        max_seq_len,
+        clean_logits=True,
+    )
+
+
+def _hcu_mqa_logits(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+    kv_scale: Optional[torch.Tensor],
+) -> torch.Tensor:
+    return lightop_attention.mqa_logits(
+        q,
+        kv,
+        weights,
+        ks,
+        ke,
+        kv_scale=kv_scale,
+        clean_logit=True,
+    )
+
+
+def rotate_activation(x: torch.Tensor, apply_scale: bool = True) -> torch.Tensor:
     # from sgl_kernel import hadamard_transform
-    if _is_hip:
+    if _is_hip and not _is_hcu:
         from fast_hadamard_transform import hadamard_transform
     elif _is_xpu:
         from sgl_kernel import hadamard_transform
@@ -199,7 +254,12 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
     assert (
         hidden_size & (hidden_size - 1)
     ) == 0, "Hidden size must be a power of 2 for Hadamard transform."
-    return hadamard_transform(x, scale=hidden_size**-0.5)
+    scale = hidden_size**-0.5 if apply_scale else 1.0
+    if _is_hcu and _use_fast_hadamard_transform:
+        return hcu_fast_hadamard_transform(x, scale=scale)
+    if _is_hcu:
+        return hadamard_transform_optimized(x, scale=scale)
+    return hadamard_transform(x, scale=scale)
 
 
 class Indexer(DSANPUIndexerMixin, BaseFusedOp):
@@ -320,6 +380,74 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             get_exec().kernel.dsa_paged_mqa_logits_backend
         )
 
+    @staticmethod
+    def _use_hcu_bf16_index_cache(pool) -> bool:
+        return _is_hcu and not getattr(pool, "use_fp8_index_k_cache", True)
+
+    @staticmethod
+    def _get_gate_input_tensor(
+        x: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+    ) -> torch.Tensor:
+        if not isinstance(x, tuple):
+            return x
+
+        assert len(x) in (
+            2,
+            3,
+        ), "For tuple input, only (x, x_s) or (x, x_s, y) formats are accepted"
+        x_q, x_s = x[0], x[1]
+        if (
+            x_s is not None
+            and x_q.dim() == 2
+            and x_s.dim() == 2
+            and x_q.shape[0] == x_s.shape[0]
+        ):
+            m, n = x_q.shape
+            ng = x_s.shape[1]
+            if ng > 0 and n % ng == 0:
+                group = n // ng
+                return (
+                    x_q.to(torch.float32)
+                    .view(m, ng, group)
+                    .mul_(x_s.to(torch.float32).unsqueeze(-1))
+                    .view(m, n)
+                    .to(torch.bfloat16)
+                )
+        return x_q.to(torch.bfloat16)
+
+    def _get_bf16_logits_head_gate(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]]
+    ) -> torch.Tensor:
+        weights = self._project_and_scale_head_gates(self._get_gate_input_tensor(x))
+        return weights.unsqueeze(-1) * self.softmax_scale
+
+    def _hcu_fused_qk_quant_and_store(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        pool,
+        layer_id: int,
+        out_cache_loc: torch.Tensor,
+        weights: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        if hasattr(pool, "invalidate_index_buffer_for_layer"):
+            pool.invalidate_index_buffer_for_layer(layer_id)
+
+        hadamard_scale = self.hidden_size**-0.5
+        return lightop_kvcache.fuse_qk_quant_and_store_index_k_cache(
+            query,
+            key,
+            pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+            out_cache_loc.contiguous(),
+            pool.page_size,
+            weights,
+            hadamard_scale * self.softmax_scale,
+            hadamard_scale,
+            1e-5,
+            False,
+            not _is_fp8_fnuz,
+        )
+
     @contextlib.contextmanager
     def _with_real_sm_count(self):
         # When pipeline parallelism is enabled, each PP rank initiates a recv operation after the _pp_launch_batch
@@ -369,6 +497,13 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]], q_scale: torch.Tensor
     ):
         weights = self._weights_proj_bf16_in_fp32_out(x)
+        if _is_hcu:
+            return fused_get_logits_head_gate_triton(
+                weights=weights,
+                q_scale=q_scale,
+                n_heads=self.n_heads,
+                softmax_scale=self.softmax_scale,
+            )
         weights = weights * self.n_heads**-0.5
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights
@@ -394,6 +529,12 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         return x if self.use_dsa_indexer_fusion else rotate_activation(x)
 
     def _should_skip_logits_computation(self, forward_batch: ForwardBatch) -> bool:
+        # The HCU LightOp path keeps query preparation and index-K storage in a
+        # fused operation and does not use the generic act_quant fallback that
+        # powers the K-only shortcut.
+        if _is_hcu:
+            return False
+
         # When kv_len <= index_topk the top-k selects ALL valid positions, so the
         # indexer's logits GEMM + paged_mqa_logits + top-k are wasted work: a plain
         # topk_transform(dummy_logits) already yields the correct "select-all"
@@ -468,8 +609,50 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         positions: torch.Tensor,
         enable_dual_stream: bool,
         forward_batch: ForwardBatch,
+        apply_hadamard_scale: bool = True,
     ):
         weights_raw = None
+        if _is_hcu:
+            query, _ = self.wq_b(q_lora)
+            query = rearrange(query, "l (h d) -> l h d", d=self.head_dim)
+            key, _ = self.wk(x)
+            if key.ndim == 2:
+                key = key.view(key.shape[0], -1, self.head_dim)
+
+            lightop_attention.fuse_layernorm_rotary_embedding(
+                positions,
+                query,
+                key,
+                self.head_dim,
+                self._indexer_cos_sin_cache,
+                False,
+                None,
+                None,
+                self.k_norm.weight,
+                getattr(self.k_norm, "bias", None),
+                None,
+                None,
+                self.k_norm.variance_epsilon,
+            )
+            query = rotate_activation(query, apply_scale=apply_hadamard_scale)
+            key = rotate_activation(key, apply_scale=apply_hadamard_scale)
+
+            if is_cp_v2_active(forward_batch):
+                key = get_cp_strategy().materialize_full_indexer_k_cache(
+                    key, forward_batch
+                )
+            elif (
+                forward_batch.attn_cp_metadata is not None
+                and self.dsa_enable_prefill_cp
+            ):
+                key = cp_all_gather_rerange_output(
+                    key.contiguous(),
+                    self.cp_size,
+                    forward_batch,
+                    torch.cuda.current_stream(),
+                )
+            return query, key, weights_raw
+
         if enable_dual_stream:
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
@@ -747,6 +930,20 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             return pool.get_broadcastable_index_k_with_scale_buffer(layer_id)
         return pool.get_index_k_with_scale_buffer(layer_id=layer_id)
 
+    def _get_hcu_paged_index_k_cache(
+        self, pool, layer_id: int
+    ) -> Tuple[torch.Tensor, bool]:
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
+        if use_bf16_index_cache:
+            return pool.get_index_k_buffer(layer_id=layer_id), True
+
+        kv_cache = self._get_index_k_read_buffer(pool, layer_id)
+        assert len(kv_cache.shape) == 2
+        return (
+            kv_cache.view(kv_cache.shape[0], pool.page_size, 1, self.head_dim + 4),
+            False,
+        )
+
     @staticmethod
     def _pad_heads_for_deep_gemm(q_fp8, weights):
         """Pad q and weights to 32 heads when num_heads < 32,
@@ -804,9 +1001,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        page_size = get_token_to_kv_pool().page_size
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
         # NOTE(dark): blocksize = 64 is hardcoded in deep_gemm
-        if _is_hip:
+        if _is_hip and not _is_hcu:
             if _use_aiter_preshuffle:
                 assert (
                     page_size % 16 == 0
@@ -818,14 +1016,12 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         else:
             assert page_size == 64, "only support page size 64"
         # NOTE(dark): this support extend/decode/decode+graph
-        if _is_hip and not _use_aiter_preshuffle:
+        if _is_hip and not _is_hcu and not _use_aiter_preshuffle:
             block_tables = metadata.get_page_table_1()
         else:
             block_tables = metadata.get_page_table_64()
 
         max_seq_len = block_tables.shape[1] * page_size
-        kv_cache_fp8 = self._get_index_k_read_buffer(get_token_to_kv_pool(), layer_id)
-
         blocksize = page_size
         forward_mode = effective_forward_mode(forward_batch)
         if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
@@ -879,15 +1075,33 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     seqlens_32_2d, blocksize, self.sm_count
                 )
 
-        assert len(kv_cache_fp8.shape) == 2
-        block_kv = page_size
-        num_heads_kv = 1
-        head_dim_with_sf = 132
-        kv_cache_fp8 = kv_cache_fp8.view(
-            kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
-        )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
+
+        if self.paged_mqa_logits_backend.is_lightop():
+            kv_cache, use_bf16_index_cache = self._get_hcu_paged_index_k_cache(
+                pool, layer_id
+            )
+            if use_bf16_index_cache:
+                active_weights = weights[:q_offset].to(torch.float32)
+            else:
+                active_weights = weights[:q_offset]
+            logits = _hcu_paged_mqa_logits(
+                q_fp8[:q_offset],
+                kv_cache,
+                active_weights,
+                seqlens_32,
+                block_tables,
+                schedule_metadata,
+                max_seq_len,
+            )
+        else:
+            kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
+            assert len(kv_cache_fp8.shape) == 2
+            block_kv = page_size
+            kv_cache_fp8 = kv_cache_fp8.view(
+                kv_cache_fp8.shape[0], block_kv, 1, self.head_dim + 4
+            )
 
         if self.paged_mqa_logits_backend.is_aiter():
             logits = aiter_paged_mqa_logits(
@@ -900,6 +1114,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 preshuffle=_use_aiter_preshuffle,
                 kv_block_size=block_kv,
             )
+        elif self.paged_mqa_logits_backend.is_lightop():
+            pass
         elif use_cute_dsl:
             logits = cutedsl_paged_mqa_logits(
                 q_fp8,
@@ -1029,8 +1245,9 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         assert effective_forward_mode(forward_batch).is_extend_without_speculative()
 
-        page_size = get_token_to_kv_pool().page_size
-        if _is_hip:
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
+        if _is_hip and not _is_hcu:
             if _use_aiter_preshuffle:
                 assert (
                     page_size % 16 == 0
@@ -1049,7 +1266,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         )
         weights = weights.squeeze(-1)
 
-        if _is_hip and not _use_aiter_preshuffle:
+        if _is_hip and not _is_hcu and not _use_aiter_preshuffle:
             block_tables = metadata.get_page_table_1()
         else:
             block_tables = metadata.get_page_table_64()
@@ -1077,26 +1294,41 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         indexer_seq_lens_cpu = metadata.get_indexer_seq_len_cpu()
         seq_len_sum = torch.sum(indexer_seq_lens_cpu).item()
         max_seq_len = torch.max(indexer_seq_lens_cpu).item()
-        k_fp8, k_scale = get_token_to_kv_pool().get_index_k_scale_buffer(
-            layer_id,
-            metadata.get_indexer_seq_len(),
-            block_tables,
-            seq_len_sum,
-            max_seq_len,
-        )
-        if _is_fp8_fnuz:
-            k_fp8 = k_fp8.view(torch.float8_e4m3fnuz)
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
+        if use_bf16_index_cache:
+            kv_bf16 = torch.cat(
+                [
+                    pool.get_index_k_continuous(
+                        layer_id,
+                        int(indexer_seq_lens_cpu[batch_idx].item()),
+                        block_tables[batch_idx],
+                    )
+                    for batch_idx in range(batch_size)
+                ],
+                dim=0,
+            )
+            k_offset = kv_bf16.shape[0]
         else:
-            k_fp8 = k_fp8.view(torch.float8_e4m3fn)
+            k_fp8, k_scale = pool.get_index_k_scale_buffer(
+                layer_id,
+                metadata.get_indexer_seq_len(),
+                block_tables,
+                seq_len_sum,
+                max_seq_len,
+            )
+            if _is_fp8_fnuz:
+                k_fp8 = k_fp8.view(torch.float8_e4m3fnuz)
+            else:
+                k_fp8 = k_fp8.view(torch.float8_e4m3fn)
 
-        k_scale = k_scale.view(torch.float32).squeeze(-1)
-        kv_fp8 = (k_fp8, k_scale)
+            k_scale = k_scale.view(torch.float32).squeeze(-1)
+            kv_fp8 = (k_fp8, k_scale)
+            k_offset = k_fp8.shape[0]
 
         # Check if we need to chunk to avoid OOM
         seq_lens_expanded = metadata.get_seqlens_expanded()
         token_to_batch_idx = metadata.get_token_to_batch_idx()
         q_offset = ks.shape[0]
-        k_offset = k_fp8.shape[0]
         need_chunk, logits_budget_bytes = self._should_chunk_mqa_logits(
             q_offset, k_offset, device_index
         )
@@ -1104,7 +1336,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if not need_chunk:
             assert q_fp8[:q_offset].shape[0] != 0
             with self._with_real_sm_count():
-                if _is_hip:
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8[:q_offset],
+                        kv_bf16,
+                        weights[:q_offset].to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    kv, scale = kv_fp8
+                    logits = _hcu_mqa_logits(
+                        q_fp8[:q_offset],
+                        kv,
+                        weights[:q_offset],
+                        ks,
+                        ke,
+                        kv_scale=scale,
+                    )
+                elif _is_hip:
                     from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 
                     kv, scale = kv_fp8
@@ -1163,7 +1414,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             end = min(start + max_rows, q_offset)
 
             with self._with_real_sm_count():
-                if _is_hip:
+                if use_bf16_index_cache:
+                    logits_chunk = _hcu_mqa_logits(
+                        q_fp8[start:end],
+                        kv_bf16,
+                        weights[start:end].to(torch.float32),
+                        ks[start:end],
+                        ke[start:end],
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    kv, scale = kv_fp8
+                    logits_chunk = _hcu_mqa_logits(
+                        q_fp8[start:end],
+                        kv,
+                        weights[start:end],
+                        ks[start:end],
+                        ke[start:end],
+                        kv_scale=scale,
+                    )
+                elif _is_hip:
                     from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 
                     kv, scale = kv_fp8
@@ -1323,12 +1593,15 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
-        page_size = get_token_to_kv_pool().page_size
+        pool = get_token_to_kv_pool()
+        page_size = pool.page_size
         assert page_size == 64, "only support page size 64"
         assert len(weights.shape) == 3
         weights = weights.squeeze(-1)
+        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
         k_fp8_list = []
         k_scale_list = []
+        k_bf16_list = []
         ks_list = []
         ke_offset_list = []
         offset = 0
@@ -1352,23 +1625,27 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 end_seq_position += pre_chunk_offset
                 if offset == 0 and batch_idx != 0:
                     offset += forward_batch.extend_seq_lens_cpu[batch_idx - 1]
-                k_fp8 = get_token_to_kv_pool().get_index_k_continuous(
+                index_k = pool.get_index_k_continuous(
                     layer_id,
                     end_seq_position,
                     block_tables[batch_idx],
                 )
-                k_scale = get_token_to_kv_pool().get_index_k_scale_continuous(
-                    layer_id,
-                    end_seq_position,
-                    block_tables[batch_idx],
-                )
+                if not use_bf16_index_cache:
+                    k_scale = pool.get_index_k_scale_continuous(
+                        layer_id,
+                        end_seq_position,
+                        block_tables[batch_idx],
+                    )
 
                 extend_seq_len = end_seq_position - start_seq_position
                 ks = torch.full(
                     (extend_seq_len,), offset, dtype=torch.int32, device="cuda"
                 )
-                k_fp8_list.append(k_fp8)
-                k_scale_list.append(k_scale)
+                if use_bf16_index_cache:
+                    k_bf16_list.append(index_k)
+                else:
+                    k_fp8_list.append(index_k)
+                    k_scale_list.append(k_scale)
                 ks_list.append(ks)
                 ke_offset = torch.arange(
                     start_seq_position + 1,
@@ -1383,23 +1660,49 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 actual_seq_q_list.append(actual_seq_q)
                 batch_idx_list.append(batch_idx)
 
-            k_fp8 = torch.cat(k_fp8_list, dim=0).view(torch.float8_e4m3fn)
-            k_scale = torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
-            kv_fp8 = (k_fp8, k_scale)
             ks = torch.cat(ks_list, dim=0)
             ke_offset = torch.cat(ke_offset_list, dim=0)
             ke = ks + ke_offset
             actual_seq_q = torch.cat(actual_seq_q_list, dim=0)
             with self._with_real_sm_count():
-                q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(q_fp8, weights)
-                logits = deep_gemm.fp8_mqa_logits(
-                    q_padded,
-                    kv_fp8,
-                    w_padded,
-                    ks,
-                    ke,
-                    clean_logits=False,
-                )
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        torch.cat(k_bf16_list, dim=0),
+                        weights.to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                elif _is_hcu:
+                    k_fp8 = torch.cat(k_fp8_list, dim=0).view(fp8_dtype)
+                    k_scale = (
+                        torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
+                    )
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        k_fp8,
+                        weights,
+                        ks,
+                        ke,
+                        kv_scale=k_scale,
+                    )
+                else:
+                    k_fp8 = torch.cat(k_fp8_list, dim=0).view(torch.float8_e4m3fn)
+                    k_scale = (
+                        torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
+                    )
+                    q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(
+                        q_fp8, weights
+                    )
+                    logits = deep_gemm.fp8_mqa_logits(
+                        q_padded,
+                        (k_fp8, k_scale),
+                        w_padded,
+                        ks,
+                        ke,
+                        clean_logits=False,
+                    )
             topk_result = metadata.topk_transform(
                 logits,
                 self.index_topk,
@@ -1414,20 +1717,11 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 - forward_batch.extend_seq_lens_cpu[0]
                 + kv_len
             )
-            k_fp8 = get_token_to_kv_pool().get_index_k_continuous(
+            index_k = pool.get_index_k_continuous(
                 layer_id,
                 kv_len,
                 block_tables[0],
             )
-            k_scale = get_token_to_kv_pool().get_index_k_scale_continuous(
-                layer_id,
-                kv_len,
-                block_tables[0],
-            )
-
-            k_fp8 = k_fp8.view(torch.float8_e4m3fn)
-            k_scale = k_scale.view(torch.float32).squeeze(-1)
-            kv_fp8 = (k_fp8, k_scale)
             ks = torch.full((actual_seq_q,), offset, dtype=torch.int32, device="cuda")
             ke_offset = torch.arange(
                 (kv_len - actual_seq_q) + 1,
@@ -1438,15 +1732,44 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             ke = ks + ke_offset
 
             with self._with_real_sm_count():
-                q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(q_fp8, weights)
-                logits = deep_gemm.fp8_mqa_logits(
-                    q_padded,
-                    kv_fp8,
-                    w_padded,
-                    ks,
-                    ke,
-                    clean_logits=False,
-                )
+                if use_bf16_index_cache:
+                    logits = _hcu_mqa_logits(
+                        q_fp8,
+                        index_k,
+                        weights.to(torch.float32),
+                        ks,
+                        ke,
+                        kv_scale=None,
+                    )
+                else:
+                    k_scale = pool.get_index_k_scale_continuous(
+                        layer_id,
+                        kv_len,
+                        block_tables[0],
+                    )
+                    k_fp8 = index_k.view(fp8_dtype if _is_hcu else torch.float8_e4m3fn)
+                    k_scale = k_scale.view(torch.float32).squeeze(-1)
+                    if _is_hcu:
+                        logits = _hcu_mqa_logits(
+                            q_fp8,
+                            k_fp8,
+                            weights,
+                            ks,
+                            ke,
+                            kv_scale=k_scale,
+                        )
+                    else:
+                        q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(
+                            q_fp8, weights
+                        )
+                        logits = deep_gemm.fp8_mqa_logits(
+                            q_padded,
+                            (k_fp8, k_scale),
+                            w_padded,
+                            ks,
+                            ke,
+                            clean_logits=False,
+                        )
             actual_seq_q = torch.tensor([actual_seq_q], dtype=torch.int32).to(
                 device="cuda", non_blocking=True
             )
@@ -1485,6 +1808,26 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
         if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
+            return
+
+        if _is_hcu:
+            if self._use_hcu_bf16_index_cache(pool):
+                pool.set_index_k_buffer(
+                    layer_id=layer_id,
+                    loc=out_cache_loc,
+                    index_k=key,
+                )
+                return
+
+            lightop_kvcache.fuse_act_quant_and_store_index_k_cache(
+                key,
+                pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+                out_cache_loc.contiguous(),
+                pool.page_size,
+                1e-5,
+                False,
+                not _is_fp8_fnuz,
+            )
             return
 
         if (
@@ -1569,9 +1912,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         layer_id: int,
         return_indices: bool = True,
     ) -> Optional[torch.Tensor]:
-        if _is_hip:
+        act_quant = None
+        if _is_hip and not _is_hcu:
             from sglang.kernels.ops.attention.dsa.tilelang_kernel import act_quant
-        elif not _is_npu:
+        elif not _is_npu and not _is_hcu:
             from sglang.kernels.ops.attention.dsa.triton_kernel import act_quant
 
         if TYPE_CHECKING:
@@ -1582,7 +1926,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         x_meta = x[0] if isinstance(x, tuple) else x
 
         in_piecewise_or_breakable_cuda_graph = (
-            _is_in_piecewise_or_breakable_cuda_graph()
+            not _is_hcu and _is_in_piecewise_or_breakable_cuda_graph()
         )
 
         # In piecewise/breakable CUDA graph mode, metadata is fetched inside
@@ -1637,7 +1981,51 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             self.weights_proj, "set_lora", False
         )
 
-        if (
+        if _is_hcu:
+            pool = get_token_to_kv_pool()
+            x_for_gate = self._get_gate_input_tensor(x)
+            if self._use_hcu_bf16_index_cache(pool):
+                q_fp8, key, _ = self._get_q_k_bf16(
+                    q_lora,
+                    x,
+                    positions,
+                    False,
+                    forward_batch=forward_batch,
+                )
+                self._store_index_k_cache(
+                    forward_batch=forward_batch,
+                    layer_id=layer_id,
+                    key=key,
+                )
+                if weights_proj_lora:
+                    weights = (
+                        self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
+                    ).unsqueeze(-1) * self.softmax_scale
+                else:
+                    weights = self._get_bf16_logits_head_gate(x_for_gate)
+            else:
+                query, key, _ = self._get_q_k_bf16(
+                    q_lora,
+                    x,
+                    positions,
+                    False,
+                    forward_batch=forward_batch,
+                    apply_hadamard_scale=False,
+                )
+                q_fp8_raw, q_scale, _ = self._hcu_fused_qk_quant_and_store(
+                    query,
+                    key,
+                    pool,
+                    layer_id,
+                    forward_batch.out_cache_loc,
+                )
+                q_fp8 = q_fp8_raw.view(fp8_dtype)
+                if weights_proj_lora:
+                    gate = self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
+                    weights = self._apply_q_scale_and_softmax_scale(gate, q_scale)
+                else:
+                    weights = self._get_logits_head_gate(x_for_gate, q_scale)
+        elif (
             self.use_dsa_indexer_fusion
             and not in_piecewise_or_breakable_cuda_graph
             and forward_batch.attn_cp_metadata is None

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
     bcg_dsa_indexer_prefill_split,
     pcg_dsa_indexer_prefill_split,
 )
+from sglang.srt.layers.attention.dsa.hcu_int8_index_k_cache import IndexKCacheMode
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
     effective_forward_mode,
 )
@@ -397,7 +398,22 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
     @staticmethod
     def _use_hcu_bf16_index_cache(pool) -> bool:
-        return _is_hcu and not getattr(pool, "use_fp8_index_k_cache", True)
+        return _is_hcu and getattr(
+            pool, "index_k_cache_mode", IndexKCacheMode.FP8_SCALED
+        ) is IndexKCacheMode.BF16
+
+    @staticmethod
+    def _use_hcu_int8_index_cache(pool) -> bool:
+        return _is_hcu and getattr(
+            pool, "index_k_cache_mode", IndexKCacheMode.FP8_SCALED
+        ) is IndexKCacheMode.INT8_SCALED
+
+    @classmethod
+    def _use_hcu_bf16_indexer_compute(cls, pool) -> bool:
+        """Whether LightOp must consume BF16 K with FP32 gate weights."""
+        return cls._use_hcu_bf16_index_cache(
+            pool
+        ) or cls._use_hcu_int8_index_cache(pool)
 
     @staticmethod
     def _get_gate_input_tensor(
@@ -946,10 +962,22 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         return pool.get_index_k_with_scale_buffer(layer_id=layer_id)
 
     def _get_hcu_paged_index_k_cache(
-        self, pool, layer_id: int
+        self,
+        pool,
+        layer_id: int,
+        block_tables: torch.Tensor,
+        context_lens: torch.Tensor,
     ) -> Tuple[torch.Tensor, bool]:
-        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
-        if use_bf16_index_cache:
+        if self._use_hcu_int8_index_cache(pool):
+            return (
+                pool.dequantize_index_k_int8_paged(
+                    layer_id=layer_id,
+                    block_tables=block_tables,
+                    context_lens=context_lens,
+                ),
+                True,
+            )
+        if self._use_hcu_bf16_index_cache(pool):
             return pool.get_index_k_buffer(layer_id=layer_id), True
 
         kv_cache = self._get_index_k_read_buffer(pool, layer_id)
@@ -1096,7 +1124,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         if self.paged_mqa_logits_backend.is_lightop():
             kv_cache, use_bf16_index_cache = self._get_hcu_paged_index_k_cache(
-                pool, layer_id
+                pool,
+                layer_id,
+                block_tables,
+                metadata.get_seqlens_int32(),
             )
             if use_bf16_index_cache:
                 active_weights = weights[:q_offset].to(torch.float32)
@@ -1389,7 +1420,13 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         indexer_seq_lens_cpu = metadata.get_indexer_seq_len_cpu()
         seq_len_sum = torch.sum(indexer_seq_lens_cpu).item()
         max_seq_len = torch.max(indexer_seq_lens_cpu).item()
-        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
+        use_bf16_index_cache = self._use_hcu_bf16_indexer_compute(pool)
+        if self._use_hcu_int8_index_cache(pool):
+            pool.dequantize_index_k_int8_paged(
+                layer_id=layer_id,
+                block_tables=block_tables,
+                context_lens=metadata.get_indexer_seq_len(),
+            )
         if use_bf16_index_cache:
             kv_bf16 = torch.cat(
                 [
@@ -1693,7 +1730,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         assert page_size == 64, "only support page size 64"
         assert len(weights.shape) == 3
         weights = weights.squeeze(-1)
-        use_bf16_index_cache = self._use_hcu_bf16_index_cache(pool)
+        use_bf16_index_cache = self._use_hcu_bf16_indexer_compute(pool)
         k_fp8_list = []
         k_scale_list = []
         k_bf16_list = []
@@ -1704,6 +1741,13 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         batch_idx_list = []
 
         block_tables = metadata.get_page_table_64()
+
+        if self._use_hcu_int8_index_cache(pool):
+            pool.dequantize_index_k_int8_paged(
+                layer_id=layer_id,
+                block_tables=block_tables,
+                context_lens=metadata.get_indexer_seq_len(),
+            )
 
         assert (
             forward_batch.seq_lens_cpu is not None
@@ -1906,6 +1950,13 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             return
 
         if _is_hcu:
+            if self._use_hcu_int8_index_cache(pool):
+                pool.set_index_k_int8_buffer(
+                    layer_id=layer_id,
+                    loc=out_cache_loc,
+                    index_k=key,
+                )
+                return
             if self._use_hcu_bf16_index_cache(pool):
                 pool.set_index_k_buffer(
                     layer_id=layer_id,
@@ -2079,7 +2130,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if _is_hcu:
             pool = get_token_to_kv_pool()
             x_for_gate = self._get_gate_input_tensor(x)
-            if self._use_hcu_bf16_index_cache(pool):
+            if self._use_hcu_bf16_indexer_compute(pool):
                 q_fp8, key, _ = self._get_q_k_bf16(
                     q_lora,
                     x,

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer_metadata.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer_metadata.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.dsa_backend_mtp_precompute import (
     compute_cu_seqlens,
 )
@@ -89,6 +90,16 @@ class BaseIndexerMetadata(ABC):
                 Don't assume it is the topk indices of the input logits.
         """
 
+    def topk_transform_sparse_mask(
+        self,
+        logits: torch.Tensor,
+        nonzero_mask: torch.Tensor,
+        topk: int,
+    ) -> torch.Tensor:
+        """Consume sparse Page-MQA output with its mandatory mask."""
+
+        raise NotImplementedError("mask-aware sparse TopK is not implemented")
+
 
 @dataclass(frozen=True)
 class DSAIndexerMetadata(BaseIndexerMetadata):
@@ -166,4 +177,49 @@ class DSAIndexerMetadata(BaseIndexerMetadata):
             row_starts=ks,
             batch_idx_list=batch_idx_list,
             force_unfused_topk=self.force_unfused_topk,
+        )
+
+    def topk_transform_sparse_mask(
+        self,
+        logits: torch.Tensor,
+        nonzero_mask: torch.Tensor,
+        topk: int,
+    ) -> torch.Tensor:
+        """Run the only valid consumer for LightOp sparse Page-MQA logits."""
+
+        if (
+            not envs.SGLANG_DSA_HCU_LIGHTOP_MASK_TOPK.get()
+            or not envs.SGLANG_DSA_FUSE_TOPK.get()
+            or self.force_unfused_topk
+            or not self.topk_backend.is_sgl_kernel()
+            or self.topk_transform_method != TopkTransformMethod.PAGED
+            or topk != 2048
+        ):
+            raise RuntimeError(
+                "Sparse Page-MQA requires the LightOp fused paged mask-aware "
+                "TopK=2048 consumer"
+            )
+
+        lengths = self.get_seqlens_expanded()
+        page_table_size_1 = self.attn_metadata.page_table_1
+        cu_seqlens_q = self.attn_metadata.cu_seqlens_q
+        if page_table_size_1 is None or (
+            logits.dim() != 2
+            or logits.shape[0] != lengths.shape[0]
+            or page_table_size_1.shape[0] != logits.shape[0]
+            or cu_seqlens_q.shape[0] != logits.shape[0] + 1
+        ):
+            raise RuntimeError(
+                "Sparse Page-MQA metadata rows must match its paired paged TopK"
+            )
+
+        from lightop.attention import fast_topk_transform_sparse_mask_fused
+
+        return fast_topk_transform_sparse_mask_fused(
+            score=logits,
+            nonzero_mask=nonzero_mask,
+            lengths=lengths,
+            page_table_size_1=page_table_size_1,
+            cu_seqlens_q=cu_seqlens_q,
+            topk=topk,
         )

--- a/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
@@ -57,6 +57,28 @@ def can_fuse_flashmla_metadata(
     )
 
 
+def refresh_flashmla_metadata(
+    destination: DSAFlashMLAMetadata,
+    source: DSAFlashMLAMetadata,
+    sli,
+    *,
+    is_hcu: bool,
+) -> DSAFlashMLAMetadata:
+    """Return the metadata wrapper the next forward must retain.
+
+    Tensor metadata is refreshed in-place so captured data pointers stay
+    stable. HCU scheduler objects carry shape-bound mutable state, so callers
+    must retain the fresh source object instead of mutating a sliced temporary
+    wrapper that the forward never reads.
+    """
+
+    if is_hcu:
+        return source
+    destination_view = destination.slice(sli)
+    destination_view.copy_(source)
+    return destination_view
+
+
 def wrap_flashmla_metadata_result(
     result: tuple[Any, Optional[torch.Tensor]], *, is_hcu: bool
 ) -> DSAFlashMLAMetadata:

--- a/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/flashmla_backend.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable, Optional
+
+import torch
+
+
+def get_flashmla_op(name: str, *, is_hcu: bool) -> Callable[..., Any]:
+    module_name = "flash_mla.flash_mla_interface" if is_hcu else "sgl_kernel.flash_mla"
+    return getattr(import_module(module_name), name)
+
+
+@dataclass(frozen=True)
+class DSAFlashMLAMetadata:
+    """Metadata needed only by FlashMLA.
+
+    CUDA FlashMLA stores scheduler metadata in tensors. HCU FlashMLA stores it
+    in a mutable backend object and initializes the object's tensor fields on
+    the first kernel invocation.
+    """
+
+    flashmla_metadata: Any
+    num_splits: Optional[torch.Tensor]
+
+    def slice(self, sli) -> DSAFlashMLAMetadata:
+        return DSAFlashMLAMetadata(
+            flashmla_metadata=self.flashmla_metadata,
+            num_splits=(None if self.num_splits is None else self.num_splits[sli]),
+        )
+
+    def copy_(self, other: DSAFlashMLAMetadata) -> None:
+        if isinstance(self.flashmla_metadata, torch.Tensor) and isinstance(
+            other.flashmla_metadata, torch.Tensor
+        ):
+            self.flashmla_metadata.copy_(other.flashmla_metadata)
+        else:
+            object.__setattr__(self, "flashmla_metadata", other.flashmla_metadata)
+
+        if isinstance(self.num_splits, torch.Tensor) and isinstance(
+            other.num_splits, torch.Tensor
+        ):
+            self.num_splits.copy_(other.num_splits)
+        else:
+            object.__setattr__(self, "num_splits", other.num_splits)
+
+
+def can_fuse_flashmla_metadata(
+    *metadatas: Optional[DSAFlashMLAMetadata],
+) -> bool:
+    return all(
+        metadata is not None
+        and isinstance(metadata.flashmla_metadata, torch.Tensor)
+        and isinstance(metadata.num_splits, torch.Tensor)
+        for metadata in metadatas
+    )
+
+
+def wrap_flashmla_metadata_result(
+    result: tuple[Any, Optional[torch.Tensor]], *, is_hcu: bool
+) -> DSAFlashMLAMetadata:
+    flashmla_metadata, num_splits = result
+    if is_hcu:
+        num_splits = getattr(flashmla_metadata, "num_splits", num_splits)
+    return DSAFlashMLAMetadata(
+        flashmla_metadata=flashmla_metadata,
+        num_splits=num_splits,
+    )

--- a/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
+++ b/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 
 def effective_forward_mode(forward_batch):
     """Return the algorithmic mode before MLP-sync remaps it to EXTEND."""
@@ -10,3 +12,50 @@ def effective_forward_mode(forward_batch):
         if original_forward_mode is None
         else original_forward_mode
     )
+
+
+def get_flashmla_kv_valid_rows(forward_batch, num_rows: int) -> Optional[int]:
+    """Return the real prefix length when MLP-sync padded FlashMLA KV rows."""
+
+    forward_mode = effective_forward_mode(forward_batch)
+    planned_batch_size = getattr(forward_batch, "forward_metadata_planned_bs", None)
+    planned_num_tokens = getattr(
+        forward_batch, "forward_metadata_planned_num_tokens", None
+    )
+    original_batch_size = getattr(forward_batch, "_original_batch_size", None)
+    original_num_tokens = getattr(forward_batch, "_original_num_tokens", None)
+
+    has_planned_layout = (
+        planned_batch_size is not None or planned_num_tokens is not None
+    )
+    if has_planned_layout:
+        if not (
+            isinstance(planned_batch_size, int)
+            and isinstance(planned_num_tokens, int)
+            and planned_batch_size == original_batch_size
+        ):
+            return None
+        real_batch_size = planned_batch_size
+        real_num_tokens = planned_num_tokens
+    else:
+        real_batch_size = original_batch_size
+        real_num_tokens = original_num_tokens
+
+    if forward_mode.is_decode_or_idle():
+        spec_info = getattr(forward_batch, "spec_info", None)
+        if getattr(spec_info, "num_tokens_per_req", None) != 1:
+            return None
+        if isinstance(real_batch_size, int) and 0 <= real_batch_size < num_rows:
+            return real_batch_size
+        return None
+
+    if not (forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2()):
+        return None
+    if not (
+        isinstance(real_batch_size, int)
+        and real_batch_size >= 0
+        and isinstance(real_num_tokens, int)
+        and 0 <= real_num_tokens < num_rows
+    ):
+        return None
+    return real_num_tokens

--- a/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
+++ b/python/sglang/srt/layers/attention/dsa/forward_batch_utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def effective_forward_mode(forward_batch):
+    """Return the algorithmic mode before MLP-sync remaps it to EXTEND."""
+
+    original_forward_mode = getattr(forward_batch, "_original_forward_mode", None)
+    return (
+        forward_batch.forward_mode
+        if original_forward_mode is None
+        else original_forward_mode
+    )

--- a/python/sglang/srt/layers/attention/dsa/hcu_int8_index_k_cache.py
+++ b/python/sglang/srt/layers/attention/dsa/hcu_int8_index_k_cache.py
@@ -18,7 +18,6 @@ import triton.language as tl
 from sglang.srt.environ import envs
 from sglang.srt.utils.common import is_hcu, is_hcu_native_fp8_supported
 
-
 INDEX_K_PAGE_SIZE = 64
 INDEX_K_HEAD_DIM = 128
 INDEX_K_SCALE_BYTES = 4
@@ -114,11 +113,13 @@ def create_index_k_int8_aliases(
 
     num_pages = packed_cache.shape[0]
     k_bytes = INDEX_K_PAGE_SIZE * INDEX_K_HEAD_DIM
-    int8_k = packed_cache[:, :k_bytes].view(torch.int8).view(
-        num_pages, INDEX_K_PAGE_SIZE, INDEX_K_HEAD_DIM
+    int8_k = (
+        packed_cache[:, :k_bytes]
+        .view(torch.int8)
+        .view(num_pages, INDEX_K_PAGE_SIZE, INDEX_K_HEAD_DIM)
     )
-    fp32_scales = packed_cache[:, k_bytes:].view(torch.float32).view(
-        num_pages, INDEX_K_PAGE_SIZE
+    fp32_scales = (
+        packed_cache[:, k_bytes:].view(torch.float32).view(num_pages, INDEX_K_PAGE_SIZE)
     )
     return int8_k, fp32_scales
 
@@ -176,17 +177,13 @@ def _quantize_and_store_index_k_int8_kernel(
     key = tl.load(key_ptr + token_idx * key_stride_0 + offsets).to(tl.float32)
     scale = tl.maximum(tl.max(tl.abs(key)), epsilon) / 127.0
     scaled = key / scale
-    rounded = tl.where(
-        scaled >= 0.0, tl.floor(scaled + 0.5), tl.ceil(scaled - 0.5)
-    )
+    rounded = tl.where(scaled >= 0.0, tl.floor(scaled + 0.5), tl.ceil(scaled - 0.5))
     quantized = tl.clamp(rounded, -127.0, 127.0).to(tl.int8)
 
     loc = tl.load(loc_ptr + token_idx).to(tl.int64)
     page = loc // PAGE_SIZE
     token_offset = loc % PAGE_SIZE
-    k_ptr = (
-        k_cache_ptr + page * k_page_stride_0 + token_offset * HEAD_DIM + offsets
-    )
+    k_ptr = k_cache_ptr + page * k_page_stride_0 + token_offset * HEAD_DIM + offsets
     scale_ptr = scale_cache_ptr + page * scale_page_stride_0 + token_offset
     tl.store(k_ptr, quantized)
     tl.store(scale_ptr, scale)
@@ -292,9 +289,7 @@ def _dequantize_index_k_int8_paged_kernel(
                         + offsets
                     ).to(tl.float32)
                     scale = tl.load(
-                        scale_ptr
-                        + physical_page * scale_page_stride_0
-                        + token_offset
+                        scale_ptr + physical_page * scale_page_stride_0 + token_offset
                     )
                     tl.store(
                         workspace_ptr

--- a/python/sglang/srt/layers/attention/dsa/hcu_int8_index_k_cache.py
+++ b/python/sglang/srt/layers/attention/dsa/hcu_int8_index_k_cache.py
@@ -404,9 +404,7 @@ def dequantize_index_k_int8_paged(
     )
 
 
-def validate_hcu_int8_index_k_cache_server_args(
-    server_args, *, allow_mooncake_pd: bool
-) -> None:
+def validate_hcu_int8_index_k_cache_server_args(server_args) -> None:
     """Reject combinations whose INT8 cache lifetime is not implemented."""
     if not envs.SGLANG_DSA_HCU_INT8_INDEX_K_CACHE.get():
         return
@@ -424,7 +422,7 @@ def validate_hcu_int8_index_k_cache_server_args(
     disaggregation_mode = getattr(server_args, "disaggregation_mode", "null")
     if disaggregation_mode != "null":
         backend = getattr(server_args, "disaggregation_transfer_backend", "mooncake")
-        if not allow_mooncake_pd or backend not in ("mooncake", "mooncake_tcp"):
+        if backend not in ("mooncake", "mooncake_tcp"):
             unsupported.append(f"--disaggregation-transfer-backend={backend}")
 
     if unsupported:

--- a/python/sglang/srt/layers/attention/dsa/hcu_int8_index_k_cache.py
+++ b/python/sglang/srt/layers/attention/dsa/hcu_int8_index_k_cache.py
@@ -1,0 +1,435 @@
+"""INT8 page-planar cache helpers for the HCU DSA indexer.
+
+The persistent packed ABI is shared with the scaled FP8 indexer cache: every
+physical page stores 64 K vectors followed by 64 FP32 token scales.  In INT8
+mode the K bytes are signed INT8 values.  Referenced pages are dequantized into
+one reusable BF16 workspace before they are consumed by LightOp.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.environ import envs
+from sglang.srt.utils.common import is_hcu, is_hcu_native_fp8_supported
+
+
+INDEX_K_PAGE_SIZE = 64
+INDEX_K_HEAD_DIM = 128
+INDEX_K_SCALE_BYTES = 4
+INDEX_K_BYTES_PER_TOKEN = INDEX_K_HEAD_DIM + INDEX_K_SCALE_BYTES
+INDEX_K_EPSILON = 1e-6
+
+
+class IndexKCacheMode(str, Enum):
+    BF16 = "bf16"
+    FP8_SCALED = "fp8_scaled"
+    INT8_SCALED = "int8_scaled"
+
+
+def is_hcu_gfx936() -> bool:
+    """Return whether the active HCU device is the validated INT8 target."""
+    if not is_hcu():
+        return False
+    try:
+        gcn_arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+        return "gfx936" in gcn_arch
+    except Exception:
+        return False
+
+
+def resolve_index_k_cache_mode(
+    dtype: torch.dtype,
+    page_size: int,
+    index_head_dim: int,
+    *,
+    int8_enabled: Optional[bool] = None,
+    hcu_device: Optional[bool] = None,
+    gfx936_device: Optional[bool] = None,
+    native_fp8_supported: Optional[bool] = None,
+) -> IndexKCacheMode:
+    """Resolve the index-K format and reject non-gfx936 INT8 opt-ins."""
+    if int8_enabled is None:
+        int8_enabled = envs.SGLANG_DSA_HCU_INT8_INDEX_K_CACHE.get()
+    if hcu_device is None:
+        hcu_device = is_hcu()
+    if gfx936_device is None:
+        gfx936_device = is_hcu_gfx936()
+
+    if int8_enabled:
+        if not hcu_device or not gfx936_device:
+            raise ValueError(
+                "SGLANG_DSA_HCU_INT8_INDEX_K_CACHE=1 is only supported on "
+                "HCU gfx936; gfx938 continues to use the native FP8 index-K cache."
+            )
+        if page_size != INDEX_K_PAGE_SIZE or index_head_dim != INDEX_K_HEAD_DIM:
+            raise ValueError(
+                "SGLANG_DSA_HCU_INT8_INDEX_K_CACHE=1 requires "
+                f"page_size={INDEX_K_PAGE_SIZE} and "
+                f"index_head_dim={INDEX_K_HEAD_DIM}; got page_size={page_size} "
+                f"and index_head_dim={index_head_dim}."
+            )
+        return IndexKCacheMode.INT8_SCALED
+
+    if native_fp8_supported is None:
+        native_fp8_supported = is_hcu_native_fp8_supported()
+    fp8_dtype = dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    if not hcu_device or (fp8_dtype and native_fp8_supported):
+        return IndexKCacheMode.FP8_SCALED
+    return IndexKCacheMode.BF16
+
+
+def index_k_cache_bytes_per_token(mode: IndexKCacheMode) -> int:
+    if mode is IndexKCacheMode.BF16:
+        return INDEX_K_HEAD_DIM * torch.bfloat16.itemsize
+    return INDEX_K_BYTES_PER_TOKEN
+
+
+def index_k_workspace_bytes_per_token(mode: IndexKCacheMode) -> float:
+    """Return the shared workspace and page-claim reservation for INT8."""
+    if mode is IndexKCacheMode.INT8_SCALED:
+        return INDEX_K_HEAD_DIM * torch.bfloat16.itemsize + 4 / INDEX_K_PAGE_SIZE
+    return 0.0
+
+
+def create_index_k_int8_aliases(
+    packed_cache: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Create zero-copy INT8-K and FP32-scale aliases of packed storage."""
+    if packed_cache.dtype != torch.uint8 or packed_cache.ndim != 2:
+        raise ValueError("packed INT8 index-K cache must be a 2D torch.uint8 tensor")
+    expected_page_bytes = INDEX_K_PAGE_SIZE * INDEX_K_BYTES_PER_TOKEN
+    if packed_cache.shape[1] != expected_page_bytes:
+        raise ValueError(
+            "packed INT8 index-K cache has invalid page width: "
+            f"expected {expected_page_bytes}, got {packed_cache.shape[1]}"
+        )
+    if not packed_cache.is_contiguous():
+        raise ValueError("packed INT8 index-K cache must be contiguous")
+
+    num_pages = packed_cache.shape[0]
+    k_bytes = INDEX_K_PAGE_SIZE * INDEX_K_HEAD_DIM
+    int8_k = packed_cache[:, :k_bytes].view(torch.int8).view(
+        num_pages, INDEX_K_PAGE_SIZE, INDEX_K_HEAD_DIM
+    )
+    fp32_scales = packed_cache[:, k_bytes:].view(torch.float32).view(
+        num_pages, INDEX_K_PAGE_SIZE
+    )
+    return int8_k, fp32_scales
+
+
+def _validate_quantize_inputs(
+    key: torch.Tensor,
+    packed_cache: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    page_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if page_size != INDEX_K_PAGE_SIZE:
+        raise ValueError(f"INT8 index-K cache requires page_size={INDEX_K_PAGE_SIZE}")
+    if key.dtype != torch.bfloat16:
+        raise ValueError(f"INT8 index-K cache expects BF16 K, got {key.dtype}")
+    key = key.reshape(-1, key.shape[-1])
+    if key.shape[1] != INDEX_K_HEAD_DIM:
+        raise ValueError(
+            f"INT8 index-K cache requires head dim {INDEX_K_HEAD_DIM}, "
+            f"got {key.shape[1]}"
+        )
+    if key.shape[0] != out_cache_loc.numel():
+        raise ValueError("key and out_cache_loc must contain the same number of tokens")
+    if out_cache_loc.dtype not in (torch.int32, torch.int64):
+        raise ValueError("out_cache_loc must be an int32 or int64 tensor")
+    if not key.is_contiguous():
+        key = key.contiguous()
+    if not out_cache_loc.is_contiguous():
+        out_cache_loc = out_cache_loc.contiguous()
+    expected_page_bytes = INDEX_K_PAGE_SIZE * INDEX_K_BYTES_PER_TOKEN
+    if (
+        packed_cache.dtype != torch.uint8
+        or packed_cache.ndim != 2
+        or packed_cache.shape[1] != expected_page_bytes
+        or not packed_cache.is_contiguous()
+    ):
+        raise ValueError("packed INT8 index-K cache has an invalid page-planar layout")
+    return key, out_cache_loc
+
+
+@triton.jit
+def _quantize_and_store_index_k_int8_kernel(
+    key_ptr,
+    k_cache_ptr,
+    scale_cache_ptr,
+    loc_ptr,
+    key_stride_0: tl.constexpr,
+    k_page_stride_0: tl.constexpr,
+    scale_page_stride_0: tl.constexpr,
+    epsilon: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    offsets = tl.arange(0, HEAD_DIM)
+    key = tl.load(key_ptr + token_idx * key_stride_0 + offsets).to(tl.float32)
+    scale = tl.maximum(tl.max(tl.abs(key)), epsilon) / 127.0
+    scaled = key / scale
+    rounded = tl.where(
+        scaled >= 0.0, tl.floor(scaled + 0.5), tl.ceil(scaled - 0.5)
+    )
+    quantized = tl.clamp(rounded, -127.0, 127.0).to(tl.int8)
+
+    loc = tl.load(loc_ptr + token_idx).to(tl.int64)
+    page = loc // PAGE_SIZE
+    token_offset = loc % PAGE_SIZE
+    k_ptr = (
+        k_cache_ptr + page * k_page_stride_0 + token_offset * HEAD_DIM + offsets
+    )
+    scale_ptr = scale_cache_ptr + page * scale_page_stride_0 + token_offset
+    tl.store(k_ptr, quantized)
+    tl.store(scale_ptr, scale)
+
+
+def _quantize_and_store_index_k_int8_reference(
+    key: torch.Tensor,
+    int8_k: torch.Tensor,
+    fp32_scales: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    epsilon: float,
+) -> None:
+    key_fp32 = key.float()
+    scales = key_fp32.abs().amax(dim=-1).clamp_min(epsilon) / 127.0
+    scaled = key_fp32 / scales[:, None]
+    quantized = torch.clamp(
+        torch.where(
+            scaled >= 0,
+            torch.floor(scaled + 0.5),
+            torch.ceil(scaled - 0.5),
+        ),
+        -127,
+        127,
+    ).to(torch.int8)
+    pages = (out_cache_loc // INDEX_K_PAGE_SIZE).long()
+    offsets = (out_cache_loc % INDEX_K_PAGE_SIZE).long()
+    int8_k[pages, offsets] = quantized
+    fp32_scales[pages, offsets] = scales
+
+
+def quantize_and_store_index_k_int8(
+    key: torch.Tensor,
+    packed_cache: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    page_size: int = INDEX_K_PAGE_SIZE,
+    epsilon: float = INDEX_K_EPSILON,
+    *,
+    int8_k: Optional[torch.Tensor] = None,
+    fp32_scales: Optional[torch.Tensor] = None,
+) -> None:
+    """Symmetrically quantize BF16 K and scatter it into packed storage."""
+    key, out_cache_loc = _validate_quantize_inputs(
+        key, packed_cache, out_cache_loc, page_size
+    )
+    if int8_k is None or fp32_scales is None:
+        int8_k, fp32_scales = create_index_k_int8_aliases(packed_cache)
+    if key.numel() == 0:
+        return
+
+    if key.is_cuda:
+        _quantize_and_store_index_k_int8_kernel[(key.shape[0],)](
+            key,
+            int8_k,
+            fp32_scales,
+            out_cache_loc,
+            key.stride(0),
+            int8_k.stride(0),
+            fp32_scales.stride(0),
+            epsilon=epsilon,
+            HEAD_DIM=INDEX_K_HEAD_DIM,
+            PAGE_SIZE=INDEX_K_PAGE_SIZE,
+            num_warps=4,
+        )
+        return
+    _quantize_and_store_index_k_int8_reference(
+        key, int8_k, fp32_scales, out_cache_loc, epsilon
+    )
+
+
+@triton.jit
+def _dequantize_index_k_int8_paged_kernel(
+    int8_k_ptr,
+    scale_ptr,
+    block_tables_ptr,
+    context_lens_ptr,
+    workspace_ptr,
+    page_claims_ptr,
+    block_table_stride_0: tl.constexpr,
+    k_page_stride_0: tl.constexpr,
+    scale_page_stride_0: tl.constexpr,
+    workspace_page_stride_0: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    NUM_PHYSICAL_PAGES: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    logical_page_idx = tl.program_id(1)
+    context_len = tl.load(context_lens_ptr + batch_idx).to(tl.int64)
+    valid_page_count = (context_len + PAGE_SIZE - 1) // PAGE_SIZE
+    if logical_page_idx < valid_page_count:
+        physical_page = tl.load(
+            block_tables_ptr + batch_idx * block_table_stride_0 + logical_page_idx
+        ).to(tl.int64)
+        if (physical_page >= 0) & (physical_page < NUM_PHYSICAL_PAGES):
+            previous_claim = tl.atomic_cas(page_claims_ptr + physical_page, 0, 1)
+            if previous_claim == 0:
+                offsets = tl.arange(0, HEAD_DIM)
+                for token_offset in tl.static_range(0, PAGE_SIZE):
+                    quantized = tl.load(
+                        int8_k_ptr
+                        + physical_page * k_page_stride_0
+                        + token_offset * HEAD_DIM
+                        + offsets
+                    ).to(tl.float32)
+                    scale = tl.load(
+                        scale_ptr
+                        + physical_page * scale_page_stride_0
+                        + token_offset
+                    )
+                    tl.store(
+                        workspace_ptr
+                        + physical_page * workspace_page_stride_0
+                        + token_offset * HEAD_DIM
+                        + offsets,
+                        (quantized * scale).to(tl.bfloat16),
+                    )
+
+
+def _dequantize_index_k_int8_paged_reference(
+    int8_k: torch.Tensor,
+    fp32_scales: torch.Tensor,
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    workspace: torch.Tensor,
+    page_claims: torch.Tensor,
+) -> torch.Tensor:
+    page_claims.zero_()
+    for batch_idx, context_len in enumerate(context_lens.tolist()):
+        page_count = (int(context_len) + INDEX_K_PAGE_SIZE - 1) // INDEX_K_PAGE_SIZE
+        for physical_page in block_tables[batch_idx, :page_count].tolist():
+            if physical_page < 0:
+                continue
+            if physical_page >= int8_k.shape[0]:
+                raise ValueError(f"invalid physical index-K page ID {physical_page}")
+            if page_claims[physical_page] != 0:
+                continue
+            page_claims[physical_page] = 1
+            workspace[physical_page, :, 0, :] = (
+                int8_k[physical_page].float() * fp32_scales[physical_page, :, None]
+            ).to(torch.bfloat16)
+    return workspace
+
+
+def dequantize_index_k_int8_paged(
+    packed_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    workspace: torch.Tensor,
+    page_claims: torch.Tensor,
+    *,
+    int8_k: Optional[torch.Tensor] = None,
+    fp32_scales: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Dequantize referenced physical pages once into a BF16 workspace."""
+    expected_page_bytes = INDEX_K_PAGE_SIZE * INDEX_K_BYTES_PER_TOKEN
+    if (
+        packed_cache.dtype != torch.uint8
+        or packed_cache.ndim != 2
+        or packed_cache.shape[1] != expected_page_bytes
+        or not packed_cache.is_contiguous()
+    ):
+        raise ValueError("packed INT8 index-K cache has an invalid page-planar layout")
+    if workspace.dtype != torch.bfloat16 or workspace.ndim != 4:
+        raise ValueError(
+            "INT8 index-K workspace must have BF16 [pages, 64, 1, 128] layout"
+        )
+    expected_workspace_shape = (
+        packed_cache.shape[0],
+        INDEX_K_PAGE_SIZE,
+        1,
+        INDEX_K_HEAD_DIM,
+    )
+    if tuple(workspace.shape) != expected_workspace_shape:
+        raise ValueError(
+            "INT8 index-K workspace has invalid shape: "
+            f"expected {expected_workspace_shape}, got {tuple(workspace.shape)}"
+        )
+    if page_claims.dtype != torch.int32 or page_claims.numel() != packed_cache.shape[0]:
+        raise ValueError("INT8 index-K page_claims must be one int32 value per page")
+    if block_tables.ndim != 2 or context_lens.ndim != 1:
+        raise ValueError("block_tables must be 2D and context_lens must be 1D")
+    if block_tables.shape[0] != context_lens.shape[0]:
+        raise ValueError(
+            "block_tables and context_lens must have matching batch dimensions"
+        )
+
+    if int8_k is None or fp32_scales is None:
+        int8_k, fp32_scales = create_index_k_int8_aliases(packed_cache)
+    page_claims.zero_()
+    if context_lens.numel() == 0 or block_tables.shape[1] == 0:
+        return workspace
+
+    if packed_cache.is_cuda:
+        _dequantize_index_k_int8_paged_kernel[
+            (block_tables.shape[0], block_tables.shape[1])
+        ](
+            int8_k,
+            fp32_scales,
+            block_tables,
+            context_lens,
+            workspace,
+            page_claims,
+            block_tables.stride(0),
+            int8_k.stride(0),
+            fp32_scales.stride(0),
+            workspace.stride(0),
+            HEAD_DIM=INDEX_K_HEAD_DIM,
+            PAGE_SIZE=INDEX_K_PAGE_SIZE,
+            NUM_PHYSICAL_PAGES=packed_cache.shape[0],
+            num_warps=4,
+        )
+        return workspace
+    return _dequantize_index_k_int8_paged_reference(
+        int8_k, fp32_scales, block_tables, context_lens, workspace, page_claims
+    )
+
+
+def validate_hcu_int8_index_k_cache_server_args(
+    server_args, *, allow_mooncake_pd: bool
+) -> None:
+    """Reject combinations whose INT8 cache lifetime is not implemented."""
+    if not envs.SGLANG_DSA_HCU_INT8_INDEX_K_CACHE.get():
+        return
+
+    unsupported = []
+    if getattr(server_args, "enable_hisparse", False):
+        unsupported.append("--enable-hisparse")
+    if getattr(server_args, "enable_hierarchical_cache", False):
+        unsupported.append("--enable-hierarchical-cache")
+    if getattr(server_args, "cpu_offload_gb", 0) > 0:
+        unsupported.append("--cpu-offload-gb")
+    if getattr(server_args, "enable_two_batch_overlap", False):
+        unsupported.append("--enable-two-batch-overlap")
+
+    disaggregation_mode = getattr(server_args, "disaggregation_mode", "null")
+    if disaggregation_mode != "null":
+        backend = getattr(server_args, "disaggregation_transfer_backend", "mooncake")
+        if not allow_mooncake_pd or backend not in ("mooncake", "mooncake_tcp"):
+            unsupported.append(f"--disaggregation-transfer-backend={backend}")
+
+    if unsupported:
+        raise ValueError(
+            "SGLANG_DSA_HCU_INT8_INDEX_K_CACHE=1 does not support "
+            + ", ".join(unsupported)
+            + "."
+        )

--- a/python/sglang/srt/layers/attention/dsa/hcu_int8_index_k_cache.py
+++ b/python/sglang/srt/layers/attention/dsa/hcu_int8_index_k_cache.py
@@ -407,8 +407,6 @@ def validate_hcu_int8_index_k_cache_server_args(server_args) -> None:
     unsupported = []
     if getattr(server_args, "enable_hisparse", False):
         unsupported.append("--enable-hisparse")
-    if getattr(server_args, "enable_hierarchical_cache", False):
-        unsupported.append("--enable-hierarchical-cache")
     if getattr(server_args, "cpu_offload_gb", 0) > 0:
         unsupported.append("--cpu-offload-gb")
     if getattr(server_args, "enable_two_batch_overlap", False):

--- a/python/sglang/srt/layers/attention/dsa/hcu_sparse_mqa.py
+++ b/python/sglang/srt/layers/attention/dsa/hcu_sparse_mqa.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Hygon Information Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Eligibility checks for the paired LightOp sparse-MQA/mask-TopK path.
+
+The sparse Page-MQA kernel intentionally leaves logical ``+0.0`` logits
+unwritten. It is therefore safe only when its matching mask-aware paged TopK
+consumer is available. A rejected route must happen before the sparse producer
+runs so the dense Page-MQA path remains a correct fallback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional, Sequence
+
+import torch
+
+
+@dataclass(frozen=True)
+class LightOpSparseMQARoute:
+    """Validated sparse-MQA dispatch choice.
+
+    ``group_size == 1`` selects independent rows. Values 3, 4, and 5 select
+    the MTP grouped implementation, after the caller has proved that each
+    consecutive group shares one request's page table.
+    """
+
+    group_size: int
+
+
+@lru_cache(maxsize=1)
+def lightop_sparse_mask_api_available() -> bool:
+    """Return whether both the sparse producer and consumer APIs exist."""
+
+    try:
+        from lightop.attention import fast_topk_transform_sparse_mask_fused
+        from lightop.gemmopt import (
+            page_mqa_logits_sparse_mask,
+            page_mqa_logits_sparse_mask_grouped,
+        )
+    except (AttributeError, ImportError, OSError):
+        return False
+
+    return all(
+        callable(operation)
+        for operation in (
+            page_mqa_logits_sparse_mask,
+            page_mqa_logits_sparse_mask_grouped,
+            fast_topk_transform_sparse_mask_fused,
+        )
+    )
+
+
+def select_lightop_sparse_mqa_route(
+    *,
+    enabled: bool,
+    api_available: bool,
+    is_hcu: bool,
+    arch_name: str,
+    num_cus: int,
+    page_size: int,
+    topk: int,
+    fuse_topk: bool,
+    force_unfused_topk: bool,
+    topk_transform_method_name: str,
+    q: torch.Tensor,
+    fused_kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    max_context_len: int,
+    batch_size: int,
+    is_target_verify: bool,
+    is_draft_extend_v2: bool,
+    mtp_group_size: Optional[int],
+    grouping_lens_cpu: Sequence[int],
+) -> Optional[LightOpSparseMQARoute]:
+    """Choose the native gfx938 sparse-MQA route, or return ``None``.
+
+    The validated target is deliberately narrow: gfx938/64CU, E4M3FN Q,
+    packed FP8 KV, 32 heads, page size 64, and paged TopK=2048.
+    """
+
+    if not (
+        enabled
+        and api_available
+        and is_hcu
+        and fuse_topk
+        and not force_unfused_topk
+        and topk_transform_method_name == "PAGED"
+        and topk == 2048
+        and page_size == 64
+        and arch_name.startswith("gfx938")
+        and num_cus == 64
+    ):
+        return None
+
+    if (
+        q.dtype != torch.float8_e4m3fn
+        or q.dim() != 4
+        or tuple(q.shape[1:]) != (1, 32, 128)
+        or q.shape[0] <= 0
+        or not q.is_contiguous()
+    ):
+        return None
+
+    rows = q.shape[0]
+    if (
+        fused_kv_cache.dtype != torch.uint8
+        or fused_kv_cache.dim() != 4
+        or fused_kv_cache.shape[0] <= 0
+        or tuple(fused_kv_cache.shape[1:]) != (64, 1, 132)
+        or tuple(fused_kv_cache.stride()) != (64 * 132, 132, 132, 1)
+    ):
+        return None
+
+    if any(
+        tensor.device != q.device
+        for tensor in (fused_kv_cache, weights, context_lens, block_table)
+    ):
+        return None
+    if (
+        weights.dtype != torch.float32
+        or tuple(weights.shape) != (rows, 32)
+        or not weights.is_contiguous()
+    ):
+        return None
+    if (
+        context_lens.dtype != torch.int32
+        or tuple(context_lens.shape) != (rows,)
+        or not context_lens.is_contiguous()
+    ):
+        return None
+    if (
+        block_table.dtype != torch.int32
+        or block_table.dim() != 2
+        or block_table.shape[0] != rows
+        or not block_table.is_contiguous()
+        or max_context_len != block_table.shape[1] * page_size
+    ):
+        return None
+
+    if is_target_verify or is_draft_extend_v2:
+        if mtp_group_size not in (3, 4, 5):
+            return None
+        if rows != batch_size * mtp_group_size:
+            return None
+        has_request_lens = len(grouping_lens_cpu) == batch_size and all(
+            extend_len == mtp_group_size for extend_len in grouping_lens_cpu
+        )
+        has_expanded_row_lens = len(grouping_lens_cpu) == rows and all(
+            extend_len == 1 for extend_len in grouping_lens_cpu
+        )
+        if not (has_request_lens or has_expanded_row_lens):
+            return None
+        return LightOpSparseMQARoute(group_size=mtp_group_size)
+
+    if rows == batch_size:
+        return LightOpSparseMQARoute(group_size=1)
+    return None

--- a/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from enum import Enum
 
-from sglang.srt.utils import is_hip, is_sm100_supported
+from sglang.srt.utils import is_hcu, is_hip, is_sm100_supported
 
 
 class DSAPagedMQALogitsBackend(Enum):
     DEEPGEMM = "deepgemm"
     CUTEDSL = "cutedsl"
     AITER = "aiter"
+    LIGHTOP = "lightop"
 
     def is_deepgemm(self) -> bool:
         return self == DSAPagedMQALogitsBackend.DEEPGEMM
@@ -19,8 +20,21 @@ class DSAPagedMQALogitsBackend(Enum):
     def is_aiter(self) -> bool:
         return self == DSAPagedMQALogitsBackend.AITER
 
+    def is_lightop(self) -> bool:
+        return self == DSAPagedMQALogitsBackend.LIGHTOP
+
     @staticmethod
     def resolve(value: str) -> DSAPagedMQALogitsBackend:
+        # HCU reports itself as a HIP platform, but its DSA indexer uses the
+        # LightOp page-64 layout rather than AITER's ROCm layout.
+        if is_hcu():
+            if value not in ("auto", "lightop"):
+                raise ValueError(
+                    f"dsa_paged_mqa_logits_backend={value!r} is not supported on "
+                    "HCU; only 'lightop' is implemented."
+                )
+            return DSAPagedMQALogitsBackend.LIGHTOP
+
         if is_hip():
             if value not in ("auto", "aiter"):
                 raise ValueError(
@@ -33,6 +47,8 @@ class DSAPagedMQALogitsBackend(Enum):
             return DSAPagedMQALogitsBackend.DEEPGEMM
         if value == "aiter":
             raise ValueError("dsa_paged_mqa_logits_backend='aiter' requires ROCm.")
+        if value == "lightop":
+            raise ValueError("dsa_paged_mqa_logits_backend='lightop' requires HCU.")
         if value == "cutedsl":
             if not is_sm100_supported():
                 raise ValueError(

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -5,6 +5,9 @@ import torch
 import triton
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.dp_attention import DpPaddingMode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     is_in_breakable_cuda_graph,
@@ -142,12 +145,12 @@ def is_graph_dsa_split_op_surface(forward_batch: "ForwardBatch") -> bool:
     return (
         is_cuda()
         and (is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph())
-        and forward_batch.forward_mode.is_extend_without_speculative()
+        and effective_forward_mode(forward_batch).is_extend_without_speculative()
     )
 
 
 def can_dsa_prefill_cp_round_robin_split(forward_batch: "ForwardBatch"):
-    if not forward_batch.forward_mode.is_context_parallel_extend():
+    if not effective_forward_mode(forward_batch).is_context_parallel_extend():
         return False
     cp_size = get_parallel().attn_cp_size
     seq_len = sum(forward_batch.extend_seq_lens_cpu)
@@ -256,7 +259,7 @@ def can_dsa_cp_split(seq_len: int, cp_size: int, use_dsa: bool, forward_batch):
     if (
         cp_size <= 1
         or not use_dsa
-        or not forward_batch.forward_mode.is_context_parallel_extend()
+        or not effective_forward_mode(forward_batch).is_context_parallel_extend()
         or not is_dsa_enable_prefill_cp()
         or sum(forward_batch.extend_seq_lens_cpu) < cp_size
     ):
@@ -330,7 +333,7 @@ def dsa_use_prefill_cp(forward_batch, dsa_enable_prefill_cp=None):
     if (
         forward_batch.attn_cp_metadata is not None
         and dsa_enable_prefill_cp
-        and forward_batch.forward_mode.is_context_parallel_extend()
+        and effective_forward_mode(forward_batch).is_context_parallel_extend()
     ):
         return True
     else:

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -57,6 +57,9 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     get_flashmla_op,
     wrap_flashmla_metadata_result,
 )
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -766,7 +769,7 @@ class DeepseekSparseAttnBackend(
             req_pool_indices=forward_batch.req_pool_indices,
             seq_lens=forward_batch.seq_lens,
             seq_lens_cpu=seq_lens_cpu,
-            forward_mode=forward_batch.forward_mode,
+            forward_mode=effective_forward_mode(forward_batch),
             spec_info=forward_batch.spec_info,
             out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
             actual_forward_mode=getattr(forward_batch, "actual_forward_mode", None),
@@ -776,8 +779,9 @@ class DeepseekSparseAttnBackend(
         """Init the metadata for a forward pass."""
         batch_size = forward_batch.batch_size
         device = forward_batch.seq_lens.device
+        forward_mode = effective_forward_mode(forward_batch)
 
-        if forward_batch.forward_mode.is_target_verify():
+        if forward_mode.is_target_verify():
             draft_token_num = self.speculative_num_draft_tokens
         else:
             draft_token_num = 0
@@ -806,16 +810,14 @@ class DeepseekSparseAttnBackend(
         dsa_impl_for_batch = (
             self.dsa_decode_impl
             if (
-                forward_batch.forward_mode.is_decode_or_idle()
-                or forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             )
             else self.dsa_prefill_impl
         )
         use_flashmla_kv = (not self.use_mha) and dsa_impl_for_batch == "flashmla_kv"
-        topk_transform_method = self.get_topk_transform_method(
-            forward_batch.forward_mode
-        )
+        topk_transform_method = self.get_topk_transform_method(forward_mode)
         # Batch indices selected when cp enabled: After splitting multiple sequences,
         # a certain cp rank may not have some of these sequences.
         # We use bs_idx_cpu to mark which sequences are finally selected by the current cp rank,
@@ -825,12 +827,12 @@ class DeepseekSparseAttnBackend(
         indexer_seq_lens_cpu = forward_batch.seq_lens_cpu
         indexer_seq_lens = forward_batch.seq_lens
 
-        if forward_batch.forward_mode.is_decode_or_idle():
+        if forward_mode.is_decode_or_idle():
             extend_seq_lens_cpu = [1] * batch_size
             max_seqlen_q = 1
             cu_seqlens_q = self.get_device_int32_arange(batch_size + 1)
             seqlens_expanded = cache_seqlens_int32
-        elif forward_batch.forward_mode.is_target_verify():
+        elif forward_mode.is_target_verify():
             max_seqlen_q = 1
             cu_seqlens_q = torch.arange(
                 0,
@@ -851,7 +853,7 @@ class DeepseekSparseAttnBackend(
             page_table = torch.repeat_interleave(
                 page_table, repeats=self.speculative_num_draft_tokens, dim=0
             )
-        elif forward_batch.forward_mode.is_draft_extend_v2():
+        elif forward_mode.is_draft_extend_v2():
             if forward_batch.extend_prefix_lens_cpu is None:
                 assert forward_batch.extend_prefix_lens is not None
                 forward_batch.extend_prefix_lens_cpu = (
@@ -884,7 +886,7 @@ class DeepseekSparseAttnBackend(
                 sum(extend_seq_lens_cpu),
                 self.speculative_num_draft_tokens,
             )
-            if forward_batch.forward_mode.is_draft_extend_v2():
+            if forward_mode.is_draft_extend_v2():
                 # DRAFT_EXTEND_V2: V2 worker pre-fills draft KV cache with ALL speculated
                 # tokens upfront. All requests extend by the same fixed
                 # (speculative_num_draft_tokens). Use scalar to avoid GPU sync.
@@ -898,7 +900,7 @@ class DeepseekSparseAttnBackend(
                 page_table = torch.repeat_interleave(
                     page_table, repeats=forward_batch.extend_seq_lens, dim=0
                 )
-        elif forward_batch.forward_mode.is_extend():
+        elif forward_mode.is_extend():
             assert (
                 forward_batch.extend_seq_lens_cpu is not None
                 and forward_batch.extend_seq_lens is not None
@@ -1000,7 +1002,7 @@ class DeepseekSparseAttnBackend(
                     extend_seq_lens,
                 )
         else:
-            assert False, f"Unsupported {forward_batch.forward_mode = }"
+            assert False, f"Unsupported {forward_mode = }"
 
         indexer_k_start_end, token_to_batch_idx = self._cal_indexer_k_start_end(
             forward_batch, bs_idx_cpu
@@ -1019,12 +1021,12 @@ class DeepseekSparseAttnBackend(
         paged_mqa_schedule_metadata = None
         paged_mqa_ctx_lens_2d = None
         if is_cuda() and (
-            forward_batch.forward_mode.is_decode_or_idle()
-            or forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
+            forward_mode.is_decode_or_idle()
+            or forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
         ):
             paged_mqa_ctx_lens_2d = self._build_paged_mqa_schedule_2d_ctx_lens(
-                forward_batch.forward_mode,
+                forward_mode,
                 cache_seqlens_int32,
                 seqlens_expanded,
                 forward_batch.batch_size,
@@ -1077,7 +1079,7 @@ class DeepseekSparseAttnBackend(
         forward_batch: ForwardBatch,
         bs_idx: Optional[List[int]] = None,
     ):
-        if not forward_batch.forward_mode.is_extend_without_speculative():
+        if not effective_forward_mode(forward_batch).is_extend_without_speculative():
             return None, None
         if forward_batch.batch_size == 0 or (bs_idx is not None and len(bs_idx) == 0):
             empty_t = torch.empty(0, dtype=torch.int32, device=self.device)
@@ -1115,7 +1117,7 @@ class DeepseekSparseAttnBackend(
                 (extend_seq_len,), k_offset, dtype=torch.int32, device=self.device
             )
             kv_len = seq_len
-            if forward_batch.forward_mode.is_target_verify():
+            if effective_forward_mode(forward_batch).is_target_verify():
                 kv_len += self.speculative_num_draft_tokens
             seq_lens_expanded = torch.arange(
                 kv_len - extend_seq_len + 1,
@@ -1898,11 +1900,13 @@ class DeepseekSparseAttnBackend(
         metadata = self.forward_metadata
         assert causal, "DSA is causal only"
 
+        forward_mode = effective_forward_mode(forward_batch)
         dsa_impl = (
             self.dsa_decode_impl
             if (
-                forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
             )
             else self.dsa_prefill_impl
         )
@@ -1922,7 +1926,7 @@ class DeepseekSparseAttnBackend(
                 cos_sin_cache,
                 is_neox,
                 llama_4_scaling,
-                is_prefill=True,
+                is_prefill=not forward_mode.is_decode_or_idle(),
             )
 
         if k is not None:
@@ -1971,9 +1975,7 @@ class DeepseekSparseAttnBackend(
             q_rope = q_all[:, :, layer.v_head_dim :]
 
         # NOTE(dark): here, we use page size = 1
-        topk_transform_method = self.get_topk_transform_method(
-            forward_batch.forward_mode
-        )
+        topk_transform_method = self.get_topk_transform_method(forward_mode)
 
         if self.use_fused_topk:
             if topk_indices is not None:
@@ -2004,8 +2006,8 @@ class DeepseekSparseAttnBackend(
                     page_size=1,
                     output_num_tokens=q_nope.shape[0],
                     page_table_is_expanded=(
-                        forward_batch.forward_mode.is_target_verify()
-                        or forward_batch.forward_mode.is_draft_extend_v2()
+                        forward_mode.is_target_verify()
+                        or forward_mode.is_draft_extend_v2()
                     ),
                     cu_seqlens_q=metadata.cu_seqlens_q,
                 )
@@ -2478,7 +2480,8 @@ class DeepseekSparseAttnBackend(
             return False
         # RAGGED routing requires exactly EXTEND (excludes decode/idle, MIXED,
         # target-verify and draft-extend, which use dsa_decode_impl anyway).
-        if forward_batch.forward_mode != ForwardMode.EXTEND:
+        forward_mode = effective_forward_mode(forward_batch)
+        if forward_mode != ForwardMode.EXTEND:
             return False
         # Per-batch dense fallback (il <= threshold) reads bf16 q directly.
         if self.use_mha:
@@ -2491,10 +2494,7 @@ class DeepseekSparseAttnBackend(
             return False
         if is_dsa_enable_prefill_cp():
             return False
-        if (
-            self.get_topk_transform_method(forward_batch.forward_mode)
-            != TopkTransformMethod.RAGGED
-        ):
+        if self.get_topk_transform_method(forward_mode) != TopkTransformMethod.RAGGED:
             return False
         # Mirror the helper's head-padding compatibility check.
         if num_heads % 64 != 0 and 64 % num_heads != 0:
@@ -3219,8 +3219,8 @@ class DeepseekSparseAttnBackend(
                 page_size=1,
                 output_num_tokens=q.shape[0],
                 page_table_is_expanded=(
-                    forward_batch.forward_mode.is_target_verify()
-                    or forward_batch.forward_mode.is_draft_extend_v2()
+                    effective_forward_mode(forward_batch).is_target_verify()
+                    or effective_forward_mode(forward_batch).is_draft_extend_v2()
                 ),
                 cu_seqlens_q=metadata.cu_seqlens_q,
             )
@@ -3329,7 +3329,8 @@ class DeepseekSparseAttnBackend(
             # guarantee correctness.
             self.use_mha = False
         elif (
-            forward_batch and forward_batch.forward_mode.is_extend_without_speculative()
+            forward_batch
+            and effective_forward_mode(forward_batch).is_extend_without_speculative()
         ):
             # Check if sequence meets criteria for MHA_ONE_SHOT
             assert forward_batch.seq_lens_cpu is not None
@@ -3362,7 +3363,7 @@ class DeepseekSparseAttnBackend(
                 if (
                     is_blackwell()
                     and forward_batch is not None
-                    and forward_batch.forward_mode == ForwardMode.EXTEND
+                    and effective_forward_mode(forward_batch) == ForwardMode.EXTEND
                 ):
                     total_kv_tokens = forward_batch.seq_lens_sum
                     total_q_tokens = forward_batch.extend_num_tokens
@@ -3400,15 +3401,13 @@ class DeepseekSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:
+        forward_mode = effective_forward_mode(forward_batch)
         force_unfused = not self.use_fused_topk or (
-            self.hisparse_coordinator is not None
-            and forward_batch.forward_mode.is_decode_or_idle()
+            self.hisparse_coordinator is not None and forward_mode.is_decode_or_idle()
         )
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,
-            topk_transform_method=self.get_topk_transform_method(
-                forward_batch.forward_mode
-            ),
+            topk_transform_method=self.get_topk_transform_method(forward_mode),
             topk_backend=self.dsa_topk_backend,
             paged_mqa_schedule_metadata=self.forward_metadata.paged_mqa_schedule_metadata,
             paged_mqa_ctx_lens_2d=self.forward_metadata.paged_mqa_ctx_lens_2d,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -55,6 +55,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     DSAFlashMLAMetadata,
     can_fuse_flashmla_metadata,
     get_flashmla_op,
+    refresh_flashmla_metadata,
     wrap_flashmla_metadata_result,
 )
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
@@ -1282,14 +1283,14 @@ class DeepseekSparseAttnBackend(
             seqlens_expanded = cache_seqlens_int32
             dsa_extend_seq_lens_list = [1] * bs
             if self.dsa_decode_impl == "flashmla_kv":
-                flashmla_metadata = self.decode_cuda_graph_metadata[
-                    "flashmla_metadata"
-                ].slice(slice(0, bs + 1))
-                flashmla_metadata.copy_(
+                flashmla_metadata = refresh_flashmla_metadata(
+                    self.decode_cuda_graph_metadata["flashmla_metadata"],
                     self._compute_flashmla_metadata(
                         cache_seqlens=dsa_cache_seqlens_int32,
                         seq_len_q=1,
-                    )
+                    ),
+                    slice(0, bs + 1),
+                    is_hcu=_is_hcu,
                 )
             else:
                 flashmla_metadata = None
@@ -1344,15 +1345,14 @@ class DeepseekSparseAttnBackend(
             dsa_extend_seq_lens_list = [1] * bs * self.speculative_num_draft_tokens
 
             if self.dsa_decode_impl == "flashmla_kv":
-                flashmla_metadata = self.decode_cuda_graph_metadata[
-                    "flashmla_metadata"
-                ].slice(slice(0, bs * self.speculative_num_draft_tokens + 1))
-
-                flashmla_metadata.copy_(
+                flashmla_metadata = refresh_flashmla_metadata(
+                    self.decode_cuda_graph_metadata["flashmla_metadata"],
                     self._compute_flashmla_metadata(
                         cache_seqlens=dsa_cache_seqlens_int32,
                         seq_len_q=1,
-                    )
+                    ),
+                    slice(0, bs * self.speculative_num_draft_tokens + 1),
+                    is_hcu=_is_hcu,
                 )
             else:
                 flashmla_metadata = None
@@ -1698,15 +1698,17 @@ class DeepseekSparseAttnBackend(
             assert metadata.real_page_table is metadata.page_table_1
 
         if self.dsa_decode_impl == "flashmla_kv":
-            flashmla_metadata = metadata.flashmla_metadata.slice(
-                slice(0, seqlens_expanded_size + 1)
-            )
-            flashmla_metadata.copy_(
+            flashmla_metadata = refresh_flashmla_metadata(
+                metadata.flashmla_metadata,
                 self._compute_flashmla_metadata(
                     cache_seqlens=dsa_cache_seqlens,
                     seq_len_q=1,
-                )
+                ),
+                slice(0, seqlens_expanded_size + 1),
+                is_hcu=_is_hcu,
             )
+            if _is_hcu:
+                object.__setattr__(metadata, "flashmla_metadata", flashmla_metadata)
 
         self.forward_metadata = metadata
 
@@ -1851,11 +1853,26 @@ class DeepseekSparseAttnBackend(
                     precomputed.real_page_table
                 )
 
-            # Copy FlashMLA metadata in fallback path
-            if precomputed.flashmla_metadata is not None:
-                size = precomputed.seqlens_expanded_size
-                flashmla_metadata = metadata.flashmla_metadata.slice(slice(0, size + 1))
-                flashmla_metadata.copy_(precomputed.flashmla_metadata)
+        if precomputed.flashmla_metadata is not None and (
+            _is_hcu or not fused_kernel_succeeded
+        ):
+            size = precomputed.seqlens_expanded_size
+            flashmla_source = (
+                self._compute_flashmla_metadata(
+                    cache_seqlens=precomputed.dsa_cache_seqlens,
+                    seq_len_q=1,
+                )
+                if _is_hcu
+                else precomputed.flashmla_metadata
+            )
+            flashmla_metadata = refresh_flashmla_metadata(
+                metadata.flashmla_metadata,
+                flashmla_source,
+                slice(0, size + 1),
+                is_hcu=_is_hcu,
+            )
+            if _is_hcu:
+                object.__setattr__(metadata, "flashmla_metadata", flashmla_metadata)
 
         # Refresh DeepGEMM paged MQA schedule metadata for the actual seqlens of
         # this replay (the captured graph holds stale data otherwise, which can
@@ -3642,11 +3659,31 @@ class DeepseekSparseAttnMultiStepBackend:
                     and not fused_flashmla_metadata
                 ):
                     size = precomputed.seqlens_expanded_size
-                    for metadata in (metadata0, metadata1, metadata2):
-                        flashmla_metadata = metadata.flashmla_metadata.slice(
-                            slice(0, size + 1)
+                    for backend, metadata in zip(
+                        self.attn_backends[:3],
+                        (metadata0, metadata1, metadata2),
+                        strict=True,
+                    ):
+                        flashmla_source = (
+                            backend._compute_flashmla_metadata(
+                                cache_seqlens=precomputed.dsa_cache_seqlens,
+                                seq_len_q=1,
+                            )
+                            if _is_hcu
+                            else precomputed.flashmla_metadata
                         )
-                        flashmla_metadata.copy_(precomputed.flashmla_metadata)
+                        flashmla_metadata = refresh_flashmla_metadata(
+                            metadata.flashmla_metadata,
+                            flashmla_source,
+                            slice(0, size + 1),
+                            is_hcu=_is_hcu,
+                        )
+                        if _is_hcu:
+                            object.__setattr__(
+                                metadata,
+                                "flashmla_metadata",
+                                flashmla_metadata,
+                            )
 
                 # Copy remaining backends one by one (if > 3 backends)
                 for i in range(3, self.speculative_num_steps - 1):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -51,6 +51,12 @@ from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
     DSATopKBackend,
     TopkTransformMethod,
 )
+from sglang.srt.layers.attention.dsa.flashmla_backend import (
+    DSAFlashMLAMetadata,
+    can_fuse_flashmla_metadata,
+    get_flashmla_op,
+    wrap_flashmla_metadata_result,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -177,24 +183,6 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
         # view — we want (N_total, 1) regardless.
         seqlens_32 = seqlens_32.reshape(-1)
     return seqlens_32.contiguous().view(-1, 1)
-
-
-@dataclass(frozen=True)
-class DSAFlashMLAMetadata:
-    """Metadata only needed by FlashMLA"""
-
-    flashmla_metadata: torch.Tensor
-    num_splits: torch.Tensor
-
-    def slice(self, sli):
-        return DSAFlashMLAMetadata(
-            flashmla_metadata=self.flashmla_metadata,
-            num_splits=self.num_splits[sli],
-        )
-
-    def copy_(self, other: DSAFlashMLAMetadata):
-        self.flashmla_metadata.copy_(other.flashmla_metadata)
-        self.num_splits.copy_(other.num_splits)
 
 
 @dataclass(frozen=True)
@@ -1741,8 +1729,16 @@ class DeepseekSparseAttnBackend(
         # Track whether fused kernel succeeded
         fused_kernel_succeeded = False
 
-        # Use fused CUDA kernel for all copy operations
-        if not _is_hip:
+        # Use fused CUDA kernel for all copy operations. HCU FlashMLA keeps
+        # scheduler state in a backend object, which the tensor-only fused
+        # copy kernel cannot consume.
+        flashmla_metadata_can_fuse = precomputed.flashmla_metadata is None or (
+            can_fuse_flashmla_metadata(
+                precomputed.flashmla_metadata,
+                metadata.flashmla_metadata,
+            )
+        )
+        if not _is_hip and flashmla_metadata_can_fuse:
             try:
                 from sglang.kernels.ops.attention.fused_metadata_copy import (
                     fused_metadata_copy_cuda,
@@ -2408,16 +2404,21 @@ class DeepseekSparseAttnBackend(
         sm_scale: float,
         topk_length: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+        flash_mla_sparse_fwd = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=_is_hcu)
 
         # FlashMLA sparse kernel requires num_heads to be a multiple of 64 (Hopper) or 128 (Blackwell)
         # When using TP, num_heads might be smaller (e.g., 256//8=32)
         num_tokens, num_heads, head_dim = q_all.shape
 
-        # Determine required padding based on GPU architecture (use cached value)
-        required_padding = 128 if self.device_sm_major >= 10 else 64
-
-        need_padding = num_heads % required_padding != 0
+        # The CUDA kernels require Hopper/Blackwell head padding. HCU's
+        # external FlashMLA implementation accepts the native TP head count.
+        if _is_hcu:
+            required_padding = num_heads
+            need_padding = False
+        else:
+            # Determine required padding based on GPU architecture (use cached value)
+            required_padding = 128 if self.device_sm_major >= 10 else 64
+            need_padding = num_heads % required_padding != 0
 
         if need_padding:
             assert required_padding % num_heads == 0, (
@@ -2812,7 +2813,9 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata,
         page_table_1,
     ) -> torch.Tensor:
-        from sgl_kernel.flash_mla import flash_mla_with_kvcache
+        flash_mla_with_kvcache = get_flashmla_op(
+            "flash_mla_with_kvcache", is_hcu=_is_hcu
+        )
 
         cache_seqlens = metadata.dsa_cache_seqlens_int32
         assert metadata.flashmla_metadata is not None
@@ -3413,24 +3416,22 @@ class DeepseekSparseAttnBackend(
         )
 
     def _compute_flashmla_metadata(self, cache_seqlens: torch.Tensor, seq_len_q: int):
-        from sgl_kernel.flash_mla import get_mla_metadata
+        get_mla_metadata = get_flashmla_op("get_mla_metadata", is_hcu=_is_hcu)
 
         num_heads_q = self.flashmla_kv_num_q_heads
 
-        flashmla_metadata, num_splits = get_mla_metadata(
-            cache_seqlens=cache_seqlens,
-            # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`
-            #      but the name looks like need seq_len_q?
-            num_q_tokens_per_head_k=seq_len_q * num_heads_q // 1,
-            num_heads_k=1,
-            num_heads_q=num_heads_q,
-            is_fp8_kvcache=True,
-            topk=self.dsa_index_topk,
-        )
-
-        return DSAFlashMLAMetadata(
-            flashmla_metadata=flashmla_metadata,
-            num_splits=num_splits,
+        return wrap_flashmla_metadata_result(
+            get_mla_metadata(
+                cache_seqlens=cache_seqlens,
+                # TODO doc says `num_q_tokens_per_q_seq * num_heads_q // num_heads_k`
+                #      but the name looks like need seq_len_q?
+                num_q_tokens_per_head_k=seq_len_q * num_heads_q // 1,
+                num_heads_k=1,
+                num_heads_q=num_heads_q,
+                is_fp8_kvcache=True,
+                topk=self.dsa_index_topk,
+            ),
+            is_hcu=_is_hcu,
         )
 
 
@@ -3514,6 +3515,16 @@ class DeepseekSparseAttnMultiStepBackend:
                 for i in range(3):
                     self.attn_backends[i].set_dsa_prefill_impl(forward_batch=None)
 
+                # HCU FlashMLA metadata may be a backend object rather than a
+                # tensor. Fuse it only when every source/destination is a
+                # plain tensor; otherwise copy it with its backend wrapper.
+                fused_flashmla_metadata = can_fuse_flashmla_metadata(
+                    precomputed.flashmla_metadata,
+                    metadata0.flashmla_metadata,
+                    metadata1.flashmla_metadata,
+                    metadata2.flashmla_metadata,
+                )
+
                 # Prepare FlashMLA tensors if needed
                 flashmla_num_splits_src = None
                 flashmla_metadata_src = None
@@ -3524,7 +3535,7 @@ class DeepseekSparseAttnMultiStepBackend:
                 flashmla_metadata_dst1 = None
                 flashmla_metadata_dst2 = None
 
-                if precomputed.flashmla_metadata is not None:
+                if fused_flashmla_metadata:
                     flashmla_num_splits_src = precomputed.flashmla_metadata.num_splits
                     flashmla_metadata_src = (
                         precomputed.flashmla_metadata.flashmla_metadata
@@ -3597,6 +3608,17 @@ class DeepseekSparseAttnMultiStepBackend:
                     precomputed.max_len,
                     precomputed.seqlens_expanded_size,
                 )
+
+                if (
+                    precomputed.flashmla_metadata is not None
+                    and not fused_flashmla_metadata
+                ):
+                    size = precomputed.seqlens_expanded_size
+                    for metadata in (metadata0, metadata1, metadata2):
+                        flashmla_metadata = metadata.flashmla_metadata.slice(
+                            slice(0, size + 1)
+                        )
+                        flashmla_metadata.copy_(precomputed.flashmla_metadata)
 
                 # Copy remaining backends one by one (if > 3 backends)
                 for i in range(3, self.speculative_num_steps - 1):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -59,6 +59,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
 )
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
     effective_forward_mode,
+    get_flashmla_kv_valid_rows,
 )
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
@@ -2159,6 +2160,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                forward_batch=forward_batch,
             )
         elif dsa_impl == "fa3":
             return self._forward_fa3(
@@ -2314,6 +2316,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                forward_batch=forward_batch,
             )
         elif self.dsa_decode_impl == "tilelang":
             # Cat-skip (HIP-only): when caller passes q_rope=None on HIP, q_all
@@ -2812,6 +2815,7 @@ class DeepseekSparseAttnBackend(
         layer,
         metadata: DSAMetadata,
         page_table_1,
+        forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         flash_mla_with_kvcache = get_flashmla_op(
             "flash_mla_with_kvcache", is_hcu=_is_hcu
@@ -2845,24 +2849,49 @@ class DeepseekSparseAttnBackend(
             indices.shape[-1] == self.dsa_index_topk
         )  # requirement of FlashMLA decode kernel
 
-        o, _ = flash_mla_with_kvcache(
-            q=q_input,
-            k_cache=kv_cache,
-            cache_seqlens=cache_seqlens,
-            head_dim_v=v_head_dim,
-            tile_scheduler_metadata=metadata.flashmla_metadata.flashmla_metadata,
-            num_splits=metadata.flashmla_metadata.num_splits,
-            softmax_scale=sm_scale,
-            indices=indices,
-            # doc says it is not used, but if pass in None then error
-            block_table=torch.empty(
-                (q_all.shape[0], 0), dtype=torch.int32, device=q_all.device
-            ),
-            is_fp8_kvcache=True,
-        )
+        # MLP-sync can append synthetic speculative rows. HCU FlashMLA must
+        # only see the real prefix; downstream MLP-sync still needs the padded
+        # output shape, so restore it after the kernel returns.
+        num_total = q_input.shape[0]
+        num_valid = get_flashmla_kv_valid_rows(forward_batch, num_total)
+        needs_repad = _is_hcu and num_valid is not None
+        flashmla_metadata = metadata.flashmla_metadata
+        if needs_repad:
+            q_input = q_input[:num_valid]
+            indices = indices[:num_valid]
+            cache_seqlens = cache_seqlens[:num_valid]
+            if num_valid > 0:
+                flashmla_metadata = self._compute_flashmla_metadata(
+                    cache_seqlens=cache_seqlens,
+                    seq_len_q=1,
+                )
+
+        if needs_repad and num_valid == 0:
+            o = q_input.new_zeros((0, 1, target_q_heads, v_head_dim))
+        else:
+            o, _ = flash_mla_with_kvcache(
+                q=q_input,
+                k_cache=kv_cache,
+                cache_seqlens=cache_seqlens,
+                head_dim_v=v_head_dim,
+                tile_scheduler_metadata=flashmla_metadata.flashmla_metadata,
+                num_splits=flashmla_metadata.num_splits,
+                softmax_scale=sm_scale,
+                indices=indices,
+                # doc says it is not used, but if pass in None then error
+                block_table=torch.empty(
+                    (q_input.shape[0], 0), dtype=torch.int32, device=q_input.device
+                ),
+                is_fp8_kvcache=True,
+            )
+
+        if needs_repad:
+            full_o = o.new_zeros((num_total, *o.shape[1:]))
+            full_o[:num_valid] = o
+            o = full_o
 
         if target_q_heads != num_q_heads:
-            o = o[:, :, :num_q_heads, :]
+            o = o[:, :, :num_q_heads, :].contiguous()
 
         return o
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -300,6 +300,12 @@ class DeepseekSparseAttnBackend(
     # the D2H sync. The eager fallback derives lengths from GPU seq_lens.
     needs_cpu_seq_lens: bool = False
 
+    def _translate_main_kv_loc_to_compact(self, loc: torch.Tensor) -> torch.Tensor:
+        translate = getattr(
+            self.token_to_kv_pool, "translate_main_kv_loc_to_compact", None
+        )
+        return loc if translate is None else translate(loc)
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -2055,6 +2061,11 @@ class DeepseekSparseAttnBackend(
                 page_table_1
             ).to(torch.int32)
 
+        # Index-K keeps physical metadata. Translate only the final Main-KV
+        # consumer locations into this batch's compact scratch layout.
+        if topk_transform_method == TopkTransformMethod.PAGED:
+            page_table_1 = self._translate_main_kv_loc_to_compact(page_table_1)
+
         if dsa_impl == "tilelang":
             if q_rope is not None:
                 # Triton prefill kernel reads q_nope/q_rope directly, skipping
@@ -2107,6 +2118,9 @@ class DeepseekSparseAttnBackend(
                             self.forward_metadata.page_table_1_flattened
                         )
                         assert page_table_1_flattened is not None
+                        page_table_1_flattened = self._translate_main_kv_loc_to_compact(
+                            page_table_1_flattened
+                        )
                         return self._forward_flashmla_sparse_q8kv8(
                             q_nope=q_nope,
                             q_rope=q_rope,
@@ -2154,6 +2168,9 @@ class DeepseekSparseAttnBackend(
                         self.forward_metadata.page_table_1_flattened
                     )
                     assert page_table_1_flattened is not None
+                    page_table_1_flattened = self._translate_main_kv_loc_to_compact(
+                        page_table_1_flattened
+                    )
                     kv_cache = dequantize_k_cache_paged(
                         kv_cache, page_table_1_flattened
                     )
@@ -3328,6 +3345,8 @@ class DeepseekSparseAttnBackend(
                 topk_indices=topk_indices,
                 page_size=1,
             )
+
+        page_table_1 = self._translate_main_kv_loc_to_compact(page_table_1)
 
         q_scale = 1.0
         k_scale = (

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1992,6 +1992,10 @@ class DeepseekSparseAttnBackend(
             q_nope = q_all[:, :, : layer.v_head_dim]
             q_rope = q_all[:, :, layer.v_head_dim :]
 
+        topk_was_padded = (
+            topk_indices is not None and topk_indices.shape[0] != q_nope.shape[0]
+        )
+
         # NOTE(dark): here, we use page size = 1
         topk_transform_method = self.get_topk_transform_method(forward_mode)
 
@@ -2144,6 +2148,15 @@ class DeepseekSparseAttnBackend(
 
             if q_rope is not None:
                 q_all = concat_mla_absorb_q_general(q_nope, q_rope)
+            skip_reused_topk_sort = (
+                _is_hcu
+                and envs.SGLANG_DSA_HCU_REUSE_SORTED_TOPK.get()
+                and getattr(layer, "reuse_topk_indices", False)
+                and not topk_was_padded
+                and envs.SGLANG_DSA_FUSE_TOPK.get()
+                and topk_transform_method == TopkTransformMethod.RAGGED
+                and self.hisparse_coordinator is None
+            )
             return self._forward_flashmla_sparse(
                 q_all=q_all,
                 kv_cache=kv_cache,
@@ -2151,6 +2164,7 @@ class DeepseekSparseAttnBackend(
                 sm_scale=layer.scaling,
                 v_head_dim=layer.v_head_dim,
                 topk_length=metadata.dsa_cache_seqlens_int32,
+                indices_are_sorted=skip_reused_topk_sort,
             )
         elif dsa_impl == "flashinfer_sparse_mla":
             if q_rope is not None:
@@ -2425,6 +2439,7 @@ class DeepseekSparseAttnBackend(
         page_table_1: torch.Tensor,
         sm_scale: float,
         topk_length: Optional[torch.Tensor] = None,
+        indices_are_sorted: bool = False,
     ) -> torch.Tensor:
         flash_mla_sparse_fwd = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=_is_hcu)
 
@@ -2470,14 +2485,35 @@ class DeepseekSparseAttnBackend(
             # they ever diverge.
             topk_length = None
 
-        o, _, _ = flash_mla_sparse_fwd(
-            q=q_input,
-            kv=kv_cache,
-            indices=indices_input,
-            sm_scale=sm_scale,
-            d_v=v_head_dim,
-            topk_length=topk_length,
-        )
+        raw_sparse_prefill_fwd = None
+        if _is_hcu and indices_are_sorted:
+            from flash_mla import flash_mla_interface
+
+            raw_sparse_prefill_fwd = getattr(
+                getattr(flash_mla_interface, "flash_mla_cuda", None),
+                "sparse_prefill_fwd",
+                None,
+            )
+
+        if raw_sparse_prefill_fwd is not None:
+            o, _, _ = raw_sparse_prefill_fwd(
+                q_input,
+                kv_cache,
+                indices_input,
+                sm_scale,
+                v_head_dim,
+                None,
+                topk_length,
+            )
+        else:
+            o, _, _ = flash_mla_sparse_fwd(
+                q=q_input,
+                kv=kv_cache,
+                indices=indices_input,
+                sm_scale=sm_scale,
+                d_v=v_head_dim,
+                topk_length=topk_length,
+            )
 
         # Trim output back to original num_heads if we padded
         if need_padding:

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -45,6 +45,7 @@ from sglang.srt.layers.attention.dsa.dsa_backend_mtp_precompute import (
     DeepseekSparseAttnBackendMTPPrecomputeMixin,
     PrecomputedMetadata,
     compute_cu_seqlens,
+    fill_decode_page_table_gpu,
 )
 from sglang.srt.layers.attention.dsa.dsa_indexer_metadata import DSAIndexerMetadata
 from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
@@ -1409,7 +1410,7 @@ class DeepseekSparseAttnBackend(
         bs: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
-        seq_lens_cpu: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
         out_cache_loc: Optional[torch.Tensor] = None,
@@ -1480,8 +1481,14 @@ class DeepseekSparseAttnBackend(
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
                 )
-                page_indices = self.req_to_token[req_pool_indices, :max_len]
-                metadata.page_table_1[:, :max_len].copy_(page_indices)
+                fill_decode_page_table_gpu(
+                    self.req_to_token,
+                    req_pool_indices,
+                    seq_lens,
+                    metadata.page_table_1,
+                    bs,
+                )
+                page_indices = metadata.page_table_1
                 dsa_cache_seqlens = compute_dsa_seqlens(
                     cache_seqlens, dsa_index_topk=self.dsa_index_topk
                 )

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -770,6 +770,36 @@ class DeepseekSparseAttnBackend(
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
+        if _is_hcu:
+            # HCU records the static-shape metadata kernels through
+            # init_forward_metadata_in_graph. At replay the captured graph reads
+            # the live input buffers directly, so the host only has to select
+            # the metadata object captured for this batch-size bucket.
+            bs = forward_batch.batch_size
+            if bs not in self.decode_cuda_graph_metadata:
+                seq_lens_cpu = (
+                    forward_batch.seq_lens.cpu()
+                    if in_capture
+                    else forward_batch.seq_lens_cpu
+                )
+                self._build_forward_metadata_cuda_graph(
+                    bs=bs,
+                    num_tokens=None,
+                    req_pool_indices=forward_batch.req_pool_indices,
+                    seq_lens=forward_batch.seq_lens,
+                    seq_lens_cpu=seq_lens_cpu,
+                    forward_mode=effective_forward_mode(forward_batch),
+                    spec_info=forward_batch.spec_info,
+                    out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
+                    actual_forward_mode=getattr(
+                        forward_batch, "actual_forward_mode", None
+                    ),
+                )
+            else:
+                self.set_dsa_prefill_impl(forward_batch=None)
+                self.forward_metadata = self.decode_cuda_graph_metadata[bs]
+            return
+
         seq_lens_cpu = (
             forward_batch.seq_lens.cpu() if in_capture else forward_batch.seq_lens_cpu
         )
@@ -778,6 +808,24 @@ class DeepseekSparseAttnBackend(
             req_pool_indices=forward_batch.req_pool_indices,
             seq_lens=forward_batch.seq_lens,
             seq_lens_cpu=seq_lens_cpu,
+            forward_mode=effective_forward_mode(forward_batch),
+            spec_info=forward_batch.spec_info,
+            out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
+            actual_forward_mode=getattr(forward_batch, "actual_forward_mode", None),
+        )
+
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch) -> None:
+        if not _is_hcu:
+            return
+        # Restore the pre-forward-port behavior for HCU: metadata tensor
+        # generation is captured once and automatically replayed after the
+        # runner refreshes its static input buffers. This removes the per-step
+        # host launch train from _apply_cuda_graph_metadata.
+        self._apply_cuda_graph_metadata(
+            bs=forward_batch.batch_size,
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens,
+            seq_lens_cpu=None,
             forward_mode=effective_forward_mode(forward_batch),
             spec_info=forward_batch.spec_info,
             out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
@@ -3591,7 +3639,7 @@ class DeepseekSparseAttnMultiStepBackend:
     ):
         from sglang.srt.model_executor.forward_batch_info import build_inner_fb_view
 
-        if in_capture:
+        if in_capture or _is_hcu:
             inner_fb = build_inner_fb_view(
                 forward_batch,
                 bs=forward_batch.batch_size,
@@ -3599,7 +3647,7 @@ class DeepseekSparseAttnMultiStepBackend:
             )
             for i in range(self.speculative_num_steps - 1):
                 self.attn_backends[i].init_forward_metadata_out_graph(
-                    inner_fb, in_capture=True
+                    inner_fb, in_capture=in_capture
                 )
             return
 
@@ -3793,8 +3841,18 @@ class DeepseekSparseAttnMultiStepBackend:
                 )
 
     def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch) -> None:
+        if _is_hcu:
+            from sglang.srt.model_executor.forward_batch_info import build_inner_fb_view
+
+            inner_fb = build_inner_fb_view(
+                forward_batch,
+                bs=forward_batch.batch_size,
+                forward_mode=ForwardMode.DECODE,
+            )
+        else:
+            inner_fb = forward_batch
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata_in_graph(forward_batch)
+            self.attn_backends[i].init_forward_metadata_in_graph(inner_fb)
 
 
 # Backward-compat aliases (deprecated: use DSA class names)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1203,6 +1203,15 @@ class DeepseekSparseAttnBackend(
             "cu_seqlens_k": torch.zeros(
                 max_bs + 1, dtype=torch.int32, device=self.device
             ),
+            # TARGET_VERIFY has a fixed number of query tokens per request.
+            # Keep those lengths on device so graph replay does not allocate and
+            # fill a new tensor on every speculative step.
+            "target_verify_extend_seq_lens": torch.full(
+                (max_bs,),
+                self.speculative_num_draft_tokens or 0,
+                dtype=torch.int32,
+                device=self.device,
+            ),
             # fake page_table for sparse_prefill
             # Match req_to_token's width exactly. It is over-allocated beyond
             # context_len because spec decoding lets seq_len transiently overshoot.
@@ -1553,18 +1562,16 @@ class DeepseekSparseAttnBackend(
                 )
                 page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
                 page_indices = torch.repeat_interleave(
-                    page_indices, repeats=self.speculative_num_draft_tokens, dim=0
+                    page_indices,
+                    repeats=self.speculative_num_draft_tokens,
+                    dim=0,
+                    output_size=bs * self.speculative_num_draft_tokens,
                 )
                 metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
 
-                # Fill the constant per-req qo lengths on-device; torch.tensor(list,
-                # device=cuda) does a pageable H2D copy that blocks the host.
-                extend_seq_lens = torch.full(
-                    (bs,),
-                    self.speculative_num_draft_tokens,
-                    dtype=torch.int32,
-                    device=self.device,
-                )
+                extend_seq_lens = self.decode_cuda_graph_metadata[
+                    "target_verify_extend_seq_lens"
+                ][:bs]
                 seqlens_expanded = seqlens_expand_triton(
                     extend_seq_lens,
                     cache_seqlens,

--- a/python/sglang/srt/layers/communicator_dsa_cp.py
+++ b/python/sglang/srt/layers/communicator_dsa_cp.py
@@ -102,7 +102,7 @@ def maybe_prefetch_full_attention_kv(
     forward_batch: ForwardBatch,
     full_attention_layer_id: Optional[int],
 ) -> None:
-    """Configure the batch page plan and prefetch one DSA layer's Main-KV."""
+    """Configure the batch plan and prefetch one DSA layer's caches."""
 
     maybe_configure_main_kv_page_plan(forward_batch)
 
@@ -110,11 +110,20 @@ def maybe_prefetch_full_attention_kv(
         return
 
     token_to_kv_pool = get_token_to_kv_pool()
+    has_history = _dsa_prefill_has_history(forward_batch)
+    # Index-K and Main-KV share one communicator. Every rank must enqueue
+    # collectives in this order; skip-topk layers make the Index-K call a no-op.
+    prefetch_index_buffer = getattr(token_to_kv_pool, "prefetch_index_buffer", None)
+    if is_hcu() and prefetch_index_buffer is not None:
+        prefetch_index_buffer(
+            full_attention_layer_id,
+            has_history=has_history,
+        )
     prefetch_kv_buffer = getattr(token_to_kv_pool, "prefetch_kv_buffer", None)
     if prefetch_kv_buffer is not None:
         prefetch_kv_buffer(
             full_attention_layer_id,
-            has_history=_dsa_prefill_has_history(forward_batch),
+            has_history=has_history,
         )
 
 

--- a/python/sglang/srt/layers/communicator_dsa_cp.py
+++ b/python/sglang/srt/layers/communicator_dsa_cp.py
@@ -37,9 +37,14 @@ from sglang.srt.layers.dp_attention import (
     get_local_dp_buffer,
 )
 from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
+from sglang.srt.mem_cache.dsa_cache_layer_split import build_main_kv_page_plan
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
+from sglang.srt.model_executor.forward_context import (
+    get_req_to_token_pool,
+    get_token_to_kv_pool,
+)
 from sglang.srt.runtime_context import get_parallel
+from sglang.srt.utils import is_hcu
 
 
 def dsa_enable_prefill_cp():
@@ -49,23 +54,77 @@ def dsa_enable_prefill_cp():
     return is_dsa_enable_prefill_cp()
 
 
+def _dsa_prefill_has_history(forward_batch: ForwardBatch) -> bool:
+    prefix_lens = forward_batch.extend_prefix_lens_cpu
+    if prefix_lens is None:
+        return True
+    return any(int(prefix_len) > 0 for prefix_len in prefix_lens)
+
+
+def maybe_configure_main_kv_page_plan(forward_batch: ForwardBatch) -> None:
+    """Install this batch's compact Main-KV mapping when LayerSplit is active."""
+
+    token_to_kv_pool = get_token_to_kv_pool()
+    use_prefill_cp = dsa_use_prefill_cp(forward_batch)
+    configure_page_plan = getattr(token_to_kv_pool, "configure_main_kv_page_plan", None)
+    if configure_page_plan is not None:
+        page_plan = None
+        can_compact_main_kv = (
+            is_hcu()
+            and getattr(token_to_kv_pool, "layer_shard_enabled", False)
+            and use_prefill_cp
+            and forward_batch.forward_mode.is_extend_without_speculative()
+            # Compact mapping is batch-specific; retain the official full-
+            # scratch path while TBO alternates between two child batches.
+            and not forward_batch.can_run_tbo
+            and forward_batch.tbo_parent_token_range is None
+            and forward_batch.extend_prefix_lens_cpu is not None
+            and forward_batch.out_cache_loc is not None
+        )
+        if can_compact_main_kv:
+            if forward_batch.dsa_layer_split_main_kv_page_plan is None:
+                forward_batch.dsa_layer_split_main_kv_page_plan = (
+                    build_main_kv_page_plan(
+                        req_to_token=get_req_to_token_pool().req_to_token,
+                        req_pool_indices=forward_batch.req_pool_indices,
+                        prefix_lens=forward_batch.extend_prefix_lens_cpu,
+                        current_locs=forward_batch.out_cache_loc,
+                        page_size=token_to_kv_pool.page_size,
+                    )
+                )
+            page_plan = forward_batch.dsa_layer_split_main_kv_page_plan
+        # Explicitly clear a compact layout left by an earlier ForwardBatch
+        # before entering the legacy full-pool path.
+        configure_page_plan(page_plan, forward_batch)
+
+
+def maybe_prefetch_full_attention_kv(
+    forward_batch: ForwardBatch,
+    full_attention_layer_id: Optional[int],
+) -> None:
+    """Configure the batch page plan and prefetch one DSA layer's Main-KV."""
+
+    maybe_configure_main_kv_page_plan(forward_batch)
+
+    if full_attention_layer_id is None or not dsa_use_prefill_cp(forward_batch):
+        return
+
+    token_to_kv_pool = get_token_to_kv_pool()
+    prefetch_kv_buffer = getattr(token_to_kv_pool, "prefetch_kv_buffer", None)
+    if prefetch_kv_buffer is not None:
+        prefetch_kv_buffer(
+            full_attention_layer_id,
+            has_history=_dsa_prefill_has_history(forward_batch),
+        )
+
+
 def maybe_prefetch_next_full_attention_kv(
     forward_batch: ForwardBatch,
     next_full_attention_layer_id: Optional[int],
 ) -> None:
-    """Prefetch (owner-broadcast) the next layer's DSA KV under layer split.
+    """Prefetch the next layer while the current layer's MLP runs."""
 
-    No-op unless the current batch runs DSA prefill-CP and the active KV pool is
-    a layer-sharded pool exposing ``prefetch_kv_buffer`` (i.e.
-    ``LayerSplitDSATokenToKVPool``). Kicking the broadcast off one layer ahead
-    overlaps it with the current layer's attention compute.
-    """
-    if next_full_attention_layer_id is None or not dsa_use_prefill_cp(forward_batch):
-        return
-
-    prefetch_kv_buffer = getattr(get_token_to_kv_pool(), "prefetch_kv_buffer", None)
-    if prefetch_kv_buffer is not None:
-        prefetch_kv_buffer(next_full_attention_layer_id)
+    maybe_prefetch_full_attention_kv(forward_batch, next_full_attention_layer_id)
 
 
 def dsa_cp_gather_hidden_states(hidden_states: torch.Tensor):

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -96,7 +96,7 @@ from sglang.srt.eplb.expert_location_dispatch import (
     topk_ids_logical_to_physical,
 )
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
-from sglang.srt.layers.moe import get_moe_runner_backend
+from sglang.srt.layers.moe import get_moe_a2a_backend, get_moe_runner_backend
 from sglang.srt.layers.moe.utils import (
     has_per_rank_fused_shared_slots,
 )
@@ -2276,6 +2276,11 @@ def _post_process_topk_ids(
     capture_routed_experts_if_allowed(topk_config, layer_id, topk_ids)
     recorder_topk_ids = None
     _fold_pad_into_append = False
+    skip_deepep_padded_tokens = (
+        _is_hcu
+        and get_moe_a2a_backend().is_deepep()
+        and get_moe_runner_backend().is_deep_gemm()
+    )
     if _is_cuda:
         # LP path: solve LP outside torch.compile (the solver contains an
         # EP all-reduce that can't run inside compiled regions).
@@ -2316,10 +2321,10 @@ def _post_process_topk_ids(
             )
     elif _is_hip:
         # On AMD HIP the aiter MoE kernels do not handle topk_ids=-1 safely
-        # (negative indices cause illegal memory access). Always fill the padded
-        # region with 0 so every kernel sees a valid in-range expert id.
-        # Routing weights for padded tokens are zeroed below so their
-        # contribution to the hidden state is still zero regardless of the id.
+        # (negative indices cause illegal memory access). Keep their padded IDs
+        # in range and zero their weights below. HCU DeepEP + DeepGEMM instead
+        # masks the final IDs to -1 after shared-expert remapping so dispatch can
+        # omit padded tokens, matching the pre-forward-port behavior.
         # Regression: skipping this mask when EPLB is disabled caused garbage
         # MoE routing for models like DeepSeek-R1-MXFP4 (accuracy ~0.09 vs 0.94+).
         #
@@ -2328,12 +2333,13 @@ def _post_process_topk_ids(
         # (pad_fill_id=0 -> remap(0)=0, bit-identical), so skip the separate
         # _fill_padded_rows launch here.
         _fold_pad_into_append = (
-            num_fused_shared_experts > 0
+            not skip_deepep_padded_tokens
+            and num_fused_shared_experts > 0
             and _use_aiter
             and use_per_rank_shared_slots
             and not _eplb_remap_enabled()
         )
-        if not _fold_pad_into_append:
+        if not skip_deepep_padded_tokens and not _fold_pad_into_append:
             _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=0)
         # The logical->physical remap is only meaningful when a real
         # expert-location mapping exists. With a trivial placement and EPLB off
@@ -2430,7 +2436,11 @@ def _post_process_topk_ids(
             topk_config,
         )
 
-    if _is_hip and not _skip_hip_pad_mask:
+    if skip_deepep_padded_tokens:
+        # Apply this after shared-expert remapping so every padded route,
+        # including appended shared slots, is omitted by DeepEP dispatch.
+        _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=-1)
+    elif _is_hip and not _skip_hip_pad_mask:
         # Shared-expert append/remap can introduce non-zero weights after the
         # initial HIP padding mask above. Ensure padded tokens leave this helper
         # with all expert weights zeroed.

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -2459,7 +2459,7 @@ def _post_process_topk_ids(
         # Apply this after shared-expert remapping so every padded route,
         # including appended shared slots, is omitted by DeepEP dispatch.
         _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=-1)
-    elif _is_hip and not _skip_hip_pad_mask:
+    elif _is_hip and not skip_deepep_padded_tokens and not _skip_hip_pad_mask:
         # Shared-expert append/remap can introduce non-zero weights after the
         # initial HIP padding mask above. Ensure padded tokens leave this helper
         # with all expert weights zeroed.

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1666,7 +1666,15 @@ def _topk_ids_postprocess_torch(
     topk_ids, expert_location_dispatch_info, num_token_non_padded
 ):
     topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
-    _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    if _is_hip and num_token_non_padded is not None:
+        # Keep the HIP fallback as plain torch ops inside this compiled region.
+        # Calling _fill_padded_rows here would introduce a separate explicit
+        # Triton launch after the logical-to-physical gather, while Inductor can
+        # fuse this mask with that gather just like the pre-forward-port path.
+        indices = torch.arange(0, topk_ids.shape[0], device=topk_ids.device)
+        topk_ids[indices >= num_token_non_padded, :] = -1
+    else:
+        _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
     return topk_ids
 
 
@@ -2284,6 +2292,7 @@ def _post_process_topk_ids(
         and get_moe_a2a_backend().is_deepep()
         and (get_moe_runner_backend().is_deep_gemm() or _use_deepgemm_moe)
     )
+    hip_deepep_postprocessed = False
     if _is_cuda:
         # LP path: solve LP outside torch.compile (the solver contains an
         # EP all-reduce that can't run inside compiled regions).
@@ -2330,27 +2339,34 @@ def _post_process_topk_ids(
         # omit padded tokens, matching the pre-forward-port behavior.
         # Regression: skipping this mask when EPLB is disabled caused garbage
         # MoE routing for models like DeepSeek-R1-MXFP4 (accuracy ~0.09 vs 0.94+).
-        #
-        # Fold: when the fused append+remap kernel runs below (aiter per-rank
-        # shared-slot path, EPLB off) it folds this padded fill itself
-        # (pad_fill_id=0 -> remap(0)=0, bit-identical), so skip the separate
-        # _fill_padded_rows launch here.
-        _fold_pad_into_append = (
-            not skip_deepep_padded_tokens
-            and num_fused_shared_experts > 0
-            and _use_aiter
-            and use_per_rank_shared_slots
-            and not _eplb_remap_enabled()
-        )
+        remap_info = expert_location_dispatch_info if _eplb_remap_enabled() else None
+        if skip_deepep_padded_tokens and not use_per_rank_shared_slots:
+            # DeepEP disables shared-expert fusion by default. On that main HCU
+            # path no later operation can introduce another route, so remap and
+            # the final -1 padding mask can be compiled into one kernel. Keep
+            # the post-shared-expert mask below for the explicitly forced fused
+            # shared-expert configuration.
+            topk_ids = _biased_grouped_topk_postprocess(
+                topk_ids, remap_info, num_token_non_padded
+            )
+            hip_deepep_postprocessed = True
+        else:
+            # The fused append+remap kernel can fold the padded fill into its
+            # existing launch on the aiter per-rank shared-slot path.
+            _fold_pad_into_append = (
+                not skip_deepep_padded_tokens
+                and num_fused_shared_experts > 0
+                and _use_aiter
+                and use_per_rank_shared_slots
+                and remap_info is None
+            )
         if not skip_deepep_padded_tokens and not _fold_pad_into_append:
             _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=0)
         # The logical->physical remap is only meaningful when a real
         # expert-location mapping exists. With a trivial placement and EPLB off
         # the map is identity so the remap can be skipped safely.
-        if _eplb_remap_enabled():
-            topk_ids = topk_ids_logical_to_physical(
-                topk_ids, expert_location_dispatch_info
-            )
+        if remap_info is not None and not hip_deepep_postprocessed:
+            topk_ids = topk_ids_logical_to_physical(topk_ids, remap_info)
         # NOTE (HIP): padded-token routing-weight zeroing is deferred to the
         # single pass at the end of this function (gated by SGLANG_MORI_NO_PAD_MASK).
         # That final pass re-zeros after any shared-expert append/remap, so a
@@ -2439,7 +2455,7 @@ def _post_process_topk_ids(
             topk_config,
         )
 
-    if skip_deepep_padded_tokens:
+    if skip_deepep_padded_tokens and not hip_deepep_postprocessed:
         # Apply this after shared-expert remapping so every padded route,
         # including appended shared slots, is omitted by DeepEP dispatch.
         _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=-1)

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1663,7 +1663,10 @@ def _zero_topk_weights_padded_region(
 
 @torch.compile(dynamic=True, backend=get_compiler_backend())
 def _topk_ids_postprocess_torch(
-    topk_ids, expert_location_dispatch_info, num_token_non_padded
+    topk_ids,
+    expert_location_dispatch_info,
+    num_token_non_padded,
+    output_int64: bool = False,
 ):
     topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
     if _is_hip and num_token_non_padded is not None:
@@ -1675,6 +1678,8 @@ def _topk_ids_postprocess_torch(
         topk_ids[indices >= num_token_non_padded, :] = -1
     else:
         _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    if output_int64 and topk_ids.dtype != torch.int64:
+        topk_ids = topk_ids.to(torch.int64)
     return topk_ids
 
 
@@ -1729,25 +1734,43 @@ def _topk_ids_postprocess(
     topk_ids: torch.Tensor,
     expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo],
     num_token_non_padded: Optional[torch.Tensor],
+    output_int64: bool = False,
 ) -> torch.Tensor:
-    if expert_location_dispatch_info is None and num_token_non_padded is None:
+    if (
+        expert_location_dispatch_info is None
+        and num_token_non_padded is None
+        and (not output_int64 or topk_ids.dtype == torch.int64)
+    ):
         return topk_ids
 
-    lightop_output = _try_lightop_topk_ids_postprocess(
-        topk_ids, expert_location_dispatch_info, num_token_non_padded
-    )
-    if lightop_output is not None:
-        return lightop_output
+    # An int32 -> int64 result must stay in the compiled fallback so Inductor
+    # can fuse it with the remap/padding work. If the input is already int64,
+    # the in-place LightOp path still satisfies the requested output dtype.
+    if not output_int64 or topk_ids.dtype == torch.int64:
+        lightop_output = _try_lightop_topk_ids_postprocess(
+            topk_ids, expert_location_dispatch_info, num_token_non_padded
+        )
+        if lightop_output is not None:
+            return lightop_output
     return _topk_ids_postprocess_torch(
-        topk_ids, expert_location_dispatch_info, num_token_non_padded
+        topk_ids,
+        expert_location_dispatch_info,
+        num_token_non_padded,
+        output_int64,
     )
 
 
 def _biased_grouped_topk_postprocess(
-    topk_ids, expert_location_dispatch_info, num_token_non_padded
+    topk_ids,
+    expert_location_dispatch_info,
+    num_token_non_padded,
+    output_int64: bool = False,
 ):
     return _topk_ids_postprocess(
-        topk_ids, expert_location_dispatch_info, num_token_non_padded
+        topk_ids,
+        expert_location_dispatch_info,
+        num_token_non_padded,
+        output_int64,
     )
 
 
@@ -2343,11 +2366,16 @@ def _post_process_topk_ids(
         if skip_deepep_padded_tokens and not use_per_rank_shared_slots:
             # DeepEP disables shared-expert fusion by default. On that main HCU
             # path no later operation can introduce another route, so remap and
-            # the final -1 padding mask can be compiled into one kernel. Keep
+            # the final -1 padding mask can be compiled into one kernel. Emit
+            # int64 from that kernel as well because DeepEP requires int64 IDs;
+            # otherwise its dispatcher adds one copy kernel per MoE layer. Keep
             # the post-shared-expert mask below for the explicitly forced fused
             # shared-expert configuration.
             topk_ids = _biased_grouped_topk_postprocess(
-                topk_ids, remap_info, num_token_non_padded
+                topk_ids,
+                remap_info,
+                num_token_non_padded,
+                output_int64=True,
             )
             hip_deepep_postprocessed = True
         else:

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -130,6 +130,7 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_xpu = is_xpu()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_deepgemm_moe = get_bool_env_var("SGLANG_USE_DEEPGEMM_MOE")
 _is_musa = is_musa()
 _use_lightop = get_bool_env_var("SGLANG_USE_LIGHTOP")
 _use_lightop_topk_ids_postprocess = get_bool_env_var(
@@ -2276,10 +2277,12 @@ def _post_process_topk_ids(
     capture_routed_experts_if_allowed(topk_config, layer_id, topk_ids)
     recorder_topk_ids = None
     _fold_pad_into_append = False
+    # HCU W8A8 deployments can select DeepGEMM through the legacy env while
+    # the global runner backend remains AUTO, so recognize both selectors.
     skip_deepep_padded_tokens = (
         _is_hcu
         and get_moe_a2a_backend().is_deepep()
-        and get_moe_runner_backend().is_deep_gemm()
+        and (get_moe_runner_backend().is_deep_gemm() or _use_deepgemm_moe)
     )
     if _is_cuda:
         # LP path: solve LP outside torch.compile (the solver contains an

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -46,6 +46,14 @@ from sglang.srt.utils import W8a8GetCacheJSON
 W8A8_TRITONJSON = W8a8GetCacheJSON()
 
 
+def _use_kme_hipblaslt(device: torch.device) -> bool:
+    if device.type != "cuda":
+        return False
+    device_props = torch.cuda.get_device_properties(device)
+    gcn_arch = getattr(device_props, "gcnArchName", "").split(":")[0]
+    return gcn_arch == "gfx928"
+
+
 class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
 
     def __init__(
@@ -119,6 +127,9 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
     def process_weights_after_loading(self, layer) -> None:
         n = layer.weight.shape[0]
         k = layer.weight.shape[1]
+        use_kme_hipblaslt = self.w8a8_strategy == 3 and _use_kme_hipblaslt(
+            layer.weight.device
+        )
 
         if self.w8a8_strategy == 1:
             if [n, k] not in W8A8_TRITONJSON.weight_shapes:
@@ -142,9 +153,6 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
                             best_config=value,
                         )
         elif self.w8a8_strategy == 3:
-            # KME/gfx928 hipBLASLt swapped TN: pack W as col-major [K,N]
-            # stride (1,K). Do not apply the later CHANNEL .t() that would
-            # turn it into contiguous [N,K] for the legacy blaslt path.
             w = layer.weight.data  # [N, K]
             if self.strategy == QuantizationStrategy.TENSOR:
                 max_w_scale, w = requantize_with_max_scale(
@@ -161,9 +169,16 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
             else:
                 raise ValueError(f"Unknown quantization strategy {self.strategy}")
 
-            w_col = torch.empty_strided((k, n), (1, k), device=w.device, dtype=w.dtype)
-            w_col.copy_(w.t().contiguous())
-            layer.weight = Parameter(w_col, requires_grad=False)
+            if use_kme_hipblaslt:
+                # gfx928 KME swapped TN: col-major [K,N], stride (1,K).
+                packed_weight = torch.empty_strided(
+                    (k, n), (1, k), device=w.device, dtype=w.dtype
+                )
+                packed_weight.copy_(w.t().contiguous())
+            else:
+                # gfx936/gfx938 use legacy NT with contiguous [N,K].
+                packed_weight = w.contiguous()
+            layer.weight = Parameter(packed_weight, requires_grad=False)
 
             W8A8_TRITONJSON.gen_model_json()
 
@@ -190,8 +205,13 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
                 layer.input_zero_point = None
 
             if not self.input_symmetric:
-                # W is [K,N] col-major; AZP adj is sum over K -> [1,N]
-                azp_adj = layer.weight.sum(dim=0, keepdim=True, dtype=torch.int32)
+                # AZP adjustment is the reduction over K, normalized to [1,N].
+                if use_kme_hipblaslt:
+                    azp_adj = layer.weight.sum(dim=0, keepdim=True, dtype=torch.int32)
+                else:
+                    azp_adj = layer.weight.sum(
+                        dim=1, keepdim=False, dtype=torch.int32
+                    ).unsqueeze(0)
                 if self.is_static_input_scheme:
                     azp_adj = layer.input_zero_point * azp_adj
                 layer.azp_adj = Parameter(azp_adj, requires_grad=False)

--- a/python/sglang/srt/layers/quantization/slimquant_w4a8_marlin.py
+++ b/python/sglang/srt/layers/quantization/slimquant_w4a8_marlin.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
+import importlib
 import os
 from typing import Dict, List, Optional
 
@@ -39,79 +39,75 @@ from sglang.srt.utils import set_weight_attrs
 # from sglang.srt.layers.moe.token_dispatcher.base import CombineInput
 
 
-logger = logging.getLogger(__name__)
-
 W4A8_TPMOE_BACKEND_ENV = "SGLANG_W4A8_TPMOE_BACKEND"
 W4A8_TPMOE_BACKEND_AUTO = "auto"
 W4A8_TPMOE_BACKEND_LIGHTOP = "lightop"
 W4A8_TPMOE_BACKEND_AITER = "aiter"
-_requested_backend = (
-    os.getenv(W4A8_TPMOE_BACKEND_ENV, W4A8_TPMOE_BACKEND_AUTO).strip().lower()
-)
+_resolved_backend: Optional[str] = None
 
 
-_lmslim_w4a8_marlin_available = False
-_aiter_w4a8_marlin_available = False
+def _resolve_backend() -> str:
+    global _resolved_backend
 
-if _requested_backend in {W4A8_TPMOE_BACKEND_AUTO, W4A8_TPMOE_BACKEND_LIGHTOP}:
-    try:
-        from lightop.moe import (
-            fused_experts_impl_w4a8_marlin,
-        )
+    if _resolved_backend is not None:
+        return _resolved_backend
 
-        _lmslim_w4a8_marlin_available = True
-    except Exception:
-        logger.info(
-            "INFO: Please install lightop if you want to infer the quantitative model of moe.\n"
-        )
-
-if _requested_backend in {W4A8_TPMOE_BACKEND_AUTO, W4A8_TPMOE_BACKEND_AITER}:
-    try:
-        from aiter.moe import MoeQuantType, aiter_moe, get_aiter_moe_config
-        from aiter.ops.shuffle import w4a8_moe_layout_shuffle_gemm2
-
-        _aiter_w4a8_marlin_available = True
-    except Exception:
-        pass
-
-if _requested_backend not in {
-    W4A8_TPMOE_BACKEND_AUTO,
-    W4A8_TPMOE_BACKEND_LIGHTOP,
-    W4A8_TPMOE_BACKEND_AITER,
-}:
-    raise ValueError(
-        f"Unsupported {W4A8_TPMOE_BACKEND_ENV}={_requested_backend!r}. "
-        f"Supported values: {W4A8_TPMOE_BACKEND_AUTO!r}, "
-        f"{W4A8_TPMOE_BACKEND_LIGHTOP!r}, {W4A8_TPMOE_BACKEND_AITER!r}."
+    requested_backend = (
+        os.getenv(W4A8_TPMOE_BACKEND_ENV, W4A8_TPMOE_BACKEND_AUTO).strip().lower()
     )
-
-if _requested_backend == W4A8_TPMOE_BACKEND_AUTO:
-    if _lmslim_w4a8_marlin_available:
-        _resolved_backend = W4A8_TPMOE_BACKEND_LIGHTOP
-    elif _aiter_w4a8_marlin_available:
-        _resolved_backend = W4A8_TPMOE_BACKEND_AITER
-    else:
-        raise RuntimeError(
-            "Neither lightop nor aiter backend is available for w4a8 tpmoe."
+    if requested_backend not in {
+        W4A8_TPMOE_BACKEND_AUTO,
+        W4A8_TPMOE_BACKEND_LIGHTOP,
+        W4A8_TPMOE_BACKEND_AITER,
+    }:
+        raise ValueError(
+            f"Unsupported {W4A8_TPMOE_BACKEND_ENV}={requested_backend!r}. "
+            f"Supported values: {W4A8_TPMOE_BACKEND_AUTO!r}, "
+            f"{W4A8_TPMOE_BACKEND_LIGHTOP!r}, {W4A8_TPMOE_BACKEND_AITER!r}."
         )
-elif _requested_backend == W4A8_TPMOE_BACKEND_LIGHTOP:
-    if not _lmslim_w4a8_marlin_available:
+
+    lightop_error = None
+    if requested_backend in {
+        W4A8_TPMOE_BACKEND_AUTO,
+        W4A8_TPMOE_BACKEND_LIGHTOP,
+    }:
+        try:
+            lightop_moe = importlib.import_module("lightop.moe")
+            getattr(lightop_moe, "fused_experts_impl_w4a8_marlin")
+        except Exception as error:
+            lightop_error = error
+        else:
+            _resolved_backend = W4A8_TPMOE_BACKEND_LIGHTOP
+
+    aiter_error = None
+    if _resolved_backend is None and requested_backend in {
+        W4A8_TPMOE_BACKEND_AUTO,
+        W4A8_TPMOE_BACKEND_AITER,
+    }:
+        try:
+            aiter_moe_module = importlib.import_module("aiter.moe")
+            for symbol in ("MoeQuantType", "aiter_moe", "get_aiter_moe_config"):
+                getattr(aiter_moe_module, symbol)
+            aiter_shuffle = importlib.import_module("aiter.ops.shuffle")
+            getattr(aiter_shuffle, "w4a8_moe_layout_shuffle_gemm2")
+        except Exception as error:
+            aiter_error = error
+        else:
+            _resolved_backend = W4A8_TPMOE_BACKEND_AITER
+
+    if _resolved_backend is not None:
+        return _resolved_backend
+    if requested_backend == W4A8_TPMOE_BACKEND_LIGHTOP:
         raise RuntimeError(
             "lightop backend is selected for w4a8 tpmoe, but lightop is not available."
-        )
-    _resolved_backend = W4A8_TPMOE_BACKEND_LIGHTOP
-else:
-    if not _aiter_w4a8_marlin_available:
+        ) from lightop_error
+    if requested_backend == W4A8_TPMOE_BACKEND_AITER:
         raise RuntimeError(
             "aiter backend is selected for w4a8 tpmoe, but aiter is not available."
-        )
-    _resolved_backend = W4A8_TPMOE_BACKEND_AITER
-
-logger.info(
-    "[slimquant_w4a8_marlin] "
-    f"requested_backend={_requested_backend}, "
-    f"resolved_backend={_resolved_backend}"
-)
+        ) from aiter_error
+    raise RuntimeError(
+        "Neither lightop nor aiter backend is available for w4a8 tpmoe."
+    ) from (aiter_error or lightop_error)
 
 
 class MarlinMoeWorkspace:
@@ -150,6 +146,8 @@ def repack_and_shuffle_w4a8(weight_data, E):
     逐 expert 处理 [n, k_half]
     处理完直接写回 weight_data[i]
     """
+    from aiter.ops.shuffle import w4a8_moe_layout_shuffle_gemm2
+
     # 原始 shape: [E, n, k_half]
     for i in range(E):
         # 1. 取当前 expert [n, k_half]
@@ -245,7 +243,7 @@ class SlimQuantW4A8Int8MarlinConfig(QuantizationConfig):
         if isinstance(layer, LinearBase):
             return SlimQuantW4A8Int8LinearMethod(self)
         elif isinstance(layer, FusedMoE):
-            if _resolved_backend == W4A8_TPMOE_BACKEND_AITER:
+            if _resolve_backend() == W4A8_TPMOE_BACKEND_AITER:
                 return SlimQuantW4A8Int8AiterMoEMethod(self)
             return SlimQuantW4A8Int8MarlinMoEMethod(self)
         return None
@@ -280,8 +278,11 @@ class SlimQuantW4A8Int8MarlinMoEMethod:
         return super().__new__(cls)
 
     def __init__(self, quant_config):
+        from lightop.moe import fused_experts_impl_w4a8_marlin
+
         self.quant_config = quant_config
         self.use_deepep = get_moe_a2a_backend().is_deepep()
+        self.fused_experts_impl_w4a8_marlin = fused_experts_impl_w4a8_marlin
 
     def create_weights(
         self,
@@ -388,7 +389,7 @@ class SlimQuantW4A8Int8MarlinMoEMethod:
             if self.moe_runner_config.routed_scaling_factor is not None
             else 1.0
         )
-        output = fused_experts_impl_w4a8_marlin(
+        output = self.fused_experts_impl_w4a8_marlin(
             x,
             layer.w13_weight,
             layer.w2_weight,
@@ -435,7 +436,7 @@ class SlimQuantW4A8Int8MarlinMoEMethod:
             if self.moe_runner_config.routed_scaling_factor is not None
             else 1.0
         )
-        return fused_experts_impl_w4a8_marlin(
+        return self.fused_experts_impl_w4a8_marlin(
             x,
             layer.w13_weight,
             layer.w2_weight,
@@ -555,7 +556,7 @@ class SlimQuantW4A8Int8MarlinMoEMethod:
         routed_scaling_factor = (
             1.0 if routed_scaling_factor is None else routed_scaling_factor
         )
-        return fused_experts_impl_w4a8_marlin(
+        return self.fused_experts_impl_w4a8_marlin(
             x,
             w1,
             w2,
@@ -689,6 +690,8 @@ class SlimQuantW4A8Int8AiterMoEMethod:
         layer: torch.nn.Module,
         dispatch_output,
     ):
+        from aiter.moe import MoeQuantType, aiter_moe, get_aiter_moe_config
+
         from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
 
         x = dispatch_output.hidden_states

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -60,11 +60,7 @@ def resolve_shared_index_layers(
     if not is_deepseek_dsa(hf_text_config):
         return None
     num_layers = hf_text_config.num_hidden_layers
-    cli_factor = getattr(hf_text_config, "cli_factor", 1) or 1
-    if cli_factor > 1:
-        pattern = [i % cli_factor != 0 for i in range(num_layers)]
-    else:
-        pattern = [dsa_layer_skips_topk(hf_text_config, i) for i in range(num_layers)]
+    pattern = [dsa_layer_skips_topk(hf_text_config, i) for i in range(num_layers)]
     if not any(pattern):
         return None
     if pp_size != 1 or is_speculative:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1345,11 +1345,11 @@ class Scheduler(
         ):
             if not self.require_mlp_sync:
                 raise RuntimeError("PD Decode DP sync requires require_mlp_sync=True")
-            if self.pp_size != 1:
+            if self.ps.pp_size != 1:
                 raise RuntimeError(
                     "PD Decode DP sync currently supports pp_size=1 only"
                 )
-            if self.attn_tp_size != 1 or self.attn_cp_size != 1:
+            if self.ps.attn_tp_size != 1 or self.ps.attn_cp_size != 1:
                 raise RuntimeError(
                     "PD Decode DP sync currently supports attn_tp_size=1 and "
                     "attn_cp_size=1 only"
@@ -1357,7 +1357,7 @@ class Scheduler(
 
             tp_ranks = list(self.tp_group.ranks)
             expected_world = (
-                self.server_args.dp_size * self.attn_tp_size * self.attn_cp_size
+                self.ps.dp_size * self.ps.attn_tp_size * self.ps.attn_cp_size
             )
             default_world = torch.distributed.get_world_size()
             if len(tp_ranks) != expected_world or len(tp_ranks) != default_world:
@@ -1384,7 +1384,7 @@ class Scheduler(
                 backend="gloo",
                 timeout=timedelta(seconds=timeout_s),
             )
-            if self.tp_rank == 0:
+            if self.ps.tp_rank == 0:
                 logger.info(
                     "PD Decode single-clock enabled: dedicated Gloo scheduler "
                     "group, world=%s timeout=%.1fs",

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -71,10 +71,8 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         self.remote_layer_id: Optional[int] = None
 
     def _layer_num_pages(self, layer_idx: int, num_pages: int) -> int:
-        layer_id = self.pool.start_layer + layer_idx
-        if not self.pool._is_layer_owned(layer_id):
-            return 0
-        return super()._layer_num_pages(layer_idx, num_pages)
+        layer_id = self.pool.indexer_layer_ids[layer_idx]
+        return num_pages if self.pool._is_layer_owned(layer_id) else 0
 
     def clear(self) -> None:
         super().clear()
@@ -132,9 +130,9 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
 
     def get_broadcastable_buffer(self, layer_id: int) -> torch.Tensor:
         if self.remote_layer_id != layer_id:
-            local_idx = layer_id - self.pool.start_layer
+            cache_idx = self.pool._get_indexer_cache_index(layer_id)
             src_tensor = (
-                self.buffer[local_idx] if self.pool._is_layer_owned(layer_id) else None
+                self.buffer[cache_idx] if self.pool._is_layer_owned(layer_id) else None
             )
             self.pool._broadcast_tensor_from_owner(
                 self.remote_buffer,
@@ -145,14 +143,14 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         return self.remote_buffer
 
     def state_buf_infos(self):
-        owned_layer_ids = [
-            i
-            for i in range(self.pool.layer_num)
-            if self.pool._is_layer_owned(self.pool.start_layer + i)
+        owned_cache_indices = [
+            cache_idx
+            for cache_idx, layer_id in enumerate(self.pool.indexer_layer_ids)
+            if self.pool._is_layer_owned(layer_id)
         ]
-        data_ptrs = [self.buffer[i].data_ptr() for i in owned_layer_ids]
-        data_lens = [self.buffer[i].nbytes for i in owned_layer_ids]
-        item_lens = [self._item_len(i) for i in owned_layer_ids]
+        data_ptrs = [self.buffer[i].data_ptr() for i in owned_cache_indices]
+        data_lens = [self.buffer[i].nbytes for i in owned_cache_indices]
+        item_lens = [self._item_len(i) for i in owned_cache_indices]
         return data_ptrs, data_lens, item_lens
 
     def cpu_copy(self, indices):
@@ -161,7 +159,7 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         index_k_cpu = []
         chunk_size = self.pool.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.pool.page_size)
-        for layer_id in range(self.pool.layer_num):
+        for layer_id in range(self.pool.indexer_layer_num):
             index_k_cpu.append([])
             if self.buffer[layer_id].shape[0] == 0:
                 continue
@@ -179,7 +177,7 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         torch.cuda.synchronize()
         chunk_size = self.pool.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.pool.page_size)
-        for layer_id in range(self.pool.layer_num):
+        for layer_id in range(self.pool.indexer_layer_num):
             if self.buffer[layer_id].shape[0] == 0:
                 continue
             for i in range(0, len(page_indices), page_chunk_size):

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -345,7 +345,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
     def _clear_buffers(self):
         del self.kv_buffer
         del self.remote_kv_buffer
-        self.index_key_cache.clear()
+        self._clear_index_k_buffers()
 
     # ---- MLA latent KV: owned-only writes, owner-broadcast reads ----------
 
@@ -355,6 +355,9 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
             kv_size_bytes += get_tensor_size_bytes(kv_cache)
         for index_k_cache in self.index_k_with_scale_buffer:
             kv_size_bytes += get_tensor_size_bytes(index_k_cache)
+        if self.use_int8_index_k_cache:
+            kv_size_bytes += get_tensor_size_bytes(self.index_k_dequant_workspace)
+            kv_size_bytes += get_tensor_size_bytes(self.index_k_page_claims)
         return kv_size_bytes
 
     def get_contiguous_buf_infos(self):

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -202,6 +202,17 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
             )
         return self.get_broadcastable_buffer(layer_id)
 
+    def get_write_buffer(self, layer_id: int) -> torch.Tensor:
+        if self.pool._is_layer_owned(layer_id):
+            return super().get_write_buffer(layer_id)
+
+        # Non-owner local buffers have zero rows. HCU still needs to run the
+        # fused Q/K quant kernel to produce Q, so use the full-size remote
+        # scratch as its disposable K write target. The scratch no longer
+        # represents its previous layer and must be broadcast again before use.
+        self.remote_layer_id = None
+        return self.remote_buffer
+
     def get_k_and_scale(
         self,
         layer_id: int,

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -78,15 +78,6 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         super().clear()
         del self.remote_buffer
 
-    def move(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
-        if tgt_loc.numel() == 0:
-            return
-        tgt_loc_flat = tgt_loc.view(-1).long()
-        src_loc_flat = src_loc.view(-1).long()
-        for index_k in self.buffer:
-            if index_k.shape[0] != 0:
-                index_k[tgt_loc_flat] = index_k[src_loc_flat]
-
     def get_buffer(self, layer_id: int) -> torch.Tensor:
         if self.pool.layer_transfer_counter is not None:
             self.pool.layer_transfer_counter.wait_until(

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -39,6 +39,9 @@ from typing import TYPE_CHECKING, Any, Optional
 import torch
 
 from sglang.kernels.ops.attention.dsa import index_buf_accessor
+from sglang.srt.layers.attention.dsa.hcu_int8_index_k_cache import (
+    quantize_and_store_index_k_int8,
+)
 from sglang.srt.layers.cp.utils import get_layer_owner, get_layer_shard_range
 from sglang.srt.mem_cache.index_key_cache import IndexKeyCache
 from sglang.srt.mem_cache.memory_pool import (
@@ -180,12 +183,15 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
             if pool.custom_mem_pool
             else nullcontext()
         ):
-            self.remote_buffer = torch.empty(
+            self.remote_buffer = torch.zeros(
                 self._buffer_shape(num_pages),
                 dtype=pool.index_k_with_scale_buffer_dtype,
                 device=pool.device,
             )
         self.remote_layer_id: Optional[int] = None
+        self.pending_event = pool.device_module.Event()
+        self.pending_layer_id: Optional[int] = None
+        self.pending_broadcast = False
 
     def _layer_num_pages(self, layer_idx: int, num_pages: int) -> int:
         layer_id = self.pool.indexer_layer_ids[layer_idx]
@@ -195,6 +201,15 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         super().clear()
         del self.remote_buffer
 
+    def move(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
+        if tgt_loc.numel() == 0:
+            return
+        # The owner buffers are about to change outside the regular mirrored
+        # write path, so no cached remote layer remains valid.
+        self.finalize_pending(set_remote_layer_id=False)
+        self.remote_layer_id = None
+        super().move(tgt_loc, src_loc)
+
     def get_buffer(self, layer_id: int) -> torch.Tensor:
         if self.pool.layer_transfer_counter is not None:
             self.pool.layer_transfer_counter.wait_until(
@@ -203,15 +218,59 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         return self.get_broadcastable_buffer(layer_id)
 
     def get_write_buffer(self, layer_id: int) -> torch.Tensor:
+        if not self.prepare_remote_write(layer_id):
+            # Correctness fallback for a missed prefetch. Broadcast history
+            # before any rank writes this step's new Index-K into scratch.
+            self.get_broadcastable_buffer(layer_id)
+
         if self.pool._is_layer_owned(layer_id):
             return super().get_write_buffer(layer_id)
 
         # Non-owner local buffers have zero rows. HCU still needs to run the
-        # fused Q/K quant kernel to produce Q, so use the full-size remote
-        # scratch as its disposable K write target. The scratch no longer
-        # represents its previous layer and must be broadcast again before use.
-        self.remote_layer_id = None
+        # fused Q/K quant kernel to produce Q, so write this step's Index-K
+        # directly into the already-prefetched remote scratch.
         return self.remote_buffer
+
+    def commit_write_buffer(self, layer_id: int, loc: torch.Tensor) -> None:
+        """Mirror an owner's fused Index-K writes into prefetched scratch."""
+
+        if not self.pool._is_layer_owned(layer_id) or not self.prepare_remote_write(
+            layer_id
+        ):
+            return
+
+        loc = loc.reshape(-1)
+        loc = loc[loc >= 0].to(torch.long)
+        if loc.numel() == 0:
+            return
+
+        local_buffer = self.buffer[self.pool._get_indexer_cache_index(layer_id)]
+        page_indices = torch.div(loc, self.pool.page_size, rounding_mode="floor")
+        token_offsets = loc % self.pool.page_size
+        k_bytes_per_page = self.pool.page_size * self.pool.index_head_dim
+        scale_bytes_per_token = (
+            self.pool.index_head_dim
+            // self.pool.quant_block_size
+            * torch.float32.itemsize
+        )
+
+        local_k = local_buffer[:, :k_bytes_per_page].view(
+            -1, self.pool.page_size, self.pool.index_head_dim
+        )
+        remote_k = self.remote_buffer[:, :k_bytes_per_page].view(
+            -1, self.pool.page_size, self.pool.index_head_dim
+        )
+        remote_k[page_indices, token_offsets] = local_k[page_indices, token_offsets]
+
+        local_scale = local_buffer[:, k_bytes_per_page:].view(
+            -1, self.pool.page_size, scale_bytes_per_token
+        )
+        remote_scale = self.remote_buffer[:, k_bytes_per_page:].view(
+            -1, self.pool.page_size, scale_bytes_per_token
+        )
+        remote_scale[page_indices, token_offsets] = local_scale[
+            page_indices, token_offsets
+        ]
 
     def get_k_and_scale(
         self,
@@ -239,16 +298,150 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         index_k: torch.Tensor,
         index_k_scale: torch.Tensor,
     ) -> None:
-        self.invalidate(layer_id)
+        if not self.prepare_remote_write(layer_id):
+            self.get_broadcastable_buffer(layer_id)
+        index_buf_accessor.SetKAndS.execute(
+            pool=self.pool,
+            buf=self.remote_buffer,
+            loc=loc,
+            index_k=index_k,
+            index_k_scale=index_k_scale,
+        )
         if self.pool._is_layer_owned(layer_id):
             super().store_quantized(layer_id, loc, index_k, index_k_scale)
 
+    def store_int8(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+    ) -> None:
+        """Store current INT8 Index-K into scratch and the owner's shard."""
+
+        if not self.prepare_remote_write(layer_id):
+            self.get_broadcastable_buffer(layer_id)
+        assert self.pool.index_k_int8_remote_aliases is not None
+        remote_int8_k, remote_fp32_scales = self.pool.index_k_int8_remote_aliases
+        quantize_and_store_index_k_int8(
+            index_k,
+            self.remote_buffer,
+            loc,
+            page_size=self.pool.page_size,
+            int8_k=remote_int8_k,
+            fp32_scales=remote_fp32_scales,
+        )
+        if not self.pool._is_layer_owned(layer_id):
+            return
+
+        cache_idx = self.pool._get_indexer_cache_index(layer_id)
+        local_int8_k, local_fp32_scales = self.pool.index_k_int8_aliases[cache_idx]
+        quantize_and_store_index_k_int8(
+            index_k,
+            self.buffer[cache_idx],
+            loc,
+            page_size=self.pool.page_size,
+            int8_k=local_int8_k,
+            fp32_scales=local_fp32_scales,
+        )
+
+    def finalize_pending(self, *, set_remote_layer_id: bool = True) -> None:
+        if not self.pending_broadcast:
+            return
+        self.pool.device_module.current_stream().wait_event(self.pending_event)
+        self.pending_broadcast = False
+        if set_remote_layer_id and self.pending_layer_id is not None:
+            self.remote_layer_id = self.pending_layer_id
+        elif not set_remote_layer_id:
+            self.remote_layer_id = None
+        self.pending_layer_id = None
+
+    def prefetch(
+        self,
+        layer_id: int,
+        layer_transfer_counter: Optional[LayerDoneCounter] = None,
+        layer_transfer_idx: Optional[int] = None,
+        has_history: bool = True,
+    ) -> None:
+        """Broadcast a full Index-K buffer ahead of its indexer layer."""
+
+        # GLM-5.2 only allocates caches for layers that really run the
+        # indexer. skip-topk layers reuse prior results and need no collective.
+        if layer_id not in self.pool.indexer_prefetch_layer_ids:
+            return
+        if self.remote_layer_id == layer_id:
+            return
+        if self.pending_broadcast:
+            if self.pending_layer_id == layer_id:
+                return
+            self.finalize_pending(set_remote_layer_id=False)
+
+        if not has_history:
+            # This step's Index-K writes will populate every location read by
+            # the indexer. Page zero was initialized when scratch was created.
+            self.remote_layer_id = layer_id
+            return
+
+        cache_idx = self.pool._get_indexer_cache_index(layer_id)
+        src_tensor = (
+            self.buffer[cache_idx] if self.pool._is_layer_owned(layer_id) else None
+        )
+        transfer_counter = layer_transfer_counter or self.pool.layer_transfer_counter
+        transfer_idx = (
+            layer_transfer_idx
+            if layer_transfer_idx is not None
+            else layer_id - self.pool.start_layer
+        )
+
+        if self.pool.layer_broadcast_comm is None:
+            if transfer_counter is not None:
+                transfer_counter.wait_until(transfer_idx)
+            self.pool._broadcast_tensor_from_owner(
+                self.remote_buffer,
+                layer_id,
+                src_tensor=src_tensor,
+                use_layer_broadcast_comm=True,
+            )
+            self.remote_layer_id = layer_id
+            return
+
+        current_stream = self.pool.device_module.current_stream()
+        self.pool.kv_broadcast_stream.wait_stream(current_stream)
+        with self.pool.device_module.stream(self.pool.kv_broadcast_stream):
+            if transfer_counter is not None:
+                transfer_counter.wait_until(transfer_idx)
+            with torch.profiler.record_function(
+                "layersplit_index_k_broadcast "
+                f"layer={layer_id} bytes={self.remote_buffer.nbytes}"
+            ):
+                self.pool._broadcast_tensor_from_owner(
+                    self.remote_buffer,
+                    layer_id,
+                    src_tensor=src_tensor,
+                    use_layer_broadcast_comm=True,
+                )
+            self.pending_event.record()
+        self.remote_layer_id = None
+        self.pending_layer_id = layer_id
+        self.pending_broadcast = True
+
+    def prepare_remote_write(self, layer_id: int) -> bool:
+        if self.pending_broadcast:
+            self.finalize_pending(set_remote_layer_id=self.pending_layer_id == layer_id)
+        return self.remote_layer_id == layer_id
+
     def invalidate(self, layer_id: int) -> None:
+        if self.pending_broadcast and self.pending_layer_id == layer_id:
+            self.finalize_pending(set_remote_layer_id=False)
         if self.remote_layer_id == layer_id:
             self.remote_layer_id = None
 
     def get_broadcastable_buffer(self, layer_id: int) -> torch.Tensor:
+        if self.pending_broadcast:
+            self.finalize_pending(set_remote_layer_id=self.pending_layer_id == layer_id)
         if self.remote_layer_id != layer_id:
+            # Index-K and Main-KV share the dedicated communicator. A fallback
+            # on the current stream must follow all side-stream collectives.
+            self.pool._drain_pending_layer_broadcasts(discard_index=True)
             cache_idx = self.pool._get_indexer_cache_index(layer_id)
             src_tensor = (
                 self.buffer[cache_idx] if self.pool._is_layer_owned(layer_id) else None
@@ -257,6 +450,7 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
                 self.remote_buffer,
                 layer_id,
                 src_tensor=src_tensor,
+                use_layer_broadcast_comm=True,
             )
             self.remote_layer_id = layer_id
         return self.remote_buffer
@@ -316,6 +510,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         *args,
         layer_shard_rank: int,
         layer_shard_size: int,
+        indexer_prefetch_layer_ids: Optional[Sequence[int]] = None,
         **kwargs,
     ):
         assert (
@@ -325,7 +520,14 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         self.layer_shard_size = layer_shard_size
         self.layer_shard_enabled = True
         self.layer_broadcast_comm = None
+        self.indexer_prefetch_layer_ids = (
+            frozenset(indexer_prefetch_layer_ids)
+            if indexer_prefetch_layer_ids is not None
+            else None
+        )
         super().__init__(*args, **kwargs)
+        if self.indexer_prefetch_layer_ids is None:
+            self.indexer_prefetch_layer_ids = frozenset(self.indexer_layer_ids)
         # First global layer index owned by this rank (used by PD transfer to
         # label the contiguous owned-buffer range).
         my_start, _ = self._owned_local_layer_range()
@@ -470,7 +672,8 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
                     dtype=torch.int32,
                     device=self.device,
                 )
-                self.physical_to_compact_main_kv_page[0] = 0
+                # Keep this device-side to avoid a synchronous scalar H2D.
+                self.physical_to_compact_main_kv_page[0:1].zero_()
                 self._active_main_kv_page_plan: Optional[MainKVPagePlan] = None
                 self._active_main_kv_batch_marker: Optional[
                     weakref.ReferenceType[Any]
@@ -617,12 +820,18 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         ):
             return
 
-        # A late side-stream broadcast must not write through a mapping owned
-        # by the next ForwardBatch.
-        self._finalize_pending_kv_broadcast(set_remote_layer_id=False)
+        # A late side-stream broadcast must not write through state owned by
+        # the next ForwardBatch. Index scratch also depends on pool contents
+        # that may have changed through allocation, movement, or HiCache load.
+        self._drain_pending_layer_broadcasts(
+            discard_index=True,
+            discard_main=True,
+        )
+        self.index_key_cache.remote_layer_id = None
         self.remote_kv_layer_id = None
         self.physical_to_compact_main_kv_page.fill_(-1)
-        self.physical_to_compact_main_kv_page[0] = 0
+        # Keep this device-side to avoid a synchronous scalar H2D.
+        self.physical_to_compact_main_kv_page[0:1].zero_()
         self._active_main_kv_batch_marker = None
         self._active_main_kv_page_plan = None
         self._active_main_kv_compact_page_ids = torch.empty(
@@ -774,7 +983,34 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         self.pending_remote_kv_broadcast = False
         if set_remote_layer_id and self.pending_remote_kv_layer_id is not None:
             self.remote_kv_layer_id = self.pending_remote_kv_layer_id
+        elif not set_remote_layer_id:
+            self.remote_kv_layer_id = None
         self.pending_remote_kv_layer_id = None
+
+    def _drain_pending_layer_broadcasts(
+        self,
+        *,
+        discard_index: bool = False,
+        discard_main: bool = False,
+    ) -> None:
+        """Order synchronous fallbacks after side-stream collectives."""
+
+        self.index_key_cache.finalize_pending(set_remote_layer_id=not discard_index)
+        self._finalize_pending_kv_broadcast(set_remote_layer_id=not discard_main)
+
+    def prefetch_index_buffer(
+        self,
+        layer_id: int,
+        layer_transfer_counter: Optional[LayerDoneCounter] = None,
+        layer_transfer_idx: Optional[int] = None,
+        has_history: bool = True,
+    ) -> None:
+        self.index_key_cache.prefetch(
+            layer_id,
+            layer_transfer_counter=layer_transfer_counter,
+            layer_transfer_idx=layer_transfer_idx,
+            has_history=has_history,
+        )
 
     def prefetch_kv_buffer(
         self,
@@ -853,6 +1089,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
                 set_remote_layer_id=self.pending_remote_kv_layer_id == layer_id
             )
         if self.remote_kv_layer_id != layer_id:
+            self._drain_pending_layer_broadcasts(discard_main=True)
             local_idx = self._local_layer_idx(layer_id)
             src_tensor = (
                 self.kv_buffer[local_idx] if self._is_layer_owned(layer_id) else None
@@ -901,6 +1138,14 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         maybe_detect_oob(src_loc, 0, size_limit, "move_kv_cache src_loc")
         if tgt_loc.numel() == 0:
             return
+        # Compaction mutates owner storage. Finish any side-stream reads before
+        # moving it, and do not retain scratch identities across the mutation.
+        self._drain_pending_layer_broadcasts(
+            discard_index=True,
+            discard_main=True,
+        )
+        self.index_key_cache.remote_layer_id = None
+        self.remote_kv_layer_id = None
         tgt_loc_flat = tgt_loc.view(-1).long()
         src_loc_flat = src_loc.view(-1).long()
         for kv_cache in self.kv_buffer:
@@ -915,6 +1160,20 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         self, layer_id: int
     ) -> torch.Tensor:
         return self.index_key_cache.get_buffer(layer_id)
+
+    def commit_index_k_with_scale_write_buffer(
+        self, layer_id: int, loc: torch.Tensor
+    ) -> None:
+        self.index_key_cache.commit_write_buffer(layer_id, loc)
+
+    def set_index_k_int8_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+    ) -> None:
+        assert self.use_int8_index_k_cache, "INT8 index K cache is not enabled"
+        self.index_key_cache.store_int8(layer_id, loc, index_k)
 
     def invalidate_index_buffer_for_layer(self, layer_id: int) -> None:
         self.index_key_cache.invalidate(layer_id)
@@ -947,6 +1206,15 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
     def load_cpu_copy(self, kv_cache_cpu_dict, indices, mamba_indices=None):
         from sglang.srt.utils import current_platform
 
+        # A resume overwrites owner storage outside the mirrored write path.
+        # Drain broadcasts first so their completion cannot later make a stale
+        # scratch layer appear valid.
+        self._drain_pending_layer_broadcasts(
+            discard_index=True,
+            discard_main=True,
+        )
+        self.index_key_cache.remote_layer_id = None
+        self.remote_kv_layer_id = None
         kv_cache_cpu = kv_cache_cpu_dict["kv"]
         current_platform.synchronize()
         chunk_size = self.cpu_offloading_chunk_size

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -30,8 +30,11 @@ PD prefill workers under prefill-CP (see
 from __future__ import annotations
 
 import logging
+import weakref
+from collections.abc import Sequence
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
@@ -52,6 +55,120 @@ if TYPE_CHECKING:
     from sglang.srt.managers.cache_controller import LayerDoneCounter
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(eq=False, frozen=True)
+class MainKVPagePlan:
+    """Physical pages needed by one ordinary prefill ``ForwardBatch``.
+
+    ``history_page_ids`` is the unique payload copied from each layer owner.
+    ``all_page_ids`` additionally contains pages receiving this step's newly
+    computed KV. Object identity deliberately serves as the batch identity.
+    """
+
+    history_page_ids: torch.Tensor
+    all_page_ids: torch.Tensor
+
+
+def _build_unique_physical_pages(
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    sequence_lens: Sequence[int],
+    page_size: int,
+) -> torch.Tensor:
+    """Collect one physical page ID per logical page and remove duplicates."""
+
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    if req_to_token.ndim != 2:
+        raise ValueError(
+            f"req_to_token must be 2-D, got shape={tuple(req_to_token.shape)}"
+        )
+
+    batch_size = len(sequence_lens)
+    if batch_size == 0:
+        return torch.empty(0, dtype=torch.long, device=req_to_token.device)
+    if req_pool_indices.numel() < batch_size:
+        raise ValueError(
+            "req_pool_indices is shorter than sequence_lens: "
+            f"{req_pool_indices.numel()} < {batch_size}"
+        )
+
+    page_counts = []
+    for sequence_len in sequence_lens:
+        sequence_len = int(sequence_len)
+        if sequence_len < 0:
+            raise ValueError(
+                f"sequence length must be non-negative, got {sequence_len}"
+            )
+        page_counts.append((sequence_len + page_size - 1) // page_size)
+
+    total_pages = sum(page_counts)
+    if total_pages == 0:
+        return torch.empty(0, dtype=torch.long, device=req_to_token.device)
+
+    max_pages = max(page_counts)
+    if (max_pages - 1) * page_size >= req_to_token.shape[1]:
+        raise ValueError(
+            "sequence length exceeds req_to_token capacity: "
+            f"max_pages={max_pages}, page_size={page_size}, "
+            f"capacity={req_to_token.shape[1]}"
+        )
+
+    device = req_to_token.device
+    page_counts_tensor = torch.tensor(page_counts, dtype=torch.long, device=device)
+    request_rows = torch.repeat_interleave(
+        req_pool_indices[:batch_size].to(device=device, dtype=torch.long),
+        page_counts_tensor,
+        output_size=total_pages,
+    )
+    request_page_starts = torch.cumsum(page_counts_tensor, dim=0) - page_counts_tensor
+    repeated_page_starts = torch.repeat_interleave(
+        request_page_starts,
+        page_counts_tensor,
+        output_size=total_pages,
+    )
+    logical_pages = (
+        torch.arange(total_pages, dtype=torch.long, device=device)
+        - repeated_page_starts
+    )
+    physical_page_starts = req_to_token[request_rows, logical_pages * page_size]
+    physical_pages = torch.div(
+        physical_page_starts, page_size, rounding_mode="floor"
+    ).to(torch.long)
+    # Physical page 0 is the pool's padded/dummy page, never request history.
+    return torch.unique(physical_pages[physical_pages > 0], sorted=True).contiguous()
+
+
+def build_main_kv_page_plan(
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    prefix_lens: Sequence[int],
+    current_locs: torch.Tensor,
+    page_size: int,
+) -> MainKVPagePlan:
+    """Build the deterministic, CP-global compact layout for one batch."""
+
+    history_page_ids = _build_unique_physical_pages(
+        req_to_token,
+        req_pool_indices,
+        prefix_lens,
+        page_size,
+    )
+    current_locs = current_locs.reshape(-1)
+    valid_current_locs = current_locs[current_locs >= 0]
+    current_page_ids = torch.unique(
+        torch.div(valid_current_locs, page_size, rounding_mode="floor").to(torch.long),
+        sorted=True,
+    )
+    current_page_ids = current_page_ids[current_page_ids > 0]
+    all_page_ids = torch.unique(
+        torch.cat((history_page_ids, current_page_ids)), sorted=True
+    ).contiguous()
+    return MainKVPagePlan(
+        history_page_ids=history_page_ids,
+        all_page_ids=all_page_ids,
+    )
 
 
 class LayerSplitIndexKeyCache(IndexKeyCache):
@@ -286,7 +403,9 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
                 comm.broadcast(tensor, src=owner_rank)
         else:
             torch.distributed.broadcast(
-                tensor, src=owner_rank, group=cp_group.cpu_group
+                tensor,
+                src=cp_group.ranks[owner_rank],
+                group=cp_group.device_group,
             )
         return tensor
 
@@ -323,6 +442,31 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
                     dtype=self.store_dtype,
                     device=self.device,
                 )
+                # Physical page 0 is translated to compact page 0 and may be
+                # read for padded/dummy entries. Compact broadcasts start at
+                # page 1, so initialize this page once instead of exposing the
+                # uninitialized contents of the scratch allocation.
+                self.remote_kv_buffer[: self.page_size].zero_()
+                if (self.size + self.page_size) % self.page_size != 0:
+                    raise ValueError(
+                        "LayerSplit MLA KV buffer must contain whole pages: "
+                        f"size={self.size}, page_size={self.page_size}"
+                    )
+                self.num_pool_pages = (self.size + self.page_size) // self.page_size
+                self.physical_to_compact_main_kv_page = torch.full(
+                    (self.num_pool_pages,),
+                    -1,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                self.physical_to_compact_main_kv_page[0] = 0
+                self._active_main_kv_page_plan: Optional[MainKVPagePlan] = None
+                self._active_main_kv_batch_marker: Optional[
+                    weakref.ReferenceType[Any]
+                ] = None
+                self._active_main_kv_compact_page_ids = torch.empty(
+                    0, dtype=torch.long, device=self.device
+                )
                 self.remote_kv_layer_id: Optional[int] = None
                 self.device_module = torch.get_device_module(self.device)
                 self.kv_broadcast_stream = self.device_module.Stream()
@@ -336,6 +480,10 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
     def _clear_buffers(self):
         del self.kv_buffer
         del self.remote_kv_buffer
+        del self.physical_to_compact_main_kv_page
+        del self._active_main_kv_compact_page_ids
+        self._active_main_kv_page_plan = None
+        self._active_main_kv_batch_marker = None
         self._clear_index_k_buffers()
 
     # ---- MLA latent KV: owned-only writes, owner-broadcast reads ----------
@@ -424,8 +572,9 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
             self._finalize_pending_kv_broadcast(set_remote_layer_id=True)
         remote_kv_updatable = self.remote_kv_layer_id == layer_id
         if remote_kv_updatable:
+            remote_loc = self.translate_main_kv_loc_to_compact(loc)
             self._write_mla_kv_buffer(
-                self.remote_kv_buffer, loc, cache_k_nope, cache_k_rope
+                self.remote_kv_buffer, remote_loc, cache_k_nope, cache_k_rope
             )
         if not self._is_layer_owned(layer_id):
             return
@@ -437,6 +586,173 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         )
         if not remote_kv_updatable and self.remote_kv_layer_id == layer_id:
             self.remote_kv_layer_id = None
+
+    def configure_main_kv_page_plan(
+        self,
+        page_plan: Optional[MainKVPagePlan],
+        batch_marker: Any,
+    ) -> None:
+        """Install one batch's physical-to-compact Main-KV mapping.
+
+        History pages occupy compact slots ``[1, 1 + N_history)`` so the
+        transmitted payload is a single contiguous view. Pages used only by
+        this step follow them and are populated locally after CP AllGather.
+        """
+
+        if (
+            self._active_main_kv_batch_marker is not None
+            and self._active_main_kv_batch_marker() is batch_marker
+            and self._active_main_kv_page_plan is page_plan
+        ):
+            return
+
+        # A late side-stream broadcast must not write through a mapping owned
+        # by the next ForwardBatch.
+        self._finalize_pending_kv_broadcast(set_remote_layer_id=False)
+        self.remote_kv_layer_id = None
+        self.physical_to_compact_main_kv_page.fill_(-1)
+        self.physical_to_compact_main_kv_page[0] = 0
+        self._active_main_kv_batch_marker = None
+        self._active_main_kv_page_plan = None
+        self._active_main_kv_compact_page_ids = torch.empty(
+            0, dtype=torch.long, device=self.device
+        )
+        if page_plan is None:
+            self._active_main_kv_batch_marker = weakref.ref(batch_marker)
+            return
+
+        history_page_ids = page_plan.history_page_ids.to(
+            device=self.device, dtype=torch.long
+        ).contiguous()
+        all_page_ids = page_plan.all_page_ids.to(
+            device=self.device, dtype=torch.long
+        ).contiguous()
+        for name, page_ids in (
+            ("history_page_ids", history_page_ids),
+            ("all_page_ids", all_page_ids),
+        ):
+            if page_ids.numel() == 0:
+                continue
+            invalid_page_ids = page_ids[
+                (page_ids <= 0) | (page_ids >= self.num_pool_pages)
+            ]
+            if invalid_page_ids.numel() != 0:
+                raise RuntimeError(
+                    "LayerSplit compact Main-KV page plan contains an out-of-range "
+                    f"{name} entry: page_id={int(invalid_page_ids[0].item())}, "
+                    f"valid_range=[1, {self.num_pool_pages})"
+                )
+        if all_page_ids.numel() > self.num_pool_pages - 1:
+            raise RuntimeError(
+                "LayerSplit compact Main-KV layout exceeds the remote buffer: "
+                f"pages={all_page_ids.numel()}, "
+                f"capacity_pages={self.num_pool_pages - 1}"
+            )
+
+        history_compact_ids = torch.arange(
+            1,
+            history_page_ids.numel() + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.physical_to_compact_main_kv_page.index_copy_(
+            0, history_page_ids, history_compact_ids
+        )
+
+        current_only_mask = (
+            self.physical_to_compact_main_kv_page.index_select(0, all_page_ids) < 0
+        )
+        current_only_page_ids = all_page_ids[current_only_mask]
+        current_compact_ids = torch.arange(
+            history_page_ids.numel() + 1,
+            history_page_ids.numel() + current_only_page_ids.numel() + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.physical_to_compact_main_kv_page.index_copy_(
+            0, current_only_page_ids, current_compact_ids
+        )
+        self._active_main_kv_compact_page_ids = torch.cat(
+            (history_page_ids, current_only_page_ids)
+        ).contiguous()
+        self._active_main_kv_page_plan = page_plan
+        self._active_main_kv_batch_marker = weakref.ref(batch_marker)
+
+    def translate_main_kv_loc_to_compact(self, loc: torch.Tensor) -> torch.Tensor:
+        """Translate physical token locations for the active compact buffer."""
+
+        if self._active_main_kv_page_plan is None:
+            return loc
+
+        valid = loc >= 0
+        safe_loc = loc.clamp_min(0)
+        physical_page = torch.div(safe_loc, self.page_size, rounding_mode="floor").to(
+            torch.long
+        )
+        page_offset = safe_loc % self.page_size
+        compact_page = self.physical_to_compact_main_kv_page.index_select(
+            0, physical_page.reshape(-1)
+        ).reshape(physical_page.shape)
+        compact_loc = compact_page.to(loc.dtype) * self.page_size + page_offset
+        return torch.where(
+            valid & (compact_page >= 0),
+            compact_loc,
+            torch.full_like(compact_loc, -1),
+        )
+
+    def _broadcast_compact_main_kv_pages(
+        self,
+        layer_id: int,
+        src_tensor: Optional[torch.Tensor],
+        *,
+        include_current: bool = False,
+    ) -> None:
+        page_plan = self._active_main_kv_page_plan
+        assert page_plan is not None
+        num_pages = (
+            self._active_main_kv_compact_page_ids.numel()
+            if include_current
+            else page_plan.history_page_ids.numel()
+        )
+        if num_pages == 0:
+            return
+
+        page_ids = self._active_main_kv_compact_page_ids[:num_pages]
+        remote_pages = self.remote_kv_buffer.view(
+            self.num_pool_pages,
+            self.page_size,
+            1,
+            self.kv_cache_dim,
+        )
+        payload = remote_pages[1 : num_pages + 1]
+        bytes_to_broadcast = payload.numel() * payload.element_size()
+
+        if self._is_layer_owned(layer_id):
+            assert src_tensor is not None
+            local_pages = src_tensor.view(
+                self.num_pool_pages,
+                self.page_size,
+                1,
+                self.kv_cache_dim,
+            )
+            with torch.profiler.record_function(
+                "layersplit_main_kv_pack "
+                f"layer={layer_id} pages={num_pages} "
+                f"bytes={bytes_to_broadcast}"
+            ):
+                torch.index_select(local_pages, 0, page_ids, out=payload)
+
+        with torch.profiler.record_function(
+            "layersplit_main_kv_broadcast "
+            f"layer={layer_id} pages={num_pages} "
+            f"bytes={bytes_to_broadcast}"
+        ):
+            self._broadcast_tensor_from_owner(
+                payload,
+                layer_id,
+                src_tensor=(payload if self._is_layer_owned(layer_id) else None),
+                use_layer_broadcast_comm=True,
+            )
 
     def _finalize_pending_kv_broadcast(
         self, *, set_remote_layer_id: bool = True
@@ -454,6 +770,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         layer_id: int,
         layer_transfer_counter: Optional[LayerDoneCounter] = None,
         layer_transfer_idx: Optional[int] = None,
+        has_history: bool = True,
     ) -> None:
         """Kick off an async owner-broadcast of ``layer_id``'s latent KV.
 
@@ -468,30 +785,54 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
                 return
             self._finalize_pending_kv_broadcast(set_remote_layer_id=False)
 
+        compact_history_is_empty = (
+            self._active_main_kv_page_plan is not None
+            and self._active_main_kv_page_plan.history_page_ids.numel() == 0
+        )
+        if compact_history_is_empty or (
+            self._active_main_kv_page_plan is None and not has_history
+        ):
+            # The gathered K will populate this scratch directly. Broadcasting
+            # an empty history would only duplicate data movement.
+            self.remote_kv_layer_id = layer_id
+            return
+
         local_idx = self._local_layer_idx(layer_id)
         src_tensor = (
             self.kv_buffer[local_idx] if self._is_layer_owned(layer_id) else None
         )
+        transfer_counter = layer_transfer_counter or self.layer_transfer_counter
+        transfer_idx = (
+            layer_transfer_idx if layer_transfer_idx is not None else local_idx
+        )
         if self.layer_broadcast_comm is None:
-            self._broadcast_tensor_from_owner(
-                self.remote_kv_buffer,
-                layer_id,
-                src_tensor=src_tensor,
-                use_layer_broadcast_comm=True,
-            )
+            if transfer_counter is not None:
+                transfer_counter.wait_until(transfer_idx)
+            if self._active_main_kv_page_plan is not None:
+                self._broadcast_compact_main_kv_pages(layer_id, src_tensor)
+            else:
+                self._broadcast_tensor_from_owner(
+                    self.remote_kv_buffer,
+                    layer_id,
+                    src_tensor=src_tensor,
+                    use_layer_broadcast_comm=True,
+                )
             self.remote_kv_layer_id = layer_id
             return
 
         self.kv_broadcast_stream.wait_stream(self.device_module.current_stream())
         with self.device_module.stream(self.kv_broadcast_stream):
-            if layer_transfer_counter is not None and layer_transfer_idx is not None:
-                layer_transfer_counter.wait_until(layer_transfer_idx)
-            self._broadcast_tensor_from_owner(
-                self.remote_kv_buffer,
-                layer_id,
-                src_tensor=src_tensor,
-                use_layer_broadcast_comm=True,
-            )
+            if transfer_counter is not None:
+                transfer_counter.wait_until(transfer_idx)
+            if self._active_main_kv_page_plan is not None:
+                self._broadcast_compact_main_kv_pages(layer_id, src_tensor)
+            else:
+                self._broadcast_tensor_from_owner(
+                    self.remote_kv_buffer,
+                    layer_id,
+                    src_tensor=src_tensor,
+                    use_layer_broadcast_comm=True,
+                )
         self.pending_remote_kv_layer_id = layer_id
         self.pending_remote_kv_broadcast = True
 
@@ -505,14 +846,43 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
             src_tensor = (
                 self.kv_buffer[local_idx] if self._is_layer_owned(layer_id) else None
             )
-            self._broadcast_tensor_from_owner(
-                self.remote_kv_buffer,
-                layer_id,
-                src_tensor=src_tensor,
-                use_layer_broadcast_comm=True,
-            )
+            if self._active_main_kv_page_plan is not None:
+                # A missed prefetch reaches this fallback after current KV may
+                # already have been produced, so bootstrap every compact page.
+                self._broadcast_compact_main_kv_pages(
+                    layer_id,
+                    src_tensor,
+                    include_current=True,
+                )
+            else:
+                self._broadcast_tensor_from_owner(
+                    self.remote_kv_buffer,
+                    layer_id,
+                    src_tensor=src_tensor,
+                    use_layer_broadcast_comm=True,
+                )
             self.remote_kv_layer_id = layer_id
         return self.remote_kv_buffer
+
+    def invalidate_remote_kv_buffer_for_layer(self, layer_id: int) -> None:
+        """Invalidate a broadcast copy before HiCache restores its owner layer."""
+
+        if self.pending_remote_kv_layer_id == layer_id:
+            self._finalize_pending_kv_broadcast(set_remote_layer_id=False)
+        if self.remote_kv_layer_id == layer_id:
+            self.remote_kv_layer_id = None
+
+    def get_mla_kv_buffer(
+        self,
+        layer: RadixAttention,
+        loc: torch.Tensor,
+        dst_dtype: Optional[torch.dtype] = None,
+    ):
+        return super().get_mla_kv_buffer(
+            layer,
+            self.translate_main_kv_loc_to_compact(loc),
+            dst_dtype,
+        )
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         size_limit = self.size + self.page_size

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -40,6 +40,7 @@ import torch
 
 from sglang.kernels.ops.attention.dsa import index_buf_accessor
 from sglang.srt.layers.attention.dsa.hcu_int8_index_k_cache import (
+    IndexKCacheMode,
     quantize_and_store_index_k_int8,
 )
 from sglang.srt.layers.cp.utils import get_layer_owner, get_layer_shard_range
@@ -176,8 +177,25 @@ def build_main_kv_page_plan(
 
 class LayerSplitIndexKeyCache(IndexKeyCache):
     def __init__(self, pool: LayerSplitDSATokenToKVPool, index_buf_size: int):
-        super().__init__(pool, index_buf_size)
         num_pages = (index_buf_size + pool.page_size + 1) // pool.page_size
+        if pool.index_k_cache_mode is IndexKCacheMode.BF16:
+            self.pool = pool
+            with (
+                torch.cuda.use_mem_pool(pool.custom_mem_pool)
+                if pool.custom_mem_pool
+                else nullcontext()
+            ):
+                self.buffer = [
+                    torch.zeros(
+                        self._buffer_shape(self._layer_num_pages(i, num_pages)),
+                        dtype=self._buffer_dtype(),
+                        device=pool.device,
+                    )
+                    for i in range(pool.indexer_layer_num)
+                ]
+        else:
+            super().__init__(pool, index_buf_size)
+
         with (
             torch.cuda.use_mem_pool(pool.custom_mem_pool)
             if pool.custom_mem_pool
@@ -185,13 +203,28 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         ):
             self.remote_buffer = torch.zeros(
                 self._buffer_shape(num_pages),
-                dtype=pool.index_k_with_scale_buffer_dtype,
+                dtype=self._buffer_dtype(),
                 device=pool.device,
             )
         self.remote_layer_id: Optional[int] = None
         self.pending_event = pool.device_module.Event()
         self.pending_layer_id: Optional[int] = None
         self.pending_broadcast = False
+
+    def _buffer_shape(self, num_pages: int) -> tuple[int, ...]:
+        if self.pool.index_k_cache_mode is IndexKCacheMode.BF16:
+            return (
+                num_pages,
+                self.pool.page_size,
+                1,
+                self.pool.index_head_dim,
+            )
+        return super()._buffer_shape(num_pages)
+
+    def _buffer_dtype(self) -> torch.dtype:
+        if self.pool.index_k_cache_mode is IndexKCacheMode.BF16:
+            return self.pool.index_k_buffer_dtype
+        return self.pool.index_k_with_scale_buffer_dtype
 
     def _layer_num_pages(self, layer_idx: int, num_pages: int) -> int:
         layer_id = self.pool.indexer_layer_ids[layer_idx]
@@ -208,6 +241,16 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         # write path, so no cached remote layer remains valid.
         self.finalize_pending(set_remote_layer_id=False)
         self.remote_layer_id = None
+        if self.pool.index_k_cache_mode is IndexKCacheMode.BF16:
+            tgt_loc_flat = tgt_loc.view(-1).long()
+            src_loc_flat = src_loc.view(-1).long()
+            for index_k in self.buffer:
+                if index_k.shape[0] == 0:
+                    continue
+                flat_index_k = index_k.view(-1, 1, self.pool.index_head_dim)
+                flat_index_k[tgt_loc_flat] = flat_index_k[src_loc_flat]
+            return
+
         super().move(tgt_loc, src_loc)
 
     def get_buffer(self, layer_id: int) -> torch.Tensor:
@@ -309,6 +352,26 @@ class LayerSplitIndexKeyCache(IndexKeyCache):
         )
         if self.pool._is_layer_owned(layer_id):
             super().store_quantized(layer_id, loc, index_k, index_k_scale)
+
+    def store_bf16(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+    ) -> None:
+        """Store BF16 Index-K into scratch and the owner's persistent shard."""
+
+        if not self.prepare_remote_write(layer_id):
+            self.get_broadcastable_buffer(layer_id)
+        if index_k.dtype != self.pool.index_k_buffer_dtype:
+            index_k = index_k.to(self.pool.index_k_buffer_dtype)
+
+        page_indices = loc // self.pool.page_size
+        token_offsets = loc % self.pool.page_size
+        self.remote_buffer[page_indices, token_offsets] = index_k
+        if self.pool._is_layer_owned(layer_id):
+            cache_idx = self.pool._get_indexer_cache_index(layer_id)
+            self.buffer[cache_idx][page_indices, token_offsets] = index_k
 
     def store_int8(
         self,
@@ -689,7 +752,17 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         self._init_layer_broadcast_comm()
 
     def _create_index_key_cache(self) -> IndexKeyCache:
-        return LayerSplitIndexKeyCache(self, self.index_buf_size)
+        cache = LayerSplitIndexKeyCache(self, self.index_buf_size)
+        self.index_k_buffer = (
+            cache.buffer if self.index_k_cache_mode is IndexKCacheMode.BF16 else None
+        )
+        return cache
+
+    @property
+    def index_k_with_scale_buffer(self):
+        if not self.use_scaled_index_k_cache:
+            return None
+        return self.index_key_cache.buffer
 
     def _clear_buffers(self):
         del self.kv_buffer
@@ -706,7 +779,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         kv_size_bytes = 0
         for kv_cache in self.kv_buffer:
             kv_size_bytes += get_tensor_size_bytes(kv_cache)
-        for index_k_cache in self.index_k_with_scale_buffer:
+        for index_k_cache in self.index_key_cache.buffer:
             kv_size_bytes += get_tensor_size_bytes(index_k_cache)
         if self.use_int8_index_k_cache:
             kv_size_bytes += get_tensor_size_bytes(self.index_k_dequant_workspace)
@@ -727,6 +800,22 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
             self.kv_buffer[i][0].nbytes * self.page_size for i in owned_layer_ids
         ]
         return kv_data_ptrs, kv_data_lens, kv_item_lens
+
+    def get_kv_layer_ids(self):
+        """Global layer ids aligned with the owned-only KV transfer buffers."""
+        return [
+            self.start_layer + i
+            for i in range(self.layer_num)
+            if self._is_layer_owned(self.start_layer + i)
+        ]
+
+    def get_state_layer_ids(self):
+        """Global layer ids aligned with the owned-only Index-K buffers."""
+        return [
+            layer_id
+            for layer_id in self.indexer_layer_ids
+            if self._is_layer_owned(layer_id)
+        ]
 
     def get_key_buffer(self, layer_id: int):
         if self.layer_transfer_counter is not None:
@@ -1155,6 +1244,19 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         self.index_key_cache.move(tgt_loc, src_loc)
 
     # ---- DSA indexer buffer: owned-only writes, owner-broadcast reads -----
+
+    def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
+        assert self.index_k_buffer is not None, "BF16 index K cache is not enabled"
+        return self.index_key_cache.get_buffer(layer_id)
+
+    def set_index_k_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+    ) -> None:
+        assert self.index_k_buffer is not None, "BF16 index K cache is not enabled"
+        self.index_key_cache.store_bf16(layer_id, loc, index_k)
 
     def get_broadcastable_index_k_with_scale_buffer(
         self, layer_id: int

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1966,6 +1966,7 @@ def attach_hybrid_dsa_pool_to_hiradix_cache(
         radix_cache.full_kv_pool_host = host_pool_group.get_pool(PoolName.KV)
         radix_cache.token_to_kv_pool_host = host_pool_group
         radix_cache.cache_controller = cache_controller
+        kv.register_layer_transfer_counter(cache_controller.layer_done_counter)
         logger.info(
             "Attached hybrid DSA pool stack to HiRadixCache: pools=KV + INDEXER, "
             "transfer_layer_num=%s",

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -65,11 +65,11 @@ def _with_mtp_layer_mapping(
     layer_mapping: dict[int, int],
     *,
     transfer_layer_start: int,
-    target_device_layer_num: int,
+    target_host_layer_num: int,
     draft_layer_num: int,
 ) -> dict[int, int]:
     return layer_mapping | {
-        transfer_layer_start + depth: target_device_layer_num + depth
+        transfer_layer_start + depth: target_host_layer_num + depth
         for depth in range(draft_layer_num)
     }
 
@@ -183,7 +183,7 @@ def build_kv_only_group(
         full_layer_mapping = _with_mtp_layer_mapping(
             full_layer_mapping,
             transfer_layer_start=transfer_layer_num,
-            target_device_layer_num=kv_pool.layer_num,
+            target_host_layer_num=kv_host_pool.target_layer_num,
             draft_layer_num=len(mtp_draft_device_pools),
         )
     return HostPoolGroup(
@@ -239,7 +239,7 @@ def build_hybrid_swa_group(
         swa_layer_mapping = _with_mtp_layer_mapping(
             swa_layer_mapping,
             transfer_layer_start=transfer_layer_num,
-            target_device_layer_num=swa_kv_pool.layer_num,
+            target_host_layer_num=swa_host_pool.target_layer_num,
             draft_layer_num=len(mtp_swa_device_pools),
         )
     return HostPoolGroup(
@@ -471,7 +471,7 @@ def build_deepseek_v4_hicache_stack(
         swa_layer_mapping = _with_mtp_layer_mapping(
             swa_layer_mapping,
             transfer_layer_start=transfer_layer_num,
-            target_device_layer_num=transfer_layer_num,
+            target_host_layer_num=transfer_layer_num,
             draft_layer_num=len(mtp_swa_device_buffers),
         )
 
@@ -719,7 +719,7 @@ def build_hybrid_mamba_stack(
         full_layer_mapping = _with_mtp_layer_mapping(
             full_layer_mapping,
             transfer_layer_start=transfer_layer_num,
-            target_device_layer_num=kv_pool.layer_num,
+            target_host_layer_num=kv_host_pool.target_layer_num,
             draft_layer_num=len(mtp_draft_device_pools),
         )
     # MambaPoolHost only supports page_first/page_first_direct/layer_first.
@@ -918,7 +918,9 @@ def build_anchor_sidecar_stack(
 ) -> tuple[HostPoolGroup, HybridCacheController]:
     transfer_layer_num = len(full_layer_mapping)
     mtp_draft_device_pools = tuple(
-        pool for pool in params.mtp_draft_device_pools if pool.index_k_with_scale_buffer
+        pool
+        for pool in params.mtp_draft_device_pools
+        if pool.index_k_with_scale_buffer is not None or pool.index_k_buffer is not None
     )
     kv_host_pool = build_kv_host_pool(
         kv_pool=kv_pool,
@@ -934,7 +936,7 @@ def build_anchor_sidecar_stack(
         full_layer_mapping = _with_mtp_layer_mapping(
             full_layer_mapping,
             transfer_layer_start=transfer_layer_num,
-            target_device_layer_num=kv_pool.layer_num,
+            target_host_layer_num=kv_host_pool.target_layer_num,
             draft_layer_num=len(mtp_draft_device_pools),
         )
     entries = [
@@ -1057,7 +1059,9 @@ def build_full_draft_pools(
         )
     ]
 
-    if isinstance(pool, DSATokenToKVPool) and pool.index_k_with_scale_buffer:
+    if isinstance(pool, DSATokenToKVPool) and (
+        pool.index_k_with_scale_buffer is not None or pool.index_k_buffer is not None
+    ):
         indexer_host_pool = DSAIndexerPoolHost(
             pool,
             draft_host_pool,

--- a/python/sglang/srt/mem_cache/index_key_cache.py
+++ b/python/sglang/srt/mem_cache/index_key_cache.py
@@ -26,7 +26,7 @@ class IndexKeyCache:
                     dtype=pool.index_k_with_scale_buffer_dtype,
                     device=pool.device,
                 )
-                for i in range(pool.layer_num)
+                for i in range(pool.indexer_layer_num)
             ]
 
     def _buffer_shape(self, num_pages: int) -> tuple[int, int]:
@@ -38,9 +38,7 @@ class IndexKeyCache:
         )
 
     def _layer_num_pages(self, layer_idx: int, num_pages: int) -> int:
-        # Layers that reuse the previous layer's top-k never write index-K, so
-        # they get a 0-row placeholder that keeps ``buffer`` layer-aligned.
-        return 0 if self.pool.skip_topk_layers[layer_idx] else num_pages
+        return num_pages
 
     def clear(self) -> None:
         del self.buffer
@@ -60,7 +58,7 @@ class IndexKeyCache:
             self.pool.layer_transfer_counter.wait_until(
                 layer_id - self.pool.start_layer
             )
-        return self.buffer[layer_id - self.pool.start_layer]
+        return self.buffer[self.pool._get_indexer_cache_index(layer_id)]
 
     def get_buffer(self, layer_id: int) -> torch.Tensor:
         return self.get_local_buffer(layer_id)
@@ -104,7 +102,7 @@ class IndexKeyCache:
         index_k: torch.Tensor,
         index_k_scale: torch.Tensor,
     ) -> None:
-        buf = self.buffer[layer_id - self.pool.start_layer]
+        buf = self.buffer[self.pool._get_indexer_cache_index(layer_id)]
         index_buf_accessor.SetKAndS.execute(
             pool=self.pool,
             buf=buf,
@@ -120,7 +118,7 @@ class IndexKeyCache:
         index_k_cpu = []
         chunk_size = self.pool.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.pool.page_size)
-        for layer_id in range(self.pool.layer_num):
+        for layer_id in range(self.pool.indexer_layer_num):
             index_k_cpu.append([])
             if self.buffer[layer_id].shape[0] == 0:
                 continue
@@ -138,7 +136,7 @@ class IndexKeyCache:
         torch.cuda.synchronize()
         chunk_size = self.pool.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.pool.page_size)
-        for layer_id in range(self.pool.layer_num):
+        for layer_id in range(self.pool.indexer_layer_num):
             if self.buffer[layer_id].shape[0] == 0:
                 continue
             for i in range(0, len(page_indices), page_chunk_size):
@@ -155,7 +153,7 @@ class IndexKeyCache:
         return 0 if buf.shape[0] == 0 else buf[0].nbytes
 
     def state_buf_infos(self):
-        layer_num = self.pool.layer_num
+        layer_num = self.pool.indexer_layer_num
         data_ptrs = [self.buffer[i].data_ptr() for i in range(layer_num)]
         data_lens = [self.buffer[i].nbytes for i in range(layer_num)]
         item_lens = [self._item_len(i) for i in range(layer_num)]

--- a/python/sglang/srt/mem_cache/index_key_cache.py
+++ b/python/sglang/srt/mem_cache/index_key_cache.py
@@ -80,6 +80,10 @@ class IndexKeyCache:
             )
         return self.buffer[self.pool._get_indexer_cache_index(layer_id)]
 
+    def get_write_buffer(self, layer_id: int) -> torch.Tensor:
+        """Return storage that is safe for an in-place fused cache write."""
+        return self.get_local_buffer(layer_id)
+
     def get_buffer(self, layer_id: int) -> torch.Tensor:
         return self.get_local_buffer(layer_id)
 

--- a/python/sglang/srt/mem_cache/index_key_cache.py
+++ b/python/sglang/srt/mem_cache/index_key_cache.py
@@ -46,12 +46,32 @@ class IndexKeyCache:
     def move(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
         if tgt_loc.numel() == 0:
             return
+
+        page_size = self.pool.page_size
         tgt_loc_flat = tgt_loc.view(-1).long()
         src_loc_flat = src_loc.view(-1).long()
+        tgt_page = tgt_loc_flat // page_size
+        src_page = src_loc_flat // page_size
+        tgt_offset = tgt_loc_flat % page_size
+        src_offset = src_loc_flat % page_size
+
+        k_bytes_per_token = self.pool.index_head_dim
+        scale_bytes_per_token = (
+            self.pool.index_head_dim // self.pool.quant_block_size * 4
+        )
+        k_bytes_per_page = page_size * k_bytes_per_token
+
         for index_k in self.buffer:
             if index_k.shape[0] == 0:
                 continue
-            index_k[tgt_loc_flat] = index_k[src_loc_flat]
+            k_view = index_k[:, :k_bytes_per_page].view(
+                -1, page_size, k_bytes_per_token
+            )
+            scale_view = index_k[:, k_bytes_per_page:].view(
+                -1, page_size, scale_bytes_per_token
+            )
+            k_view[tgt_page, tgt_offset] = k_view[src_page, src_offset]
+            scale_view[tgt_page, tgt_offset] = scale_view[src_page, src_offset]
 
     def get_local_buffer(self, layer_id: int) -> torch.Tensor:
         if self.pool.layer_transfer_counter is not None:

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1321,6 +1321,7 @@ class KVCacheConfigurator:
             dsa_cp_layer_shard_size,
         ) = get_glm_dsa_cp_layer_shard_info(self)
         pool_kwargs = {}
+        use_layer_split_pool = False
         if get_memory().enable_hisparse:
             PoolCls = HiSparseDSATokenToKVPool
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
@@ -1335,20 +1336,26 @@ class KVCacheConfigurator:
             )
 
             PoolCls = LayerSplitDSATokenToKVPool
+            use_layer_split_pool = True
             pool_kwargs["layer_shard_rank"] = dsa_cp_layer_shard_rank
             pool_kwargs["layer_shard_size"] = dsa_cp_layer_shard_size
         else:
             PoolCls = DSATokenToKVPool
+        full_indexer_layer_ids = get_dsa_full_indexer_layer_ids(
+            self.model_config.hf_config,
+            self.layer_info.start_layer,
+            self.layer_info.end_layer,
+        )
         if _should_elide_dsa_index_k(is_draft_worker=self.is_draft_worker):
-            indexer_layer_ids = get_dsa_full_indexer_layer_ids(
-                self.model_config.hf_config,
-                self.layer_info.start_layer,
-                self.layer_info.end_layer,
-            )
+            indexer_layer_ids = full_indexer_layer_ids
         else:
             indexer_layer_ids = list(
                 range(self.layer_info.start_layer, self.layer_info.end_layer)
             )
+        if use_layer_split_pool:
+            # HiCache uses dense storage/transfer metadata, but skip-topk
+            # layers still must not enqueue an Index-K collective.
+            pool_kwargs["indexer_prefetch_layer_ids"] = full_indexer_layer_ids
         if not get_memory().enable_hisparse:
             pool_kwargs["indexer_layer_ids"] = indexer_layer_ids
         token_to_kv_pool = PoolCls(

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -15,7 +15,7 @@ from sglang.srt.configs.hybrid_arch import (
 )
 from sglang.srt.configs.model_config import (
     ModelConfig,
-    dsa_layer_skips_topk,
+    get_dsa_full_indexer_layer_ids,
     get_dsa_index_head_dim,
     get_minimax_sparse_attention_config,
     get_minimax_sparse_disable_value_layer_ids,
@@ -1340,12 +1340,17 @@ class KVCacheConfigurator:
         else:
             PoolCls = DSATokenToKVPool
         if _should_elide_dsa_index_k(is_draft_worker=self.is_draft_worker):
-            pool_kwargs["skip_topk_layers"] = [
-                dsa_layer_skips_topk(self.model_config.hf_config, layer_id)
-                for layer_id in range(
-                    self.layer_info.start_layer, self.layer_info.end_layer
-                )
-            ]
+            indexer_layer_ids = get_dsa_full_indexer_layer_ids(
+                self.model_config.hf_config,
+                self.layer_info.start_layer,
+                self.layer_info.end_layer,
+            )
+        else:
+            indexer_layer_ids = list(
+                range(self.layer_info.start_layer, self.layer_info.end_layer)
+            )
+        if not get_memory().enable_hisparse:
+            pool_kwargs["indexer_layer_ids"] = indexer_layer_ids
         token_to_kv_pool = PoolCls(
             max_total_num_tokens,
             page_size=self.pool_page_size,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4784,6 +4784,10 @@ class DSATokenToKVPool(MLATokenToKVPool):
         assert self.use_scaled_index_k_cache, "Scaled index K cache is not enabled"
         return self.index_key_cache.get_local_buffer(layer_id)
 
+    def get_index_k_with_scale_write_buffer(self, layer_id: int) -> torch.Tensor:
+        assert self.use_scaled_index_k_cache, "Scaled index K cache is not enabled"
+        return self.index_key_cache.get_write_buffer(layer_id)
+
     def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
         assert self.index_k_buffer is not None, "BF16 index K cache is not enabled"
         if self.layer_transfer_counter is not None:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -52,6 +52,14 @@ from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.hcu_int8_index_k_cache import (
+    IndexKCacheMode,
+    create_index_k_int8_aliases,
+    dequantize_index_k_int8_paged,
+    index_k_cache_bytes_per_token,
+    quantize_and_store_index_k_int8,
+    resolve_index_k_cache_mode,
+)
 from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     UnquantizedKVCacheMethod,
@@ -81,7 +89,6 @@ from sglang.srt.utils import (
     is_cuda,
     is_float4_e2m1fn_x2,
     is_hcu,
-    is_hcu_native_fp8_supported,
     is_hip,
     is_npu,
     next_power_of_2,
@@ -4607,19 +4614,22 @@ class DSATokenToKVPool(MLATokenToKVPool):
         self.index_buf_size = index_buf_size
         # num head == 1 and head dim == 128 for index_k in DSA
         assert index_head_dim == 128
-        if _is_hcu:
-            self.use_fp8_index_k_cache = (
-                dtype
-                in (
-                    torch.float8_e4m3fn,
-                    torch.float8_e5m2,
-                )
-                and is_hcu_native_fp8_supported()
-            )
-        else:
-            self.use_fp8_index_k_cache = True
+        self.index_k_cache_mode = resolve_index_k_cache_mode(
+            dtype, page_size, index_head_dim
+        )
+        self.use_fp8_index_k_cache = (
+            self.index_k_cache_mode is IndexKCacheMode.FP8_SCALED
+        )
+        self.use_int8_index_k_cache = (
+            self.index_k_cache_mode is IndexKCacheMode.INT8_SCALED
+        )
+        self.use_scaled_index_k_cache = (
+            self.index_k_cache_mode is not IndexKCacheMode.BF16
+        )
         self.index_k_buffer_dtype = (
-            torch.bfloat16 if _is_hcu and not self.use_fp8_index_k_cache else self.dtype
+            torch.bfloat16
+            if self.index_k_cache_mode is IndexKCacheMode.BF16
+            else self.dtype
         )
 
         if _is_hip and not _is_hcu:
@@ -4634,17 +4644,73 @@ class DSATokenToKVPool(MLATokenToKVPool):
         else:
             assert self.page_size == 64
         self.index_key_cache = self._create_index_key_cache()
+        self._initialize_int8_index_k_workspace()
         self._finalize_allocation_log(size)
 
+        if self.use_int8_index_k_cache:
+            persistent_bytes = sum(
+                buffer.nbytes for buffer in self.index_key_cache.buffer
+            ) + getattr(
+                getattr(self.index_key_cache, "remote_buffer", None), "nbytes", 0
+            )
+            logger.info(
+                "DSA index-K cache mode=%s, persistent bytes/token/layer=%d, "
+                "workspace_count=1, workspace_bytes=%d, page_claim_bytes=%d, "
+                "persistent_bytes=%d",
+                self.index_k_cache_mode.value,
+                index_k_cache_bytes_per_token(self.index_k_cache_mode),
+                self.index_k_dequant_workspace.nbytes,
+                self.index_k_page_claims.nbytes,
+                persistent_bytes,
+            )
+
     def _create_index_key_cache(self) -> Optional[IndexKeyCache]:
-        if _is_hcu and not self.use_fp8_index_k_cache:
+        if self.index_k_cache_mode is IndexKCacheMode.BF16:
             # The official facade only implements the quantized (FP8 data +
-            # FP32 scale) layout. HCU parts without native FP8 fall back to a
-            # plain bf16 index-K cache, which the pool owns directly.
+            # FP32 scale) layout. HCU parts without a scaled cache fall back to
+            # a plain bf16 index-K cache, which the pool owns directly.
             self._create_index_k_buffer()
             return None
         self.index_k_buffer = None
         return IndexKeyCache(self, self.index_buf_size)
+
+    def _initialize_int8_index_k_workspace(self) -> None:
+        self.index_k_int8_aliases = None
+        self.index_k_int8_remote_aliases = None
+        self.index_k_dequant_workspace = None
+        self.index_k_page_claims = None
+        if not self.use_int8_index_k_cache:
+            return
+
+        self.index_k_int8_aliases = [
+            create_index_k_int8_aliases(buffer)
+            for buffer in self.index_key_cache.buffer
+        ]
+        remote_buffer = getattr(self.index_key_cache, "remote_buffer", None)
+        if remote_buffer is not None:
+            self.index_k_int8_remote_aliases = create_index_k_int8_aliases(
+                remote_buffer
+            )
+
+        num_pages = (self.index_buf_size + self.page_size + 1) // self.page_size
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE), (
+            torch.cuda.use_mem_pool(self.custom_mem_pool)
+            if self.custom_mem_pool
+            else nullcontext()
+        ):
+            self.index_k_dequant_workspace = torch.empty(
+                (
+                    num_pages,
+                    self.page_size,
+                    1,
+                    self.index_head_dim,
+                ),
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            self.index_k_page_claims = torch.empty(
+                (num_pages,), dtype=torch.int32, device=self.device
+            )
 
     def _create_index_k_buffer(self):
         num_pages = (self.index_buf_size + self.page_size + 1) // self.page_size
@@ -4684,12 +4750,19 @@ class DSATokenToKVPool(MLATokenToKVPool):
             return None
         return self.index_key_cache.buffer
 
-    def _clear_buffers(self):
-        super()._clear_buffers()
+    def _clear_index_k_buffers(self) -> None:
+        self.index_k_int8_aliases = None
+        self.index_k_int8_remote_aliases = None
+        self.index_k_dequant_workspace = None
+        self.index_k_page_claims = None
         if self.index_key_cache is not None:
             self.index_key_cache.clear()
         if getattr(self, "index_k_buffer", None) is not None:
             del self.index_k_buffer
+
+    def _clear_buffers(self):
+        super()._clear_buffers()
+        self._clear_index_k_buffers()
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         """Move latent KV and the DSA indexer cache (key + scale) in lockstep."""
@@ -4708,7 +4781,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
             flat_index_k[tgt_loc_flat] = flat_index_k[src_loc_flat]
 
     def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
-        assert self.use_fp8_index_k_cache, "FP8 index K cache is not enabled"
+        assert self.use_scaled_index_k_cache, "Scaled index K cache is not enabled"
         return self.index_key_cache.get_local_buffer(layer_id)
 
     def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
@@ -4724,13 +4797,48 @@ class DSATokenToKVPool(MLATokenToKVPool):
         seq_len: int,
         page_indices: torch.Tensor,
     ):
-        if not self.use_fp8_index_k_cache:
+        if self.use_int8_index_k_cache:
+            num_pages = (seq_len + self.page_size - 1) // self.page_size
+            return self.index_k_dequant_workspace[page_indices[:num_pages]].view(
+                -1, 1, self.index_head_dim
+            )[:seq_len]
+        if self.index_k_cache_mode is IndexKCacheMode.BF16:
             num_pages = (seq_len + self.page_size - 1) // self.page_size
             buf = self.get_index_k_buffer(layer_id)
             return buf[page_indices[:num_pages]].view(-1, 1, self.index_head_dim)[
                 :seq_len
             ]
         return self.index_key_cache.get_k_continuous(layer_id, seq_len, page_indices)
+
+    def dequantize_index_k_int8_paged(
+        self,
+        layer_id: int,
+        block_tables: torch.Tensor,
+        context_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        assert self.use_int8_index_k_cache, "INT8 index K cache is not enabled"
+        cache_index = self._get_indexer_cache_index(layer_id)
+        packed_cache = self.index_key_cache.get_buffer(layer_id)
+        local_cache = self.index_key_cache.buffer[cache_index]
+        if packed_cache is local_cache:
+            int8_k, fp32_scales = self.index_k_int8_aliases[cache_index]
+        elif (
+            self.index_k_int8_remote_aliases is not None
+            and packed_cache is getattr(self.index_key_cache, "remote_buffer", None)
+        ):
+            int8_k, fp32_scales = self.index_k_int8_remote_aliases
+        else:
+            int8_k, fp32_scales = create_index_k_int8_aliases(packed_cache)
+
+        return dequantize_index_k_int8_paged(
+            packed_cache,
+            block_tables,
+            context_lens,
+            self.index_k_dequant_workspace,
+            self.index_k_page_claims,
+            int8_k=int8_k,
+            fp32_scales=fp32_scales,
+        )
 
     def get_index_k_scale_continuous(
         self,
@@ -4776,6 +4884,24 @@ class DSATokenToKVPool(MLATokenToKVPool):
     ) -> None:
         assert self.use_fp8_index_k_cache, "FP8 index K cache is not enabled"
         self.index_key_cache.store_quantized(layer_id, loc, index_k, index_k_scale)
+
+    def set_index_k_int8_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+    ) -> None:
+        assert self.use_int8_index_k_cache, "INT8 index K cache is not enabled"
+        cache_index = self._get_indexer_cache_index(layer_id)
+        int8_k, fp32_scales = self.index_k_int8_aliases[cache_index]
+        quantize_and_store_index_k_int8(
+            index_k,
+            self.index_key_cache.buffer[cache_index],
+            loc,
+            page_size=self.page_size,
+            int8_k=int8_k,
+            fp32_scales=fp32_scales,
+        )
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         # DSA keeps a page-indexed index cache alongside kv_buffer. Retract
@@ -4859,11 +4985,14 @@ class DSATokenToKVPool(MLATokenToKVPool):
         kv_size_bytes = super().get_kv_size_bytes()
         index_cache = (
             self.index_k_with_scale_buffer
-            if self.use_fp8_index_k_cache
+            if self.use_scaled_index_k_cache
             else self.index_k_buffer
         )
         for index_k_cache in index_cache:
             kv_size_bytes += get_tensor_size_bytes(index_k_cache)
+        if self.use_int8_index_k_cache:
+            kv_size_bytes += get_tensor_size_bytes(self.index_k_dequant_workspace)
+            kv_size_bytes += get_tensor_size_bytes(self.index_k_page_claims)
         return kv_size_bytes
 
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4822,9 +4822,8 @@ class DSATokenToKVPool(MLATokenToKVPool):
         local_cache = self.index_key_cache.buffer[cache_index]
         if packed_cache is local_cache:
             int8_k, fp32_scales = self.index_k_int8_aliases[cache_index]
-        elif (
-            self.index_k_int8_remote_aliases is not None
-            and packed_cache is getattr(self.index_key_cache, "remote_buffer", None)
+        elif self.index_k_int8_remote_aliases is not None and packed_cache is getattr(
+            self.index_key_cache, "remote_buffer", None
         ):
             int8_k, fp32_scales = self.index_k_int8_remote_aliases
         else:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4984,6 +4984,14 @@ class DSATokenToKVPool(MLATokenToKVPool):
         item_lens = [buffer[0].nbytes for buffer in index_cache]
         return data_ptrs, data_lens, item_lens
 
+    def get_kv_layer_ids(self):
+        """Global layer ids aligned with the MLA KV transfer buffers."""
+        return list(range(self.start_layer, self.start_layer + self.layer_num))
+
+    def get_state_layer_ids(self):
+        """Global layer ids aligned with the DSA Index-K transfer buffers."""
+        return list(self.indexer_layer_ids)
+
     def get_index_k_cache_transfer_abi(self) -> str:
         """Return the persistent index-K page ABI used by PD state transfer."""
         return (

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4981,6 +4981,13 @@ class DSATokenToKVPool(MLATokenToKVPool):
         item_lens = [buffer[0].nbytes for buffer in index_cache]
         return data_ptrs, data_lens, item_lens
 
+    def get_index_k_cache_transfer_abi(self) -> str:
+        """Return the persistent index-K page ABI used by PD state transfer."""
+        return (
+            f"dsa-index-k-page-v1:{self.index_k_cache_mode.value}:"
+            f"page_size={self.page_size}:head_dim={self.index_head_dim}"
+        )
+
     def get_kv_size_bytes(self):
         kv_size_bytes = super().get_kv_size_bytes()
         index_cache = (

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -31,7 +31,7 @@ import os
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, fields
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -4556,7 +4556,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         start_layer: Optional[int] = None,
         end_layer: Optional[int] = None,
         index_buf_size: Optional[int] = None,
-        skip_topk_layers: Optional[List[bool]] = None,
+        indexer_layer_ids: Optional[Sequence[int]] = None,
     ):
         override_dim = (
             kv_cache_dim if kv_cache_dim != kv_lora_rank + qk_rope_head_dim else None
@@ -4579,6 +4579,29 @@ class DSATokenToKVPool(MLATokenToKVPool):
         # self.index_k_dtype = torch.float8_e4m3fn
         # self.index_k_scale_dtype = torch.float32
         self.index_head_dim = index_head_dim
+        layer_range = range(self.start_layer, self.start_layer + self.layer_num)
+        if indexer_layer_ids is None:
+            resolved_indexer_layer_ids = tuple(layer_range)
+        else:
+            if len(indexer_layer_ids) != len(set(indexer_layer_ids)):
+                raise ValueError("indexer_layer_ids must not contain duplicates")
+            resolved_indexer_layer_ids = tuple(sorted(indexer_layer_ids))
+            invalid_layer_ids = [
+                layer_id
+                for layer_id in resolved_indexer_layer_ids
+                if layer_id not in layer_range
+            ]
+            if invalid_layer_ids:
+                raise ValueError(
+                    f"indexer_layer_ids {invalid_layer_ids} are outside local layer "
+                    f"range [{self.start_layer}, "
+                    f"{self.start_layer + self.layer_num})"
+                )
+        self.indexer_layer_ids = resolved_indexer_layer_ids
+        self.indexer_layer_num = len(self.indexer_layer_ids)
+        self.indexer_layer_id_to_index = {
+            layer_id: index for index, layer_id in enumerate(self.indexer_layer_ids)
+        }
         if index_buf_size is None:
             index_buf_size = size
         self.index_buf_size = index_buf_size
@@ -4598,13 +4621,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
         self.index_k_buffer_dtype = (
             torch.bfloat16 if _is_hcu and not self.use_fp8_index_k_cache else self.dtype
         )
-
-        self.skip_topk_layers = (
-            list(skip_topk_layers)
-            if skip_topk_layers is not None
-            else [False] * layer_num
-        )
-        assert len(self.skip_topk_layers) == layer_num
 
         if _is_hip and not _is_hcu:
             if aiter_can_use_preshuffle_paged_mqa():
@@ -4648,8 +4664,17 @@ class DSATokenToKVPool(MLATokenToKVPool):
                     dtype=self.index_k_buffer_dtype,
                     device=self.device,
                 )
-                for _ in range(self.layer_num)
+                for _ in range(self.indexer_layer_num)
             ]
+
+    def _get_indexer_cache_index(self, layer_id: int) -> int:
+        try:
+            return self.indexer_layer_id_to_index[layer_id]
+        except KeyError as exc:
+            raise ValueError(
+                f"Layer {layer_id} does not own an Index-K cache; active layers are "
+                f"{self.indexer_layer_ids}"
+            ) from exc
 
     @property
     def index_k_with_scale_buffer(self):
@@ -4691,7 +4716,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
 
-        return self.index_k_buffer[layer_id - self.start_layer]
+        return self.index_k_buffer[self._get_indexer_cache_index(layer_id)]
 
     def get_index_k_continuous(
         self,
@@ -4771,7 +4796,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         index_k_cpu = []
         chunk_size = self.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.page_size)
-        for layer_id in range(self.layer_num):
+        for layer_id in range(self.indexer_layer_num):
             index_k_cpu.append([])
             for i in range(0, len(page_indices), page_chunk_size):
                 chunk_page_indices = page_indices[i : i + page_chunk_size]
@@ -4797,7 +4822,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         torch.cuda.synchronize()
         chunk_size = self.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.page_size)
-        for layer_id in range(self.layer_num):
+        for layer_id in range(self.indexer_layer_num):
             for i in range(0, len(page_indices), page_chunk_size):
                 chunk_page_indices = page_indices[i : i + page_chunk_size]
                 idx_cpu = index_k_cpu[layer_id][i // page_chunk_size]
@@ -4816,7 +4841,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         if index_k.dtype != self.index_k_buffer_dtype:
             index_k = index_k.to(self.index_k_buffer_dtype)
 
-        self.index_k_buffer[layer_id - self.start_layer][
+        self.index_k_buffer[self._get_indexer_cache_index(layer_id)][
             loc // self.page_size, loc % self.page_size
         ] = index_k
 
@@ -4825,9 +4850,9 @@ class DSATokenToKVPool(MLATokenToKVPool):
             return self.index_key_cache.state_buf_infos()
 
         index_cache = self.index_k_buffer
-        data_ptrs = [index_cache[i].data_ptr() for i in range(self.layer_num)]
-        data_lens = [index_cache[i].nbytes for i in range(self.layer_num)]
-        item_lens = [index_cache[i][0].nbytes for i in range(self.layer_num)]
+        data_ptrs = [buffer.data_ptr() for buffer in index_cache]
+        data_lens = [buffer.nbytes for buffer in index_cache]
+        item_lens = [buffer[0].nbytes for buffer in index_cache]
         return data_ptrs, data_lens, item_lens
 
     def get_kv_size_bytes(self):

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -1128,7 +1128,8 @@ class DSAIndexerPoolHost(HostKVCache):
         self.dtype = device_pool.store_dtype
         self.start_layer = device_pool.start_layer
         self.end_layer = device_pool.end_layer
-        self.use_fp8 = device_pool.use_fp8_index_k_cache
+        # FP8 and HCU INT8 share the same packed uint8 K+scale storage ABI.
+        self.use_scaled_index_cache = device_pool.use_scaled_index_k_cache
         self.target_layer_num = self._effective_host_layer_num()
         self.mtp_draft_device_pools = anchor_host.mtp_draft_device_pools
         self.layer_num = self.target_layer_num + len(self.mtp_draft_device_pools)
@@ -1136,14 +1137,14 @@ class DSAIndexerPoolHost(HostKVCache):
         self.index_head_dim = device_pool.index_head_dim
         self.indexer_quant_block_size = device_pool.quant_block_size
         self.indexer_dtype = DSATokenToKVPool.index_k_with_scale_buffer_dtype
-        if self.use_fp8:
+        if self.use_scaled_index_cache:
             self.indexer_size_per_token = (
                 self.index_head_dim
                 + self.index_head_dim // self.indexer_quant_block_size * 4
             )
         else:
-            self.indexer_size_per_token = (
-                device_pool.index_k_buffer[0][0].nbytes // self.page_size
+            self.indexer_size_per_token = self._infer_bf16_indexer_size_per_token(
+                device_pool
             )
         self.size = anchor_host.size
         self.page_num = anchor_host.page_num
@@ -1194,8 +1195,14 @@ class DSAIndexerPoolHost(HostKVCache):
         self.lock = threading.RLock()
         self.clear()
 
+    def _infer_bf16_indexer_size_per_token(self, device_pool) -> int:
+        for buffer in device_pool.index_k_buffer:
+            if buffer.shape[0] > 0:
+                return buffer[0].nbytes // self.page_size
+        return self.index_head_dim * torch.bfloat16.itemsize
+
     def _get_device_index_k_cache_for_transfer(self, device_pool):
-        if self.use_fp8:
+        if self.use_scaled_index_cache:
             return device_pool.index_k_with_scale_buffer
         return [
             buf.view(torch.uint8).view(buf.shape[0], -1)

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -1480,7 +1480,7 @@ class DSAIndexerPoolHost(HostKVCache):
                     draft_device_pool,
                     host_indices,
                     device_indices,
-                    self.device_pool.layer_num + draft_layer_id,
+                    self.target_layer_num + draft_layer_id,
                     io_backend,
                     is_draft=True,
                 )

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -34,9 +34,10 @@ from sglang.kernels.ops.kvcache.hicache import (
 )
 from sglang.kernels.ops.kvcache.hisparse import transfer_cache_dsv4_mla
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
-from sglang.srt.utils import is_cuda, is_hip, is_mps, is_npu, is_xpu
+from sglang.srt.utils import is_cuda, is_hcu, is_hip, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
@@ -65,6 +66,7 @@ from sglang.srt.mem_cache.pool_host.base import (
 from sglang.srt.mem_cache.pool_host.common import (
     ALLOC_MEMORY_FUNCS,
     get_allocator_from_storage,
+    kernel_accessible_host_ptr,
 )
 from sglang.srt.mem_cache.pool_host.hisparse import HiSparseHostPoolMixin
 
@@ -1184,6 +1186,8 @@ class DSAIndexerPoolHost(HostKVCache):
                 layout,
             )
         self.init_kv_buffer()
+        # The one-layer JIT wrapper passes raw CPU TensorView pointers. Keep the
+        # sidecar on the AOT path, which translates mapped HCU host addresses.
         self.can_use_jit = False
         self.can_use_write_back_jit = False
         self._init_write_back_staging_buffers()
@@ -1231,7 +1235,7 @@ class DSAIndexerPoolHost(HostKVCache):
                 self.index_k_with_scale_buffer[i] for i in range(self.layer_num)
             ]
             self.index_k_data_ptrs = torch.tensor(
-                [x.data_ptr() for x in self.index_k_data_refs],
+                [kernel_accessible_host_ptr(x) for x in self.index_k_data_refs],
                 dtype=torch.uint64,
                 device=self.device_pool.device,
             )
@@ -1306,6 +1310,11 @@ class DSAIndexerPoolHost(HostKVCache):
         # MTP draft layers do not participate in CP layer sharding.
         host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
         device_layer_id = 0 if is_draft else layer_id
+        hcu_layer_split_kwargs = (
+            {"num_warps_per_block": 4}
+            if _is_hcu and not is_draft and self._is_device_layer_sharded(device_pool)
+            else {}
+        )
 
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices
@@ -1322,18 +1331,18 @@ class DSAIndexerPoolHost(HostKVCache):
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     item_size=self.indexer_page_stride_size,
+                    **hcu_layer_split_kwargs,
                 )
             elif self.layout == "page_first":
                 transfer_kv_per_layer_mla_pf_lf(
                     src=self.index_k_with_scale_buffer,
-                    dst=self._get_device_index_k_cache_for_transfer(device_pool)[
-                        device_layer_id
-                    ],
+                    dst=device_index_k_cache[device_layer_id],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     layer_id=host_layer_id,
                     item_size=self.indexer_page_stride_size,
                     src_layout_dim=self.indexer_layout_dim,
+                    **hcu_layer_split_kwargs,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -1381,6 +1390,11 @@ class DSAIndexerPoolHost(HostKVCache):
         # MTP draft layers do not participate in CP layer sharding.
         host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
         device_layer_id = 0 if is_draft else layer_id
+        hcu_layer_split_kwargs = (
+            {"num_warps_per_block": 4}
+            if _is_hcu and not is_draft and self._is_device_layer_sharded(device_pool)
+            else {}
+        )
 
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices
@@ -1397,12 +1411,30 @@ class DSAIndexerPoolHost(HostKVCache):
                     src_indices=device_page_indices,
                     dst_indices=host_page_indices,
                     item_size=self.indexer_page_stride_size,
+                    **hcu_layer_split_kwargs,
                 )
             elif self.layout == "page_first":
-                raise ValueError(
-                    "Layer-sharded DSA indexer HiCache backup with page_first "
-                    "layout is not supported without a per-layer LF->PF kernel."
-                )
+                if _is_hcu:
+                    # There is no per-layer LF->PF AOT kernel. Use a synchronous
+                    # HCU correctness fallback and keep the existing hard failure
+                    # on other backends where this path is unvalidated.
+                    host_layer = self.index_k_with_scale_buffer[:, host_layer_id].view(
+                        -1, self.indexer_page_stride_size
+                    )
+                    device_layer = device_index_k_cache[device_layer_id].view(
+                        -1, self.indexer_page_stride_size
+                    )
+                    copied_rows = device_layer.index_select(
+                        0, device_page_indices.to(device_layer.device)
+                    ).to(host_layer.device)
+                    host_layer.index_copy_(
+                        0, host_page_indices.to(host_layer.device), copied_rows
+                    )
+                else:
+                    raise ValueError(
+                        "Layer-sharded DSA indexer HiCache backup with page_first "
+                        "layout is not supported without a per-layer LF->PF kernel."
+                    )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
         elif io_backend == "direct":

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -16,11 +16,12 @@ from sglang.srt.mem_cache.pool_host.common import (
     get_allocator_from_storage,
 )
 from sglang.srt.runtime_context import get_parallel
-from sglang.srt.utils import is_cuda, is_hip
+from sglang.srt.utils import is_cuda, is_hcu, is_hip
 
 logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_hip = is_hip()
 
 # Host RAM to leave free when sizing HiCache pools (OS, other processes).
@@ -59,13 +60,16 @@ def host_memory_budget_bytes() -> int:
     return free // ranks_per_host()
 
 
-def sync_fixed_hicache_size(size: int, host_size: int) -> int:
-    """Sync fixed-size HiCache token capacity across PP ranks.
+def sync_fixed_hicache_size(
+    size: int, host_size: int, *, sync_tp_group: bool = False
+) -> int:
+    """Sync fixed-size HiCache token capacity across model-parallel ranks.
 
     A fixed --hicache-size is specified in GB, but each PP stage may have a
     different bytes/token because it owns different layers. Use the global
     minimum token capacity within the PP group so all stages expose the same
-    host-cache capacity.
+    host-cache capacity. HCU LayerSplit also uses a different bytes/token on
+    uneven CP layer shards, so include the TP group for that configuration.
     Ratio-based sizing already derives from the synced device pool size.
     """
     if host_size <= 0 or not torch.distributed.is_available():
@@ -75,28 +79,31 @@ def sync_fixed_hicache_size(size: int, host_size: int) -> int:
         return size
 
     try:
-        from sglang.srt.distributed.parallel_state import get_pp_group
+        from sglang.srt.distributed.parallel_state import get_pp_group, get_tp_group
 
-        pp_group = get_pp_group()
+        groups = [get_pp_group()]
+        if sync_tp_group:
+            groups.append(get_tp_group())
     except AssertionError:
         return size
 
-    if pp_group.world_size <= 1:
-        return size
-
     tensor = torch.tensor(size, dtype=torch.int64)
-    torch.distributed.all_reduce(
-        tensor,
-        op=torch.distributed.ReduceOp.MIN,
-        group=pp_group.cpu_group,
-    )
+    for group in groups:
+        if group.world_size <= 1:
+            continue
+        torch.distributed.all_reduce(
+            tensor,
+            op=torch.distributed.ReduceOp.MIN,
+            group=group.cpu_group,
+        )
     synced_size = int(tensor.item())
 
     if synced_size != size:
         logger.info(
-            "Sync fixed-size HiCache host token capacity from %d to %d.",
+            "Sync fixed-size HiCache host token capacity from %d to %d%s.",
             size,
             synced_size,
+            " across PP and TP groups" if sync_tp_group else " across PP ranks",
         )
     return synced_size
 
@@ -148,10 +155,23 @@ class HostKVCache(abc.ABC):
 
         self.dtype = device_pool.store_dtype
         self.size_per_token = self.get_size_per_token()
+        layer_sharded_on_hcu = _is_hcu and self._is_device_layer_sharded(device_pool)
         if host_size > 0:
-            self.size = sync_fixed_hicache_size(
-                int(host_size * 1e9 // self.size_per_token), host_size
+            # An empty tail shard owns no bytes. Let non-empty ranks determine
+            # the shared capacity instead of dividing by zero or constraining
+            # the group to the device-pool size.
+            local_fixed_size = (
+                int(host_size * 1e9 // self.size_per_token)
+                if self.size_per_token > 0
+                else torch.iinfo(torch.int64).max
             )
+            self.size = sync_fixed_hicache_size(
+                local_fixed_size,
+                host_size,
+                sync_tp_group=layer_sharded_on_hcu,
+            )
+            if self.size == torch.iinfo(torch.int64).max:
+                self.size = device_pool.size
         else:
             self.size = int(device_pool.size * host_to_device_ratio)
         # Align up the host memory pool size to the page size
@@ -252,6 +272,9 @@ class HostKVCache(abc.ABC):
         device_pool = device_pool or self.device_pool
         if not self._is_device_layer_sharded(device_pool):
             return device_pool.layer_num
+        if _is_hcu:
+            start, end = self._device_owned_layer_range(device_pool)
+            return end - start
         shard_size = device_pool.layer_shard_size
         return (device_pool.layer_num + shard_size - 1) // shard_size
 

--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -8,8 +8,12 @@ from collections import defaultdict
 import torch
 
 from sglang.srt.mem_cache.storage.mmap import alloc_mmap
+from sglang.srt.utils import is_hcu
 
 logger = logging.getLogger(__name__)
+
+_is_hcu = is_hcu()
+_HIP_RUNTIME = None
 
 
 class HostTensorAllocator:
@@ -120,7 +124,10 @@ def get_allocator_type(server_args) -> str:
 def _cuda_host_register(buffer: torch.Tensor) -> None:
     cudart = torch.cuda.cudart()
     n_bytes = buffer.numel() * buffer.element_size()
-    rc = cudart.cudaHostRegister(buffer.data_ptr(), n_bytes, 0)
+    # HCU transfer kernels dereference host memory from the device. Register
+    # those pages as mapped so hipHostGetDevicePointer can translate them.
+    flags = 2 if _is_hcu else 0
+    rc = cudart.cudaHostRegister(buffer.data_ptr(), n_bytes, flags)
     if int(rc) != 0:
         raise RuntimeError(
             f"cudaHostRegister failed (rc={int(rc)}, "
@@ -128,6 +135,46 @@ def _cuda_host_register(buffer: torch.Tensor) -> None:
             f"size={n_bytes}; host buffer is not pinned and device transfers "
             f"may silently return stale data."
         )
+
+
+def _hip_host_get_device_pointer(host_ptr: int) -> int:
+    """Translate a mapped HCU host pointer into the device address space."""
+
+    import ctypes
+
+    global _HIP_RUNTIME
+    if _HIP_RUNTIME is None:
+        last_error = None
+        for library in ("libamdhip64.so", "libamdhip64.so.6", "libamdhip64.so.5"):
+            try:
+                _HIP_RUNTIME = ctypes.CDLL(library)
+                break
+            except OSError as error:  # noqa: PERF203
+                last_error = error
+        if _HIP_RUNTIME is None:
+            raise RuntimeError(
+                "Failed to load the HIP runtime for hipHostGetDevicePointer: "
+                f"{last_error}"
+            )
+
+    device_ptr = ctypes.c_void_p()
+    rc = _HIP_RUNTIME.hipHostGetDevicePointer(
+        ctypes.byref(device_ptr), ctypes.c_void_p(host_ptr), ctypes.c_uint(0)
+    )
+    if int(rc) != 0 or device_ptr.value is None:
+        raise RuntimeError(
+            "hipHostGetDevicePointer failed "
+            f"(rc={int(rc)}) for mapped host ptr={host_ptr:#x}."
+        )
+    return int(device_ptr.value)
+
+
+def kernel_accessible_host_ptr(tensor: torch.Tensor) -> int:
+    """Return the address a GPU transfer kernel can dereference."""
+
+    if not _is_hcu or tensor.is_cuda:
+        return tensor.data_ptr()
+    return _hip_host_get_device_pointer(tensor.data_ptr())
 
 
 def _cuda_host_unregister(buffer: torch.Tensor) -> None:

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -24,10 +24,12 @@ from sglang.srt.mem_cache.pool_host.base import (
 from sglang.srt.mem_cache.pool_host.common import (
     ALLOC_MEMORY_FUNCS,
     get_allocator_from_storage,
+    kernel_accessible_host_ptr,
 )
-from sglang.srt.utils import is_cuda, is_hip, is_mps, is_npu, is_xpu
+from sglang.srt.utils import is_cuda, is_hcu, is_hip, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
@@ -69,6 +71,8 @@ class DSAIndexerPoolHost(HostKVCache):
         self.dtype = device_pool.store_dtype
         self.start_layer = device_pool.start_layer
         self.end_layer = device_pool.end_layer
+        # FP8 and HCU INT8 share the packed uint8 K+scale storage ABI.
+        self.use_scaled_index_cache = device_pool.use_scaled_index_k_cache
         self.target_layer_num = self._effective_host_layer_num()
         self.mtp_draft_device_pools = anchor_host.mtp_draft_device_pools
         self.layer_num = self.target_layer_num + len(self.mtp_draft_device_pools)
@@ -76,10 +80,15 @@ class DSAIndexerPoolHost(HostKVCache):
         self.index_head_dim = device_pool.index_head_dim
         self.indexer_quant_block_size = device_pool.quant_block_size
         self.indexer_dtype = DSATokenToKVPool.index_k_with_scale_buffer_dtype
-        self.indexer_size_per_token = (
-            self.index_head_dim
-            + self.index_head_dim // self.indexer_quant_block_size * 4
-        )
+        if self.use_scaled_index_cache:
+            self.indexer_size_per_token = (
+                self.index_head_dim
+                + self.index_head_dim // self.indexer_quant_block_size * 4
+            )
+        else:
+            self.indexer_size_per_token = self._infer_bf16_indexer_size_per_token(
+                device_pool
+            )
         self.size = anchor_host.size
         self.page_num = anchor_host.page_num
 
@@ -126,6 +135,20 @@ class DSAIndexerPoolHost(HostKVCache):
         self.lock = threading.RLock()
         self.clear()
 
+    def _infer_bf16_indexer_size_per_token(self, device_pool) -> int:
+        for buffer in device_pool.index_k_buffer:
+            if buffer.shape[0] > 0:
+                return buffer[0].nbytes // self.page_size
+        return self.index_head_dim * torch.bfloat16.itemsize
+
+    def _get_device_index_k_cache_for_transfer(self, device_pool):
+        if self.use_scaled_index_cache:
+            return device_pool.index_k_with_scale_buffer
+        return [
+            buf.view(torch.uint8).view(buf.shape[0], self.indexer_page_stride_size)
+            for buf in device_pool.index_k_buffer
+        ]
+
     def get_size_per_token(self):
         return (
             self.indexer_size_per_token * self.layer_num * self.indexer_dtype.itemsize
@@ -138,7 +161,9 @@ class DSAIndexerPoolHost(HostKVCache):
         alloc_func = ALLOC_MEMORY_FUNCS[self.device_pool.device]
         device_pools = (self.device_pool, *self.mtp_draft_device_pools)
         self.packed_device_index_buffers = [
-            buffer for pool in device_pools for buffer in pool.index_k_with_scale_buffer
+            buffer
+            for pool in device_pools
+            for buffer in self._get_device_index_k_cache_for_transfer(pool)
         ]
         self.index_k_device_ptrs = torch.tensor(
             [x.data_ptr() for x in self.packed_device_index_buffers],
@@ -157,7 +182,7 @@ class DSAIndexerPoolHost(HostKVCache):
                 self.index_k_with_scale_buffer[i] for i in range(self.layer_num)
             ]
             self.index_k_data_ptrs = torch.tensor(
-                [x.data_ptr() for x in self.index_k_data_refs],
+                [kernel_accessible_host_ptr(x) for x in self.index_k_data_refs],
                 dtype=torch.uint64,
                 device=self.device_pool.device,
             )
@@ -232,29 +257,37 @@ class DSAIndexerPoolHost(HostKVCache):
         # MTP draft layers do not participate in CP layer sharding.
         host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
         device_layer_id = 0 if is_draft else layer_id
+        hcu_layer_split_kwargs = (
+            {"num_warps_per_block": 4}
+            if _is_hcu and not is_draft and self._is_device_layer_sharded(device_pool)
+            else {}
+        )
 
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices
         )
         use_kernel = io_backend == "kernel" and self.indexer_page_stride_size % 8 == 0
+        device_index_k_cache = self._get_device_index_k_cache_for_transfer(device_pool)
         if use_kernel:
             if self.layout == "layer_first":
                 transfer_kv_per_layer_mla(
                     src=self.index_k_with_scale_buffer[host_layer_id],
-                    dst=device_pool.index_k_with_scale_buffer[device_layer_id],
+                    dst=device_index_k_cache[device_layer_id],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     item_size=self.indexer_page_stride_size,
+                    **hcu_layer_split_kwargs,
                 )
             elif self.layout == "page_first":
                 transfer_kv_per_layer_mla_pf_lf(
                     src=self.index_k_with_scale_buffer,
-                    dst=device_pool.index_k_with_scale_buffer[device_layer_id],
+                    dst=device_index_k_cache[device_layer_id],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     layer_id=host_layer_id,
                     item_size=self.indexer_page_stride_size,
                     src_layout_dim=self.indexer_layout_dim,
+                    **hcu_layer_split_kwargs,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -262,7 +295,7 @@ class DSAIndexerPoolHost(HostKVCache):
             if self.layout == "layer_first":
                 transfer_kv_direct(
                     src_layers=[self.index_k_with_scale_buffer[host_layer_id]],
-                    dst_layers=[device_pool.index_k_with_scale_buffer[device_layer_id]],
+                    dst_layers=[device_index_k_cache[device_layer_id]],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     page_size=1,
@@ -270,7 +303,7 @@ class DSAIndexerPoolHost(HostKVCache):
             elif self.layout == "page_first_direct":
                 transfer_kv_per_layer_direct_pf_lf(
                     src_ptrs=[self.index_k_with_scale_buffer],
-                    dst_ptrs=[device_pool.index_k_with_scale_buffer[device_layer_id]],
+                    dst_ptrs=[device_index_k_cache[device_layer_id]],
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     layer_id=host_layer_id,
@@ -294,31 +327,54 @@ class DSAIndexerPoolHost(HostKVCache):
         # MTP draft layers do not participate in CP layer sharding.
         host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
         device_layer_id = 0 if is_draft else layer_id
+        hcu_layer_split_kwargs = (
+            {"num_warps_per_block": 4}
+            if _is_hcu and not is_draft and self._is_device_layer_sharded(device_pool)
+            else {}
+        )
 
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices
         )
+        device_index_k_cache = self._get_device_index_k_cache_for_transfer(device_pool)
         use_kernel = io_backend == "kernel" and self.indexer_page_stride_size % 8 == 0
         if use_kernel:
             if self.layout == "layer_first":
                 transfer_kv_per_layer_mla(
-                    src=device_pool.index_k_with_scale_buffer[device_layer_id],
+                    src=device_index_k_cache[device_layer_id],
                     dst=self.index_k_with_scale_buffer[host_layer_id],
                     src_indices=device_page_indices,
                     dst_indices=host_page_indices,
                     item_size=self.indexer_page_stride_size,
+                    **hcu_layer_split_kwargs,
                 )
             elif self.layout == "page_first":
-                raise ValueError(
-                    "Layer-sharded DSA indexer HiCache backup with page_first "
-                    "layout is not supported without a per-layer LF->PF kernel."
-                )
+                if _is_hcu:
+                    # HCU has no per-layer LF->PF AOT kernel. Keep this path
+                    # synchronous so page-first write-through remains correct.
+                    host_layer = self.index_k_with_scale_buffer[:, host_layer_id].view(
+                        -1, self.indexer_page_stride_size
+                    )
+                    device_layer = device_index_k_cache[device_layer_id].view(
+                        -1, self.indexer_page_stride_size
+                    )
+                    copied_rows = device_layer.index_select(
+                        0, device_page_indices.to(device_layer.device)
+                    ).to(host_layer.device)
+                    host_layer.index_copy_(
+                        0, host_page_indices.to(host_layer.device), copied_rows
+                    )
+                else:
+                    raise ValueError(
+                        "Layer-sharded DSA indexer HiCache backup with page_first "
+                        "layout is not supported without a per-layer LF->PF kernel."
+                    )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
         elif io_backend == "direct":
             if self.layout == "layer_first":
                 transfer_kv_direct(
-                    src_layers=[device_pool.index_k_with_scale_buffer[device_layer_id]],
+                    src_layers=[device_index_k_cache[device_layer_id]],
                     dst_layers=[self.index_k_with_scale_buffer[host_layer_id]],
                     src_indices=device_page_indices,
                     dst_indices=host_page_indices,
@@ -347,7 +403,7 @@ class DSAIndexerPoolHost(HostKVCache):
                     draft_device_pool,
                     host_indices,
                     device_indices,
-                    self.device_pool.layer_num + draft_layer_id,
+                    self.target_layer_num + draft_layer_id,
                     io_backend,
                     is_draft=True,
                 )

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -471,7 +471,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                     draft_device_pool,
                     host_indices,
                     device_indices,
-                    self.device_pool.layer_num + draft_layer_id,
+                    self.target_layer_num + draft_layer_id,
                     io_backend,
                     is_draft=True,
                 )

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -23,11 +23,15 @@ from sglang.srt.mem_cache.pool_host.base import (
     _WRITE_BACK_STAGING_PAGE_CHUNK,
     HostKVCache,
 )
-from sglang.srt.mem_cache.pool_host.common import ALLOC_MEMORY_FUNCS
+from sglang.srt.mem_cache.pool_host.common import (
+    ALLOC_MEMORY_FUNCS,
+    kernel_accessible_host_ptr,
+)
 from sglang.srt.mem_cache.pool_host.hisparse import HiSparseHostPoolMixin
-from sglang.srt.utils import is_cuda, is_hip, is_mps, is_npu, is_xpu
+from sglang.srt.utils import is_cuda, is_hcu, is_hip, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
@@ -88,8 +92,13 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         # helpers in hicache.cuh are guarded by USE_ROCM and the staged
         # write-back kernel has a ROCm path, so enable them on HIP too. This
         # keeps the ROCm write-back path consistent with CUDA.
-        self.can_use_jit = (_is_cuda or _is_hip) and can_use_hicache_jit_kernel(
-            element_size=self.kv_cache_dim * self.dtype.itemsize
+        hcu_layer_sharded = _is_hcu and self._is_device_layer_sharded(device_pool)
+        self.can_use_jit = (
+            (_is_cuda or _is_hip)
+            and not hcu_layer_sharded
+            and can_use_hicache_jit_kernel(
+                element_size=self.kv_cache_dim * self.dtype.itemsize
+            )
         )
 
         if self.layout == "page_first":
@@ -100,7 +109,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         else:
             self.data_refs = [self.kv_buffer[i] for i in range(self.layer_num)]
         self.data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.data_refs],
+            [kernel_accessible_host_ptr(x) for x in self.data_refs],
             dtype=torch.uint64,
             device=self.device_pool.device,
         )
@@ -250,6 +259,10 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         *,
         is_draft: bool = False,
     ):
+        if _is_hcu and not is_draft and self._is_device_layer_sharded(device_pool):
+            absolute_layer_id = device_pool.start_layer + layer_id
+            device_pool.invalidate_remote_kv_buffer_for_layer(absolute_layer_id)
+            device_pool.invalidate_index_buffer_for_layer(absolute_layer_id)
         if not is_draft and not self._is_device_layer_owned(device_pool, layer_id):
             return
         host_indices = self.maybe_dcp_kernel_indices(host_indices)
@@ -257,6 +270,11 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         # MTP draft layers do not participate in CP layer sharding.
         host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
         device_layer_id = 0 if is_draft else layer_id
+        hcu_layer_split_kwargs = (
+            {"num_warps_per_block": 4}
+            if _is_hcu and not is_draft and self._is_device_layer_sharded(device_pool)
+            else {}
+        )
 
         if io_backend == "kernel":
             if self.layout == "layer_first":
@@ -275,6 +293,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                         src_indices=host_indices,
                         dst_indices=device_indices,
                         item_size=self.token_stride_size,
+                        **hcu_layer_split_kwargs,
                     )
             elif self.layout == "page_first":
                 if self.can_use_jit:
@@ -294,6 +313,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                         layer_id=host_layer_id,
                         item_size=self.token_stride_size,
                         src_layout_dim=self.layout_dim,
+                        **hcu_layer_split_kwargs,
                     )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -352,6 +372,11 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         # MTP draft layers do not participate in CP layer sharding.
         host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
         device_layer_id = 0 if is_draft else layer_id
+        hcu_layer_split_kwargs = (
+            {"num_warps_per_block": 4}
+            if _is_hcu and not is_draft and self._is_device_layer_sharded(device_pool)
+            else {}
+        )
 
         if io_backend == "kernel":
             if self.layout == "layer_first":
@@ -370,6 +395,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                         src_indices=device_indices,
                         dst_indices=host_indices,
                         item_size=self.token_stride_size,
+                        **hcu_layer_split_kwargs,
                     )
             elif self.layout == "page_first":
                 if self.can_use_jit:
@@ -379,6 +405,21 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                         indices_dst=host_indices,
                         indices_src=device_indices,
                         element_dim=self.kv_cache_dim,
+                    )
+                elif _is_hcu:
+                    # There is no per-layer LF->PF AOT kernel. This synchronous
+                    # HCU fallback preserves correctness at lower throughput.
+                    host_layer = self.data_refs[host_layer_id].view(
+                        -1, self.kv_cache_dim
+                    )
+                    device_layer = device_pool.kv_buffer[device_layer_id].view(
+                        -1, self.kv_cache_dim
+                    )
+                    copied_rows = device_layer.index_select(
+                        0, device_indices.to(device_layer.device)
+                    ).to(host_layer.device)
+                    host_layer.index_copy_(
+                        0, host_indices.to(host_layer.device), copied_rows
                     )
                 else:
                     raise ValueError(

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     from sglang.srt.layers.logits_processor import LogitsProcessorOutput
     from sglang.srt.layers.utils.cp_utils import ContextParallelMetadata
     from sglang.srt.managers.schedule_batch import MultimodalInputs, ScheduleBatch
+    from sglang.srt.mem_cache.dsa_cache_layer_split import MainKVPagePlan
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
@@ -512,6 +513,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     extend_seq_lens_cpu: Optional[List[int]] = None
     extend_logprob_start_lens_cpu: Optional[List[int]] = None
     extend_input_logprob_token_ids_gpu: Optional[torch.Tensor] = None
+    # Built once from the global request table and reused by every DSA layer.
+    # Index-K metadata deliberately remains in the original physical layout.
+    dsa_layer_split_main_kv_page_plan: Optional[MainKVPagePlan] = None
 
     # For DP attention (MLP sync sizes)
     original_global_num_tokens_cpu: Optional[List[int]] = None

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -861,8 +861,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 extend_input_logprob_token_ids = (
                     extend_input_logprob_token_ids.pin_memory()
                 )
-            ret.extend_input_logprob_token_ids_gpu = (
-                extend_input_logprob_token_ids.to(device, non_blocking=True)
+            ret.extend_input_logprob_token_ids_gpu = extend_input_logprob_token_ids.to(
+                device, non_blocking=True
             )
 
         num_tokens = len(batch.input_ids) if batch.input_ids is not None else 0

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -88,6 +88,11 @@ _is_cpu = is_cpu()
 _is_hcu = is_hcu()
 
 
+def _pin_host_metadata(device: Union[str, torch.device]) -> bool:
+    """Use pinned staging for HCU metadata copied on a busy stream."""
+    return _is_hcu and is_pin_memory_available(device)
+
+
 def _elastic_should_preserve_local_token_counts(
     *,
     model_runner: ModelRunner,
@@ -706,11 +711,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         self.original_global_num_tokens_cpu = batch.global_num_tokens
         self.global_num_tokens_cpu = global_num_tokens
         self.global_num_tokens_gpu = torch.tensor(
-            global_num_tokens, dtype=torch.int64
+            global_num_tokens,
+            dtype=torch.int64,
+            pin_memory=_pin_host_metadata(device),
         ).to(device, non_blocking=True)
         self.global_num_tokens_for_logprob_cpu = global_num_tokens_for_logprob
         self.global_num_tokens_for_logprob_gpu = torch.tensor(
-            global_num_tokens_for_logprob, dtype=torch.int64
+            global_num_tokens_for_logprob,
+            dtype=torch.int64,
+            pin_memory=_pin_host_metadata(device),
         ).to(device, non_blocking=True)
         self.can_run_dp_cuda_graph = batch.can_run_dp_cuda_graph
 
@@ -821,6 +830,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         ret._maybe_init_non_generation_fields(batch)
 
         device = model_runner.device
+        pin_host_metadata = _pin_host_metadata(device)
 
         if envs.SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE.get():
             hashed = _hash_rids_to_tensor(
@@ -842,15 +852,28 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             )
 
         if batch.extend_input_logprob_token_ids is not None:
+            extend_input_logprob_token_ids = batch.extend_input_logprob_token_ids
+            if (
+                pin_host_metadata
+                and extend_input_logprob_token_ids.device.type == "cpu"
+                and not extend_input_logprob_token_ids.is_pinned()
+            ):
+                extend_input_logprob_token_ids = (
+                    extend_input_logprob_token_ids.pin_memory()
+                )
             ret.extend_input_logprob_token_ids_gpu = (
-                batch.extend_input_logprob_token_ids.to(device, non_blocking=True)
+                extend_input_logprob_token_ids.to(device, non_blocking=True)
             )
 
         num_tokens = len(batch.input_ids) if batch.input_ids is not None else 0
         if enable_num_token_non_padded():
-            ret.num_token_non_padded = torch.tensor(num_tokens, dtype=torch.int32).to(
-                device, non_blocking=True
-            )
+            # A pageable hipMemcpyAsync blocks the host until prior work on the
+            # stream drains on HCU. Draft extend can otherwise stall here every step.
+            ret.num_token_non_padded = torch.tensor(
+                num_tokens,
+                dtype=torch.int32,
+                pin_memory=pin_host_metadata,
+            ).to(device, non_blocking=True)
         ret.num_token_non_padded_cpu = num_tokens
 
         ret.init_mlp_sync_metadata(batch, device)
@@ -889,10 +912,14 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 # Main path: H2D from host lists; populate *_cpu mirrors.
                 assert isinstance(extend_prefix_lens, list)
                 ret.extend_seq_lens = torch.tensor(
-                    extend_seq_lens, dtype=torch.int32
+                    extend_seq_lens,
+                    dtype=torch.int32,
+                    pin_memory=pin_host_metadata,
                 ).to(device, non_blocking=True)
                 ret.extend_prefix_lens = torch.tensor(
-                    extend_prefix_lens, dtype=torch.int32
+                    extend_prefix_lens,
+                    dtype=torch.int32,
+                    pin_memory=pin_host_metadata,
                 ).to(device, non_blocking=True)
                 ret.extend_prefix_lens_cpu = extend_prefix_lens
                 ret.extend_seq_lens_cpu = extend_seq_lens

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -14,6 +14,7 @@ Two entry points, same core computation:
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -32,6 +33,11 @@ from sglang.srt.configs.model_config import (
     is_minimax_sparse,
 )
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.hcu_int8_index_k_cache import (
+    index_k_cache_bytes_per_token,
+    index_k_workspace_bytes_per_token,
+    resolve_index_k_cache_mode,
+)
 from sglang.srt.mem_cache.allocation_sizing import get_alloc_len_per_decode
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
     get_compress_state_ring_size,
@@ -49,12 +55,8 @@ from sglang.srt.utils.common import (
     ceil_align,
     ceil_div,
     is_float4_e2m1fn_x2,
-    is_hcu,
-    is_hcu_native_fp8_supported,
     spec_decode_alloc_len_per_request,
 )
-
-_is_hcu = is_hcu()
 
 
 @dataclass
@@ -381,20 +383,11 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
         allocate_all_layers: bool = False,
     ) -> int:
         index_head_dim = get_dsa_index_head_dim(kvc.model_config.hf_config)
-        indexer_size_per_token = (
-            index_head_dim + index_head_dim // DSATokenToKVPool.quant_block_size * 4
+        cache_mode = resolve_index_k_cache_mode(
+            kvc.kv_cache_dtype,
+            kvc.page_size,
+            index_head_dim,
         )
-        element_size = torch._utils._element_size(
-            DSATokenToKVPool.index_k_with_scale_buffer_dtype
-        )
-        if _is_hcu and (
-            kvc.kv_cache_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2)
-            or not is_hcu_native_fp8_supported()
-        ):
-            # HCU falls back to a bf16 index-K cache whenever the KV cache is not
-            # native FP8: no per-block scale tail, and a bf16 element size.
-            indexer_size_per_token = index_head_dim
-            element_size = torch._utils._element_size(torch.bfloat16)
         memory_config = get_memory()
         indexer_ratio = 1
         if memory_config.enable_hisparse:
@@ -440,9 +433,13 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     )
                 num_indexer_layers = max_owned + 1
 
-        return int(
-            indexer_size_per_token * num_indexer_layers * element_size * indexer_ratio
+        persistent_bytes = (
+            index_k_cache_bytes_per_token(cache_mode)
+            * num_indexer_layers
+            * indexer_ratio
         )
+        workspace_bytes = index_k_workspace_bytes_per_token(cache_mode)
+        return math.ceil(persistent_bytes + workspace_bytes)
 
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -232,9 +232,8 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 and int(num_layers) > 0
             ):
                 draft_cell_size = _dflash_draft_cell_size(kvc) or None
-                if (
-                    draft_cell_size is None
-                    and is_deepseek_dsa(kvc.model_config.hf_config)
+                if draft_cell_size is None and is_deepseek_dsa(
+                    kvc.model_config.hf_config
                 ):
                     draft_cell_size = self._compute_cell_size(
                         kvc,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -22,7 +22,7 @@ import torch
 from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.configs.model_config import (
     AttentionArch,
-    dsa_layer_skips_topk,
+    get_dsa_full_indexer_layer_ids,
     get_dsa_index_head_dim,
     get_minimax_sparse_attention_config,
     get_minimax_sparse_disable_value_layer_ids,
@@ -229,15 +229,31 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 and int(draft_num_layers) > 0
                 and int(num_layers) > 0
             ):
+                draft_cell_size = _dflash_draft_cell_size(kvc) or None
+                if (
+                    draft_cell_size is None
+                    and is_deepseek_dsa(kvc.model_config.hf_config)
+                ):
+                    draft_cell_size = self._compute_cell_size(
+                        kvc,
+                        int(draft_num_layers) * get_parallel().attn_dcp_size,
+                        force_dense_dsa_indexer=True,
+                    )
                 self._cell_size = scale_kv_cell_size_per_token_for_dflash(
                     target_cell_size_per_token=self._cell_size,
                     target_num_layers=int(num_layers),
                     draft_num_layers=int(draft_num_layers)
                     * get_parallel().attn_dcp_size,
-                    draft_cell_size_per_token=_dflash_draft_cell_size(kvc) or None,
+                    draft_cell_size_per_token=draft_cell_size,
                 )
 
-    def _compute_cell_size(self, kvc: KVCacheConfigurator, num_layers: int) -> int:
+    def _compute_cell_size(
+        self,
+        kvc: KVCacheConfigurator,
+        num_layers: int,
+        *,
+        force_dense_dsa_indexer: bool = False,
+    ) -> int:
         """Compute per-token KV cache cost in bytes. Subclasses can override."""
         # args to config cell size
         model_config = kvc.model_config
@@ -249,6 +265,8 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
         effective_num_layers = get_glm_dsa_layer_split_effective_num_layers(
             kvc, num_layers
         )
+        if force_dense_dsa_indexer:
+            effective_num_layers = num_layers
 
         kv_size = torch._utils._element_size(kv_cache_dtype)
         tp_size = get_parallel().attn_tp_size
@@ -285,6 +303,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 cell_size += self._compute_dsa_indexer_cell_size(
                     kvc=kvc,
                     num_layers=num_layers,
+                    allocate_all_layers=force_dense_dsa_indexer,
                 )
         elif is_minimax_sparse(model_config.hf_config):
             # Mirrors MiniMaxSparseKVPool: main pool (K+V all layers) + indexer pool
@@ -387,18 +406,20 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             _should_elide_dsa_index_k,
         )
 
-        if allocate_all_layers or not _should_elide_dsa_index_k(
-            is_draft_worker=kvc.is_draft_worker
-        ):
+        if allocate_all_layers:
             num_indexer_layers = num_layers
         else:
-            active_indexer_layers = [
-                layer_id
-                for layer_id in range(
+            if _should_elide_dsa_index_k(is_draft_worker=kvc.is_draft_worker):
+                active_indexer_layers = get_dsa_full_indexer_layer_ids(
+                    kvc.model_config.hf_config,
                     kvc.layer_info.start_layer, kvc.layer_info.end_layer
                 )
-                if not dsa_layer_skips_topk(kvc.model_config.hf_config, layer_id)
-            ]
+            else:
+                active_indexer_layers = list(
+                    range(kvc.layer_info.start_layer, kvc.layer_info.end_layer)
+                )
+
+            num_indexer_layers = len(active_indexer_layers)
             from sglang.srt.layers.cp.utils import (
                 get_glm_dsa_cp_layer_shard_info,
                 get_layer_shard_range,
@@ -418,8 +439,6 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                         ),
                     )
                 num_indexer_layers = max_owned + 1
-            else:
-                num_indexer_layers = len(active_indexer_layers)
 
         return int(
             indexer_size_per_token * num_indexer_layers * element_size * indexer_ratio

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -404,7 +404,8 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             if _should_elide_dsa_index_k(is_draft_worker=kvc.is_draft_worker):
                 active_indexer_layers = get_dsa_full_indexer_layer_ids(
                     kvc.model_config.hf_config,
-                    kvc.layer_info.start_layer, kvc.layer_info.end_layer
+                    kvc.layer_info.start_layer,
+                    kvc.layer_info.end_layer,
                 )
             else:
                 active_indexer_layers = list(

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -567,11 +567,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             # Host-side mirror (maintained incrementally for plain decode) — no
             # d2h sync needed.
             max_kv_len = int(seq_lens_cpu.max().item())
-        elif forward_batch.seq_lens is not None and forward_batch.seq_lens.numel() > 0:
-            # Fallback: a single scalar reduction d2h (cheap, per-step).
-            max_kv_len = int(forward_batch.seq_lens.max().item())
         else:
-            # No length info: be safe and use the correct-for-all sparse graph.
+            # A missing host mirror is expected for speculative relay batches.
+            # Avoid a GPU reduction followed by .item(), which synchronizes the
+            # replay stream with the host every step. The sparse graph is valid
+            # for every sequence length, so it is the safe no-sync fallback.
             return "sparse"
         return "dense" if max_kv_len <= self.dsa_index_topk else "sparse"
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1923,6 +1923,8 @@ class DeepseekV2AttentionMLA(
             quant_config=quant_config,
             prefix=add_prefix("attn_mqa", prefix),
         )
+        # Reused DSA TopK indices were already sorted by the producing layer.
+        self.attn_mqa.reuse_topk_indices = bool(self.skip_topk and not self.is_nextn)
         # use num_local_heads * dcp_world_size because q_nope, q_rope is all gathered from dcp ranks
         if get_parallel().dcp_enabled:
             self.attn_mqa_for_dcp_decode = RadixAttention(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -80,6 +80,8 @@ from sglang.srt.layers.communicator import (
 )
 from sglang.srt.layers.communicator_dsa_cp import (
     DSACPLayerCommunicator,
+    maybe_configure_main_kv_page_plan,
+    maybe_prefetch_full_attention_kv,
     maybe_prefetch_next_full_attention_kv,
 )
 from sglang.srt.layers.cp.cp_decode_attn_tp import get_cp_decode_attn_tp_ctx
@@ -2838,6 +2840,17 @@ class DeepseekV2Model(nn.Module):
             if self.pp_group.is_first_rank:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
+
+        if _is_hcu and self.start_layer < self.end_layer:
+            # A non-zero PP stage may start on a skip-topk layer and reuse the
+            # previous stage's indices, so no local indexer would trigger the
+            # first Main-KV prefetch. Start it explicitly on HCU; the normal
+            # indexer path reuses the same pending broadcast on non-skip layers.
+            maybe_prefetch_full_attention_kv(forward_batch, self.start_layer)
+        else:
+            # Install the compact mapping before the first indexer triggers the
+            # existing current-layer Main-KV prefetch.
+            maybe_configure_main_kv_page_plan(forward_batch)
 
         # llama_4_scaling: for supporting Mistral-Large-3 model
         # Compute llama 4 scaling once per forward pass if enabled

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5853,12 +5853,26 @@ class ServerArgs:
                         f"{self.disaggregation_transfer_backend!r}. mori/nixl "
                         "support will be added later by the community."
                     )
-                if self.enable_dsa_cache_layer_split and self.pp_size > 1:
+                if (
+                    self.enable_dsa_cache_layer_split
+                    and self.pp_size > 1
+                    and not is_hcu()
+                ):
                     raise ValueError(
                         "--enable-dsa-cache-layer-split is not supported with "
-                        "pipeline parallelism (pp_size > 1) yet. It requires "
-                        "prefill context parallelism, and CP + PP has not been "
-                        "validated for this feature."
+                        "pipeline parallelism (pp_size > 1) on non-HCU devices "
+                        "yet. The PP + CP LayerSplit path is currently guarded "
+                        "to HCU because it has not been validated elsewhere."
+                    )
+                if (
+                    self.enable_dsa_cache_layer_split
+                    and is_hcu()
+                    and self.hicache_storage_backend is not None
+                ):
+                    raise NotImplementedError(
+                        "HCU --enable-dsa-cache-layer-split currently supports "
+                        "HiCache L1/L2 only. --hicache-storage-backend (L3) is "
+                        "not layer-shard-aware yet."
                     )
 
             else:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5748,6 +5748,13 @@ class ServerArgs:
         ]:
             # Set attention backend for DeepSeek
             if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
+                from sglang.srt.layers.attention.dsa.hcu_int8_index_k_cache import (
+                    validate_hcu_int8_index_k_cache_server_args,
+                )
+
+                validate_hcu_int8_index_k_cache_server_args(
+                    self, allow_mooncake_pd=False
+                )
                 if envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.is_set():
                     logger.warning(
                         f"Dense attention kv len threshold is manually set to {envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()} for DSA. Caution: This may cause performance regression if the threshold is larger than the index topk of model."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -180,6 +180,7 @@ QUANTIZATION_CHOICES = [
     "mlx_q8",  # 8 bits, group_size=64
     "unquant",
     "humming",
+    "slimquant_w4a8_marlin",
 ]
 
 ATTENTION_BACKEND_CHOICES = [

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5752,9 +5752,7 @@ class ServerArgs:
                     validate_hcu_int8_index_k_cache_server_args,
                 )
 
-                validate_hcu_int8_index_k_cache_server_args(
-                    self, allow_mooncake_pd=False
-                )
+                validate_hcu_int8_index_k_cache_server_args(self)
                 if envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.is_set():
                     logger.warning(
                         f"Dense attention kv len threshold is manually set to {envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()} for DSA. Caution: This may cause performance regression if the threshold is larger than the index topk of model."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2504,6 +2504,20 @@ class ServerArgs:
         "The algorithm to choose ranks for redundant experts in expert parallel.",
         NS("exec.moe"),
     ] = None
+    ep_static_dispatch_policy: A[
+        Literal["nearest", "locality_fair"],
+        Arg(
+            help=(
+                "Choose the replica-selection policy for static expert dispatch. "
+                "`nearest` preserves the legacy nearest-replica behavior. "
+                "`locality_fair` builds a deterministic source-rank-to-replica map "
+                "that preserves same-GPU, then same-node locality while balancing "
+                "static bindings among equally local replicas; it does not rebalance "
+                "live token traffic."
+            )
+        ),
+        NS("exec.moe"),
+    ] = "nearest"
     init_expert_location: A[str, "Initial location of EP experts.", NS("exec.moe")] = (
         "trivial"
     )
@@ -7525,6 +7539,12 @@ class ServerArgs:
         return required
 
     def _handle_eplb_and_dispatch(self):
+        if self.ep_static_dispatch_policy not in ("nearest", "locality_fair"):
+            raise ValueError(
+                "--ep-static-dispatch-policy must be one of "
+                "'nearest' or 'locality_fair'."
+            )
+
         if self.enable_eplb and (self.expert_distribution_recorder_mode is None):
             self._declare(
                 "_handle_eplb_and_dispatch",
@@ -7546,6 +7566,16 @@ class ServerArgs:
                 ep_dispatch_algorithm=(
                     "dynamic" if needs_rank_invariant_dispatch else "static"
                 ),
+            )
+
+        if (
+            self.ep_static_dispatch_policy != "nearest"
+            and self.ep_dispatch_algorithm != "static"
+        ):
+            raise ValueError(
+                "--ep-static-dispatch-policy locality_fair requires "
+                "--ep-dispatch-algorithm static. It configures a startup-time "
+                "source-rank-to-replica map, not dynamic token balancing."
             )
 
         # `dynamic` / `fake` switch to the row-index pick; `static` reads a

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5642,6 +5642,7 @@ class ServerArgs:
 
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import (
+            dsa_layer_skips_topk,
             get_mimo_v2_fused_qkv_expected_tp_size,
             is_deepseek_dsa,
         )
@@ -5770,16 +5771,15 @@ class ServerArgs:
                 # The "dsa" attention fill moved to the override registry
                 # (arg_groups/overrides.py: _deepseek_family_overrides).
 
-                index_topk_freq = getattr(hf_config, "index_topk_freq", 1) or 1
-                index_topk_pattern = getattr(hf_config, "index_topk_pattern", None)
-                if self.enable_two_batch_overlap and (
-                    index_topk_freq > 1
-                    or (index_topk_pattern is not None and "S" in index_topk_pattern)
-                ):
+                has_shared_topk_layers = any(
+                    dsa_layer_skips_topk(hf_config, layer_id)
+                    for layer_id in range(hf_config.num_hidden_layers)
+                )
+                if self.enable_two_batch_overlap and has_shared_topk_layers:
                     raise ValueError(
                         "--enable-two-batch-overlap is not supported with DSA "
-                        "index-topk sharing (index_topk_freq > 1 or an "
-                        "index_topk_pattern containing shared layers): the TBO op "
+                        "index-topk sharing (cli_factor/index_topk_freq/"
+                        "index_topk_pattern): the TBO op "
                         "path does not propagate topk indices across layers, so "
                         "shared layers would run sparse attention without indices."
                     )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -406,7 +406,13 @@ DSV4_PREFILL_BACKEND_CHOICES = [
 
 DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
 
-DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter"]
+DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = [
+    "auto",
+    "deepgemm",
+    "cutedsl",
+    "aiter",
+    "lightop",
+]
 
 MAMBA_RADIX_CACHE_STRATEGY_CHOICES = [
     "auto",
@@ -1884,7 +1890,7 @@ class ServerArgs:
     dsa_paged_mqa_logits_backend: A[
         str,
         Arg(
-            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only).",
+            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm, LightOp on HCU), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only), 'lightop' (HCU only).",
             choices=DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES,
         ),
         NS("exec.kernel"),

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -6,6 +6,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 
 from sglang.kernels.ops.speculative.spec_tree import (
     sgl_build_tree_kernel_efficient_triton,
@@ -14,6 +15,7 @@ from sglang.kernels.ops.speculative.spec_tree import (
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_build_dsv4_verify_bundle,
 )
+from sglang.srt.layers.sampler import top_k_top_p_min_p_sampling_from_probs_torch
 from sglang.srt.mem_cache.allocation import alloc_for_spec_decode
 from sglang.srt.mem_cache.allocation_sizing import (
     get_alloc_reserve_per_decode,
@@ -24,6 +26,7 @@ from sglang.srt.runtime_context import get_parallel, get_spec
 from sglang.srt.utils import (
     is_cpu,
     is_cuda,
+    is_hcu,
     is_hip,
     is_musa,
     is_npu,
@@ -42,6 +45,7 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_info import EagleVerifyInput
 
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_musa = is_musa()
@@ -49,6 +53,15 @@ _is_xpu = is_xpu()
 _is_cpu = is_cpu()
 
 logger = logging.getLogger(__name__)
+
+lightop_top_k_top_p_sampling_from_probs = None
+if _is_hcu:
+    try:
+        from lightop.sampling import (
+            top_k_top_p_sampling_from_probs as lightop_top_k_top_p_sampling_from_probs,
+        )
+    except (ImportError, AttributeError):
+        pass
 
 if _is_cuda or _is_hip or _is_musa:
     from sgl_kernel import (
@@ -59,6 +72,60 @@ elif _is_cpu:
         build_tree_kernel_efficient_cpu as sgl_build_tree_kernel_efficient_cpu,
     )
     from sgl_kernel import verify_tree_greedy_cpu as sgl_verify_tree_greedy_cpu
+
+
+def sample_mtp_target_ids(
+    next_token_logits: torch.Tensor,
+    sampling_info: SamplingBatchInfo,
+    draft_token_num: int,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Sample linear MTP target tokens on HCU before tree verification."""
+    expanded_temperature = torch.repeat_interleave(
+        sampling_info.temperatures, draft_token_num, dim=0
+    )
+    target_probs = F.softmax(next_token_logits / expanded_temperature, dim=-1)
+    expanded_top_ks = torch.repeat_interleave(
+        sampling_info.top_ks, draft_token_num, dim=0
+    )
+    expanded_top_ps = torch.repeat_interleave(
+        sampling_info.top_ps, draft_token_num, dim=0
+    )
+
+    # LightOp implements the common top-k-first/top-p path. Keep the PyTorch
+    # path for min-p and request-specific seeds.
+    if (
+        lightop_top_k_top_p_sampling_from_probs is None
+        or sampling_info.sampling_seed is not None
+        or sampling_info.need_min_p_sampling
+    ):
+        expanded_min_ps = torch.repeat_interleave(
+            sampling_info.min_ps, draft_token_num, dim=0
+        )
+        expanded_sampling_seed = (
+            None
+            if sampling_info.sampling_seed is None
+            else torch.repeat_interleave(
+                sampling_info.sampling_seed, draft_token_num, dim=0
+            )
+        )
+        return top_k_top_p_min_p_sampling_from_probs_torch(
+            target_probs,
+            expanded_top_ks,
+            expanded_top_ps,
+            expanded_min_ps,
+            sampling_info.need_min_p_sampling,
+            expanded_sampling_seed,
+            positions,
+        ).to(torch.long)
+
+    return lightop_top_k_top_p_sampling_from_probs(
+        target_probs.contiguous(),
+        expanded_top_ks,
+        expanded_top_ps,
+        filter_apply_order="top_k_first",
+        deterministic=True,
+    ).to(torch.long)
 
 
 def per_step_draft_out_cache_loc(
@@ -725,10 +792,33 @@ def eagle_sample(
     )
     num_correct_drafts = torch.empty((bs,), dtype=torch.int32, device=device)
 
-    # Sample tokens
+    # Sample tokens. HCU has no target-only tree-sampling kernel yet, so for
+    # linear MTP sample the target rows before reusing the greedy tree walk.
+    # This mirrors the target-only kernel's output for topk=1 while retaining
+    # the existing TP rank-0 broadcast below.
+    sampled_target_ids = None
+    if not sampling_info.is_all_greedy and _is_hcu and verify_input.tree_topk == 1:
+        sampled_target_ids = sample_mtp_target_ids(
+            next_token_logits,
+            sampling_info,
+            verify_input.draft_token_num,
+            verify_input.positions,
+        )
+
     target_predict = None
-    if sampling_info.is_all_greedy or _is_cpu or _is_npu or _is_hip or _is_xpu:
-        target_predict = torch.argmax(next_token_logits, dim=-1)
+    if (
+        sampling_info.is_all_greedy
+        or _is_cpu
+        or _is_npu
+        or (_is_hip and not _is_hcu)
+        or _is_xpu
+        or sampled_target_ids is not None
+    ):
+        target_predict = (
+            torch.argmax(next_token_logits, dim=-1)
+            if sampled_target_ids is None
+            else sampled_target_ids
+        )
         target_predict = target_predict.reshape(bs, verify_input.draft_token_num)
         predict, accept_index, num_correct_drafts = verify_tree_greedy_func(
             predicts=predict,  # mutable

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -122,6 +122,7 @@ from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_cpu,
     is_cuda,
+    is_hcu,
     is_hip,
     is_musa,
     is_npu,
@@ -133,12 +134,18 @@ from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _is_cuda = is_cuda()
+_is_hcu = is_hcu()
 _is_musa = is_musa()
 _is_hip = is_hip()
 _is_xpu = is_xpu()
 
 
 logger = logging.getLogger(__name__)
+
+
+def _supports_cuda_graph_runner() -> bool:
+    """Whether this platform uses the CUDA-style EAGLE graph runners."""
+    return _is_cuda or _is_hcu or _is_musa
 
 
 class EagleDraftWorker(EagleDraftWorkerBase):
@@ -449,9 +456,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             TokenspeedMLABackend,
             FlashInferAttnBackend,
         ]
-        if _is_cuda or _is_musa:
-            # DSA is CUDA-only; import lazily so non-CUDA builds don't pull in
-            # deep_gemm and the rest of the sparse-attention stack at import time.
+        if _supports_cuda_graph_runner():
+            # Import lazily so unsupported platforms do not pull in the sparse
+            # attention stack at module import time.
             from sglang.srt.layers.attention.dsa_backend import (
                 DeepseekSparseAttnBackend,
             )
@@ -474,8 +481,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             tuple(graph_supported_backend_types),
         )
         supports_cuda_draft_extend_graph = (
-            _is_cuda or _is_musa
-        ) and graph_supported_backend
+            _supports_cuda_graph_runner() and graph_supported_backend
+        )
         # Capture extend
         # TODO: support draft extend cuda graph for more attention backends
         if (

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -77,9 +77,7 @@ def _restore_glm_moe_dsa_raw_config_fields(
     if not any(arch in _GLM_MOE_DSA_ARCHS for arch in architectures):
         return
 
-    raw_config, _ = PretrainedConfig.get_config_dict(
-        model, revision=revision, **kwargs
-    )
+    raw_config, _ = PretrainedConfig.get_config_dict(model, revision=revision, **kwargs)
     for key in ("qk_rope_head_dim", "index_topk_freq"):
         if key in raw_config and getattr(config, key, None) != raw_config[key]:
             setattr(config, key, raw_config[key])

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -63,6 +63,30 @@ _LONGCAT_ARCHS = {
     "LongcatFlashNgramForCausalLM",
 }
 
+_GLM_MOE_DSA_ARCHS = {
+    "GlmMoeDsaForCausalLM",
+    "GlmMoeDsaForCausalLMNextN",
+}
+
+
+def _restore_glm_moe_dsa_raw_config_fields(
+    config, model, revision: Optional[str], **kwargs
+):
+    """Restore GLM DSA fields clobbered by incompatible Transformers versions."""
+    architectures = getattr(config, "architectures", None) or []
+    if not any(arch in _GLM_MOE_DSA_ARCHS for arch in architectures):
+        return
+
+    raw_config, _ = PretrainedConfig.get_config_dict(
+        model, revision=revision, **kwargs
+    )
+    for key in ("qk_rope_head_dim", "index_topk_freq"):
+        if key in raw_config and getattr(config, key, None) != raw_config[key]:
+            setattr(config, key, raw_config[key])
+
+    if hasattr(config, "qk_head_dim") and hasattr(config, "qk_nope_head_dim"):
+        config.qk_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+
 
 def _try_load_longcat_config(model, revision: Optional[str], **kwargs):
     config_dict, _ = PretrainedConfig.get_config_dict(
@@ -94,6 +118,10 @@ class HfModelConfigParser(ModelConfigParserBase):
                 revision=revision,
                 **kwargs,
             )
+
+        _restore_glm_moe_dsa_raw_config_fields(
+            config, model, revision=revision, **kwargs
+        )
 
         if (
             config.architectures is not None

--- a/test/registered/hcu/kernels/test_concat_mla_absorb_q_hcu.py
+++ b/test/registered/hcu/kernels/test_concat_mla_absorb_q_hcu.py
@@ -1,0 +1,40 @@
+import unittest
+
+import torch
+from sgl_kernel import concat_mla_absorb_q
+
+from sglang.test.ci.ci_register import register_hcu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_hcu_ci(est_time=30, suite="stage-b-test-1-hcu-small")
+
+
+class TestConcatMlaAbsorbQHcu(CustomTestCase):
+    def test_matches_torch_cat(self):
+        for dim_0, dim_1 in ((1, 1), (1, 5), (4, 16), (9, 7)):
+            with self.subTest(dim_0=dim_0, dim_1=dim_1):
+                q_nope = torch.randn(
+                    dim_0, dim_1, 512, device="cuda", dtype=torch.bfloat16
+                )
+                q_rope = torch.randn(
+                    dim_0, dim_1, 64, device="cuda", dtype=torch.bfloat16
+                )
+                expected = torch.cat((q_nope, q_rope), dim=-1)
+                actual = concat_mla_absorb_q(q_nope, q_rope)
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_supports_aligned_non_contiguous_rows(self):
+        q_nope_storage = torch.randn(3, 11, 520, device="cuda", dtype=torch.bfloat16)
+        q_rope_storage = torch.randn(3, 11, 72, device="cuda", dtype=torch.bfloat16)
+        q_nope = q_nope_storage[..., :512]
+        q_rope = q_rope_storage[..., :64]
+        self.assertFalse(q_nope.is_contiguous())
+        self.assertFalse(q_rope.is_contiguous())
+
+        actual = concat_mla_absorb_q(q_nope, q_rope)
+        expected = torch.cat((q_nope, q_rope), dim=-1)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_topk_padded_region.py
+++ b/test/registered/moe/test_topk_padded_region.py
@@ -169,9 +169,7 @@ class TestDeepEPPaddedTokenMasking(unittest.TestCase):
             patch.object(topk_mod, "_mask_topk_ids_padded_region") as mask_ids,
             patch.object(topk_mod, "_zero_topk_weights_padded_region") as zero_weights,
         ):
-            get_a2a.return_value.is_deepep.return_value = (
-                skip_deepep_padded_tokens
-            )
+            get_a2a.return_value.is_deepep.return_value = skip_deepep_padded_tokens
             get_runner.return_value.is_deep_gemm.return_value = (
                 skip_deepep_padded_tokens
             )
@@ -187,23 +185,19 @@ class TestDeepEPPaddedTokenMasking(unittest.TestCase):
         return mask_ids, zero_weights, topk_ids, num_token_non_padded
 
     def test_hcu_deepep_deepgemm_masks_ids_to_negative_one(self):
-        mask_ids, zero_weights, topk_ids, num_token_non_padded = (
-            self._run_post_process(skip_deepep_padded_tokens=True)
+        mask_ids, zero_weights, topk_ids, num_token_non_padded = self._run_post_process(
+            skip_deepep_padded_tokens=True
         )
 
-        mask_ids.assert_called_once_with(
-            topk_ids, num_token_non_padded, fill_value=-1
-        )
+        mask_ids.assert_called_once_with(topk_ids, num_token_non_padded, fill_value=-1)
         zero_weights.assert_not_called()
 
     def test_other_hip_paths_keep_in_range_ids_and_zero_weights(self):
-        mask_ids, zero_weights, topk_ids, num_token_non_padded = (
-            self._run_post_process(skip_deepep_padded_tokens=False)
+        mask_ids, zero_weights, topk_ids, num_token_non_padded = self._run_post_process(
+            skip_deepep_padded_tokens=False
         )
 
-        mask_ids.assert_called_once_with(
-            topk_ids, num_token_non_padded, fill_value=0
-        )
+        mask_ids.assert_called_once_with(topk_ids, num_token_non_padded, fill_value=0)
         zero_weights.assert_called_once()
 
 

--- a/test/registered/moe/test_topk_padded_region.py
+++ b/test/registered/moe/test_topk_padded_region.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -147,6 +148,63 @@ class TestZeroPaddedRegionIdempotent(CustomTestCase):
                     _zero_topk_weights_padded_region(twice, pad)
 
                     self.assertTrue(torch.equal(once, twice))
+
+
+class TestDeepEPPaddedTokenMasking(unittest.TestCase):
+    def _run_post_process(self, skip_deepep_padded_tokens):
+        topk_ids = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
+        topk_weights = torch.ones((2, 2), dtype=torch.float32)
+        router_logits = torch.ones((2, 8), dtype=torch.float32)
+        num_token_non_padded = torch.tensor(1, dtype=torch.int32)
+        cfg = TopKConfig(top_k=2, num_fused_shared_experts=0)
+
+        with (
+            patch.object(topk_mod, "_is_cuda", False),
+            patch.object(topk_mod, "_is_hip", True),
+            patch.object(topk_mod, "_is_hcu", skip_deepep_padded_tokens),
+            patch.object(topk_mod, "_eplb_remap_enabled", return_value=False),
+            patch.object(topk_mod, "capture_routed_experts_if_allowed"),
+            patch.object(topk_mod, "get_moe_a2a_backend") as get_a2a,
+            patch.object(topk_mod, "get_moe_runner_backend") as get_runner,
+            patch.object(topk_mod, "_mask_topk_ids_padded_region") as mask_ids,
+            patch.object(topk_mod, "_zero_topk_weights_padded_region") as zero_weights,
+        ):
+            get_a2a.return_value.is_deepep.return_value = (
+                skip_deepep_padded_tokens
+            )
+            get_runner.return_value.is_deep_gemm.return_value = (
+                skip_deepep_padded_tokens
+            )
+            _post_process_topk_ids(
+                topk_ids,
+                topk_weights,
+                cfg,
+                router_logits,
+                layer_id=0,
+                num_token_non_padded=num_token_non_padded,
+            )
+
+        return mask_ids, zero_weights, topk_ids, num_token_non_padded
+
+    def test_hcu_deepep_deepgemm_masks_ids_to_negative_one(self):
+        mask_ids, zero_weights, topk_ids, num_token_non_padded = (
+            self._run_post_process(skip_deepep_padded_tokens=True)
+        )
+
+        mask_ids.assert_called_once_with(
+            topk_ids, num_token_non_padded, fill_value=-1
+        )
+        zero_weights.assert_not_called()
+
+    def test_other_hip_paths_keep_in_range_ids_and_zero_weights(self):
+        mask_ids, zero_weights, topk_ids, num_token_non_padded = (
+            self._run_post_process(skip_deepep_padded_tokens=False)
+        )
+
+        mask_ids.assert_called_once_with(
+            topk_ids, num_token_non_padded, fill_value=0
+        )
+        zero_weights.assert_called_once()
 
 
 @unittest.skipUnless(

--- a/test/registered/unit/eplb/test_compute_logical_to_rank_dispatch_physical_map.py
+++ b/test/registered/unit/eplb/test_compute_logical_to_rank_dispatch_physical_map.py
@@ -5,15 +5,19 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 
 import unittest
+from collections import Counter
+from random import Random
 
 import torch
 
 from sglang.srt.eplb.expert_location import (
+    _assign_locality_fair_experts,
     _compute_logical_to_all_physical_map,
     append_trivial_expert_slots,
     compute_logical_to_rank_dispatch_physical_map,
 )
 from sglang.srt.runtime_context import get_context
+from sglang.srt.server_args import ServerArgs
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -22,6 +26,7 @@ def _published(
     nnodes: int,
     moe_a2a_backend: str = "deepep",
     ep_join_mode=None,
+    ep_static_dispatch_policy: str = "nearest",
 ):
     """Scoped publish of the config the placement functions read.
 
@@ -33,6 +38,7 @@ def _published(
         nnodes=nnodes,
         moe_a2a_backend=moe_a2a_backend,
         ep_join_mode=ep_join_mode,
+        ep_static_dispatch_policy=ep_static_dispatch_policy,
     )
 
 
@@ -222,6 +228,143 @@ class TestComputeLogicalToRankDispatchPhysicalMap(CustomTestCase):
             )
 
         self.assertEqual(logical_to_physical[0, :16, 0].tolist(), list(range(64, 80)))
+
+
+class TestLocalityFairStaticDispatch(CustomTestCase):
+    """The policy builds static bindings; it does not inspect live token load."""
+
+    CANDIDATES = [0, 4, 12]
+    EP_SIZE = 8
+    NUM_LOCAL_GPU_EXPERTS = 2
+    NUM_GPUS_PER_NODE = 2
+    NUM_LOCAL_NODE_EXPERTS = 4
+
+    @classmethod
+    def _assign(cls, seed=42):
+        return _assign_locality_fair_experts(
+            candidate_physical_expert_ids=cls.CANDIDATES,
+            ep_size=cls.EP_SIZE,
+            num_local_gpu_physical_experts=cls.NUM_LOCAL_GPU_EXPERTS,
+            num_gpus_per_node=cls.NUM_GPUS_PER_NODE,
+            num_local_node_physical_experts=cls.NUM_LOCAL_NODE_EXPERTS,
+            r=Random(seed),
+        )
+
+    def test_same_gpu_then_same_node_then_remote(self):
+        assignments = self._assign()
+
+        # Physical experts 0, 4, and 12 are on source GPUs 0, 2, and 6.
+        self.assertEqual(assignments[0], 0)
+        self.assertEqual(assignments[2], 4)
+        self.assertEqual(assignments[6], 12)
+
+        # Their node peers retain node locality even though no replica is on
+        # those peers' own GPUs.
+        self.assertEqual(assignments[1], 0)
+        self.assertEqual(assignments[3], 4)
+        self.assertEqual(assignments[7], 12)
+
+        # Node 2 has no replica, so ranks 4 and 5 use the fair remote fallback.
+        self.assertIn(assignments[4], self.CANDIDATES)
+        self.assertIn(assignments[5], self.CANDIDATES)
+        counts = Counter(assignments)
+        self.assertLessEqual(max(counts.values()) - min(counts.values()), 1)
+
+    def test_same_seed_is_deterministic(self):
+        self.assertEqual(self._assign(seed=7), self._assign(seed=7))
+
+    def test_flat_topology_skips_same_node_affinity(self):
+        assignments = _assign_locality_fair_experts(
+            candidate_physical_expert_ids=[0, 4],
+            ep_size=4,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=None,
+            num_local_node_physical_experts=None,
+            r=Random(42),
+        )
+
+        self.assertEqual(assignments[0], 0)
+        self.assertEqual(assignments[2], 4)
+        self.assertEqual({assignments[1], assignments[3]}, {0, 4})
+
+    def test_policy_is_wired_through_static_dispatch_map(self):
+        logical_to_all_physical = torch.tensor([[[0, 4, 12]]], dtype=torch.int64)
+        with _published(
+            ep_size=self.EP_SIZE,
+            nnodes=4,
+            ep_static_dispatch_policy="locality_fair",
+        ):
+            actual = [
+                compute_logical_to_rank_dispatch_physical_map(
+                    logical_to_all_physical_map=logical_to_all_physical,
+                    ep_size=self.EP_SIZE,
+                    num_physical_experts=16,
+                    ep_rank=ep_rank,
+                    seed=42,
+                ).item()
+                for ep_rank in range(self.EP_SIZE)
+            ]
+
+        self.assertEqual(actual, self._assign(seed=42))
+
+    def test_server_args_rejects_non_static_opt_in(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep",
+            ep_dispatch_algorithm="dynamic",
+            ep_static_dispatch_policy="locality_fair",
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires.*static"):
+            server_args._handle_eplb_and_dispatch()
+
+    def test_server_args_accepts_static_opt_in(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep",
+            ep_dispatch_algorithm="static",
+            ep_static_dispatch_policy="locality_fair",
+        )
+
+        server_args._handle_eplb_and_dispatch()
+
+    def test_single_rank_topology(self):
+        assignment = _assign_locality_fair_experts(
+            candidate_physical_expert_ids=[0, 1],
+            ep_size=1,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=1,
+            num_local_node_physical_experts=2,
+            r=Random(42),
+        )
+        self.assertEqual(len(assignment), 1)
+        self.assertIn(assignment[0], [0, 1])
+
+    def test_invalid_topology_is_rejected(self):
+        valid = dict(
+            candidate_physical_expert_ids=[0],
+            ep_size=4,
+            num_local_gpu_physical_experts=2,
+            num_gpus_per_node=2,
+            num_local_node_physical_experts=4,
+            r=Random(42),
+        )
+        invalid_overrides = [
+            {"candidate_physical_expert_ids": []},
+            {"ep_size": 0},
+            {"num_local_gpu_physical_experts": 0},
+            {
+                "num_gpus_per_node": None,
+                "num_local_node_physical_experts": 4,
+            },
+            {"num_gpus_per_node": 3, "num_local_node_physical_experts": 6},
+            {"num_local_node_physical_experts": 5},
+            {"candidate_physical_expert_ids": [8]},
+        ]
+
+        for overrides in invalid_overrides:
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                _assign_locality_fair_experts(**(valid | overrides))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
@@ -251,7 +251,8 @@ class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
 
     def test_fused_qk_quant_store_keeps_lightop_scale_contract(self):
         indexer = object.__new__(Indexer)
-        indexer.hidden_size = 256
+        indexer.hidden_size = 6144
+        indexer.head_dim = 128
         indexer.softmax_scale = 0.125
         pool = SimpleNamespace(
             page_size=64,
@@ -281,7 +282,7 @@ class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
             )
 
         self.assertEqual(result, expected)
-        hadamard_scale = 256**-0.5
+        hadamard_scale = 128**-0.5
         lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.assert_called_once_with(
             sentinel.query,
             sentinel.key,

--- a/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_indexer.py
@@ -1,0 +1,301 @@
+"""Unit coverage for the HCU DSA indexer's LightOp contracts."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, sentinel
+
+import torch
+
+from sglang.srt.layers.attention.dsa import dsa_indexer as indexer_module
+from sglang.srt.layers.attention.dsa import paged_mqa_logits_backend as backend_module
+from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
+    DSAPagedMQALogitsBackend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestHCUDSAPagedMQABackend(CustomTestCase):
+    def test_hcu_resolves_before_generic_hip(self):
+        with (
+            patch.object(backend_module, "is_hcu", return_value=True),
+            patch.object(backend_module, "is_hip", return_value=True),
+        ):
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("auto"),
+                DSAPagedMQALogitsBackend.LIGHTOP,
+            )
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("lightop"),
+                DSAPagedMQALogitsBackend.LIGHTOP,
+            )
+            with self.assertRaisesRegex(ValueError, "only 'lightop'"):
+                DSAPagedMQALogitsBackend.resolve("aiter")
+
+    def test_non_hcu_hip_keeps_aiter(self):
+        with (
+            patch.object(backend_module, "is_hcu", return_value=False),
+            patch.object(backend_module, "is_hip", return_value=True),
+        ):
+            self.assertEqual(
+                DSAPagedMQALogitsBackend.resolve("auto"),
+                DSAPagedMQALogitsBackend.AITER,
+            )
+
+
+class TestHCUDSAIndexerLightOpContracts(CustomTestCase):
+    def test_qk_prepare_uses_lightop_fused_layernorm_rope(self):
+        indexer = object.__new__(Indexer)
+        indexer.wq_b = MagicMock(return_value=(sentinel.query_projection, None))
+        indexer.wk = MagicMock(return_value=(sentinel.key_projection, None))
+        indexer.head_dim = 128
+        indexer.k_norm = SimpleNamespace(
+            weight=sentinel.norm_weight,
+            bias=sentinel.norm_bias,
+            variance_epsilon=1e-6,
+        )
+        indexer.rotary_emb = SimpleNamespace(cos_sin_cache=sentinel.cos_sin_cache)
+        indexer.dsa_enable_prefill_cp = False
+        query = MagicMock()
+        key = MagicMock(ndim=3)
+        forward_batch = SimpleNamespace(attn_cp_metadata=None)
+        lightop_attention = MagicMock()
+
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(indexer_module, "rearrange", return_value=query),
+            patch.object(
+                indexer_module, "rotate_activation", side_effect=lambda x, **_: x
+            ),
+            patch.object(indexer_module, "is_cp_v2_active", return_value=False),
+            patch.object(
+                indexer_module,
+                "lightop_attention",
+                lightop_attention,
+                create=True,
+            ),
+        ):
+            got_query, got_key, weights_raw = indexer._get_q_k_bf16(
+                sentinel.q_lora,
+                sentinel.x,
+                sentinel.positions,
+                False,
+                forward_batch,
+            )
+
+        self.assertIs(got_query, query)
+        self.assertIs(got_key, key)
+        self.assertIsNone(weights_raw)
+        lightop_attention.fuse_layernorm_rotary_embedding.assert_called_once_with(
+            sentinel.positions,
+            query,
+            key,
+            128,
+            sentinel.cos_sin_cache,
+            False,
+            None,
+            None,
+            sentinel.norm_weight,
+            sentinel.norm_bias,
+            None,
+            None,
+            1e-6,
+        )
+
+    def test_paged_and_ragged_mqa_abis(self):
+        lightop_attention = MagicMock()
+        lightop_attention.paged_mqa_logits.return_value = sentinel.paged_logits
+        lightop_attention.mqa_logits.return_value = sentinel.ragged_logits
+        q = MagicMock()
+        q.unsqueeze.return_value = sentinel.q_next_n
+
+        with patch.object(
+            indexer_module,
+            "lightop_attention",
+            lightop_attention,
+            create=True,
+        ):
+            paged_result = indexer_module._hcu_paged_mqa_logits(
+                q,
+                sentinel.kv_cache,
+                sentinel.weights,
+                sentinel.seqlens,
+                sentinel.block_tables,
+                None,
+                4096,
+            )
+            ragged_result = indexer_module._hcu_mqa_logits(
+                sentinel.q,
+                sentinel.kv,
+                sentinel.weights,
+                sentinel.ks,
+                sentinel.ke,
+                sentinel.kv_scale,
+            )
+
+        self.assertIs(paged_result, sentinel.paged_logits)
+        lightop_attention.paged_mqa_logits.assert_called_once_with(
+            sentinel.q_next_n,
+            sentinel.kv_cache,
+            sentinel.weights,
+            sentinel.seqlens,
+            sentinel.block_tables,
+            None,
+            4096,
+            clean_logits=True,
+        )
+        self.assertIs(ragged_result, sentinel.ragged_logits)
+        lightop_attention.mqa_logits.assert_called_once_with(
+            sentinel.q,
+            sentinel.kv,
+            sentinel.weights,
+            sentinel.ks,
+            sentinel.ke,
+            kv_scale=sentinel.kv_scale,
+            clean_logit=True,
+        )
+
+    def test_paged_cache_layout_selects_bf16_or_fp8(self):
+        indexer = object.__new__(Indexer)
+        indexer.head_dim = 128
+        bf16_cache = torch.empty((2, 64, 1, 128), dtype=torch.bfloat16)
+        bf16_pool = SimpleNamespace(
+            use_fp8_index_k_cache=False,
+            get_index_k_buffer=MagicMock(return_value=bf16_cache),
+        )
+        fp8_raw = torch.empty((2, 64 * 132), dtype=torch.uint8)
+        fp8_pool = SimpleNamespace(
+            use_fp8_index_k_cache=True,
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=fp8_raw),
+        )
+
+        with patch.object(indexer_module, "_is_hcu", True):
+            got_bf16, is_bf16 = indexer._get_hcu_paged_index_k_cache(
+                bf16_pool, layer_id=3
+            )
+            got_fp8, is_fp8_bf16 = indexer._get_hcu_paged_index_k_cache(
+                fp8_pool, layer_id=3
+            )
+
+        self.assertIs(got_bf16, bf16_cache)
+        self.assertTrue(is_bf16)
+        self.assertEqual(got_fp8.shape, (2, 64, 1, 132))
+        self.assertFalse(is_fp8_bf16)
+        bf16_pool.get_index_k_buffer.assert_called_once_with(layer_id=3)
+        fp8_pool.get_index_k_with_scale_buffer.assert_called_once_with(layer_id=3)
+
+    def test_hcu_cache_store_uses_native_layout(self):
+        indexer = object.__new__(Indexer)
+        forward_batch = SimpleNamespace(out_cache_loc=MagicMock())
+        key = sentinel.key
+        bf16_pool = SimpleNamespace(
+            use_fp8_index_k_cache=False,
+            set_index_k_buffer=MagicMock(),
+        )
+        fp8_pool = SimpleNamespace(
+            use_fp8_index_k_cache=True,
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=sentinel.fp8_cache),
+        )
+        lightop_kvcache = MagicMock()
+
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+            patch.object(
+                indexer_module, "get_token_to_kv_pool", return_value=bf16_pool
+            ),
+        ):
+            indexer._store_index_k_cache(forward_batch, layer_id=4, key=key)
+
+        bf16_pool.set_index_k_buffer.assert_called_once_with(
+            layer_id=4,
+            loc=forward_batch.out_cache_loc,
+            index_k=key,
+        )
+        lightop_kvcache.fuse_act_quant_and_store_index_k_cache.assert_not_called()
+
+        contiguous_loc = sentinel.contiguous_loc
+        forward_batch.out_cache_loc.contiguous.return_value = contiguous_loc
+        with (
+            patch.object(indexer_module, "_is_hcu", True),
+            patch.object(indexer_module, "_is_fp8_fnuz", False),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+            patch.object(indexer_module, "get_token_to_kv_pool", return_value=fp8_pool),
+        ):
+            indexer._store_index_k_cache(forward_batch, layer_id=4, key=key)
+
+        lightop_kvcache.fuse_act_quant_and_store_index_k_cache.assert_called_once_with(
+            key,
+            sentinel.fp8_cache,
+            contiguous_loc,
+            64,
+            1e-5,
+            False,
+            True,
+        )
+
+    def test_fused_qk_quant_store_keeps_lightop_scale_contract(self):
+        indexer = object.__new__(Indexer)
+        indexer.hidden_size = 256
+        indexer.softmax_scale = 0.125
+        pool = SimpleNamespace(
+            page_size=64,
+            get_index_k_with_scale_buffer=MagicMock(return_value=sentinel.fp8_cache),
+        )
+        out_cache_loc = MagicMock()
+        out_cache_loc.contiguous.return_value = sentinel.contiguous_loc
+        expected = (sentinel.q_fp8, sentinel.q_scale, None)
+        lightop_kvcache = MagicMock()
+        lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.return_value = expected
+
+        with (
+            patch.object(indexer_module, "_is_fp8_fnuz", False),
+            patch.object(
+                indexer_module,
+                "lightop_kvcache",
+                lightop_kvcache,
+                create=True,
+            ),
+        ):
+            result = indexer._hcu_fused_qk_quant_and_store(
+                sentinel.query,
+                sentinel.key,
+                pool,
+                layer_id=5,
+                out_cache_loc=out_cache_loc,
+            )
+
+        self.assertEqual(result, expected)
+        hadamard_scale = 256**-0.5
+        lightop_kvcache.fuse_qk_quant_and_store_index_k_cache.assert_called_once_with(
+            sentinel.query,
+            sentinel.key,
+            sentinel.fp8_cache,
+            sentinel.contiguous_loc,
+            64,
+            None,
+            hadamard_scale * 0.125,
+            hadamard_scale,
+            1e-5,
+            False,
+            True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/dsa/test_hcu_sparse_mqa.py
+++ b/test/registered/unit/layers/attention/dsa/test_hcu_sparse_mqa.py
@@ -1,0 +1,110 @@
+"""CPU routing tests for paired LightOp sparse Page-MQA/mask TopK."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.dsa.hcu_sparse_mqa import (
+    select_lightop_sparse_mqa_route,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+@unittest.skipUnless(
+    hasattr(torch, "float8_e4m3fn"), "PyTorch build does not expose FP8 E4M3FN"
+)
+class TestLightOpSparseMQARoute(CustomTestCase):
+    def _inputs(self, rows: int):
+        q = torch.empty((rows, 1, 32, 128), dtype=torch.float8_e4m3fn)
+        fused_kv_cache = torch.empty((2, 64, 1, 132), dtype=torch.uint8)
+        weights = torch.empty((rows, 32), dtype=torch.float32)
+        context_lens = torch.ones(rows, dtype=torch.int32)
+        block_table = torch.zeros((rows, 2), dtype=torch.int32)
+        return q, fused_kv_cache, weights, context_lens, block_table
+
+    def _select(self, rows: int, **overrides):
+        q, fused_kv_cache, weights, context_lens, block_table = self._inputs(rows)
+        kwargs = dict(
+            enabled=True,
+            api_available=True,
+            is_hcu=True,
+            arch_name="gfx938",
+            num_cus=64,
+            page_size=64,
+            topk=2048,
+            fuse_topk=True,
+            force_unfused_topk=False,
+            topk_transform_method_name="PAGED",
+            q=q,
+            fused_kv_cache=fused_kv_cache,
+            weights=weights,
+            context_lens=context_lens,
+            block_table=block_table,
+            max_context_len=128,
+            batch_size=rows,
+            is_target_verify=False,
+            is_draft_extend_v2=False,
+            mtp_group_size=None,
+            grouping_lens_cpu=[1] * rows,
+        )
+        kwargs.update(overrides)
+        return select_lightop_sparse_mqa_route(**kwargs)
+
+    def test_decode_selects_independent_row_sparse_mqa(self):
+        route = self._select(8)
+
+        self.assertIsNotNone(route)
+        self.assertEqual(route.group_size, 1)
+
+    def test_target_verify_selects_each_supported_mtp_group(self):
+        for group_size in (3, 4, 5):
+            for graph_expanded in (False, True):
+                with self.subTest(group_size=group_size, graph_expanded=graph_expanded):
+                    batch_size = 8
+                    route = self._select(
+                        batch_size * group_size,
+                        batch_size=batch_size,
+                        is_target_verify=True,
+                        mtp_group_size=group_size,
+                        grouping_lens_cpu=(
+                            [1] * (batch_size * group_size)
+                            if graph_expanded
+                            else [group_size] * batch_size
+                        ),
+                    )
+
+                    self.assertIsNotNone(route)
+                    self.assertEqual(route.group_size, group_size)
+
+    def test_grouped_route_requires_per_request_row_contract(self):
+        route = self._select(
+            40,
+            batch_size=8,
+            is_draft_extend_v2=True,
+            mtp_group_size=5,
+            grouping_lens_cpu=[1] * 39 + [2],
+        )
+
+        self.assertIsNone(route)
+
+    def test_b40_without_mtp_contract_does_not_guess_grouping(self):
+        self.assertIsNone(self._select(40, batch_size=8))
+
+    def test_consumer_or_hardware_miss_falls_back_before_sparse_mqa(self):
+        for overrides in (
+            {"api_available": False},
+            {"fuse_topk": False},
+            {"force_unfused_topk": True},
+            {"topk_transform_method_name": "RAGGED"},
+            {"topk": 1024},
+            {"arch_name": "gfx936", "num_cus": 80},
+        ):
+            with self.subTest(overrides=overrides):
+                self.assertIsNone(self._select(8, **overrides))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
+++ b/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
@@ -1,0 +1,92 @@
+"""Unit tests for platform-specific DSA FlashMLA routing and metadata."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa.flashmla_backend import (
+    DSAFlashMLAMetadata,
+    can_fuse_flashmla_metadata,
+    get_flashmla_op,
+    wrap_flashmla_metadata_result,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSAFlashMLABackend(CustomTestCase):
+    def test_loader_routes_hcu_to_external_interface(self):
+        expected_op = MagicMock()
+        module = SimpleNamespace(flash_mla_sparse_fwd=expected_op)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa.flashmla_backend.import_module",
+            return_value=module,
+        ) as import_mock:
+            actual_op = get_flashmla_op("flash_mla_sparse_fwd", is_hcu=True)
+
+        self.assertIs(actual_op, expected_op)
+        import_mock.assert_called_once_with("flash_mla.flash_mla_interface")
+
+    def test_loader_keeps_non_hcu_on_sgl_kernel(self):
+        expected_op = MagicMock()
+        module = SimpleNamespace(get_mla_metadata=expected_op)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa.flashmla_backend.import_module",
+            return_value=module,
+        ) as import_mock:
+            actual_op = get_flashmla_op("get_mla_metadata", is_hcu=False)
+
+        self.assertIs(actual_op, expected_op)
+        import_mock.assert_called_once_with("sgl_kernel.flash_mla")
+
+    def test_hcu_metadata_object_is_wrapped_and_copied(self):
+        backend_num_splits = torch.tensor([3], dtype=torch.int32)
+        backend_metadata = SimpleNamespace(num_splits=backend_num_splits)
+        source = wrap_flashmla_metadata_result((backend_metadata, None), is_hcu=True)
+
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=SimpleNamespace(num_splits=None),
+            num_splits=None,
+        )
+        destination.copy_(source)
+
+        self.assertIs(destination.flashmla_metadata, backend_metadata)
+        self.assertIs(destination.num_splits, backend_num_splits)
+        self.assertFalse(can_fuse_flashmla_metadata(source, destination))
+
+    def test_metadata_slice_accepts_uninitialized_hcu_scheduler(self):
+        backend_metadata = SimpleNamespace(num_splits=None)
+        metadata = wrap_flashmla_metadata_result((backend_metadata, None), is_hcu=True)
+
+        sliced = metadata.slice(slice(0, 2))
+
+        self.assertIs(sliced.flashmla_metadata, backend_metadata)
+        self.assertIsNone(sliced.num_splits)
+
+    def test_tensor_metadata_remains_fused_copy_eligible(self):
+        source = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.tensor([1, 2], dtype=torch.int32),
+            num_splits=torch.tensor([3, 4], dtype=torch.int32),
+        )
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.zeros(2, dtype=torch.int32),
+            num_splits=torch.zeros(2, dtype=torch.int32),
+        )
+
+        destination.copy_(source)
+
+        self.assertTrue(
+            torch.equal(destination.flashmla_metadata, source.flashmla_metadata)
+        )
+        self.assertTrue(torch.equal(destination.num_splits, source.num_splits))
+        self.assertTrue(can_fuse_flashmla_metadata(source, destination))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
+++ b/test/registered/unit/layers/attention/test_dsa_flashmla_backend.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.attention.dsa.flashmla_backend import (
     DSAFlashMLAMetadata,
     can_fuse_flashmla_metadata,
     get_flashmla_op,
+    refresh_flashmla_metadata,
     wrap_flashmla_metadata_result,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -86,6 +87,76 @@ class TestDSAFlashMLABackend(CustomTestCase):
         )
         self.assertTrue(torch.equal(destination.num_splits, source.num_splits))
         self.assertTrue(can_fuse_flashmla_metadata(source, destination))
+
+    def test_hcu_refresh_returns_fresh_scheduler_object(self):
+        captured_scheduler = SimpleNamespace(
+            have_initialized=True,
+            config="batch-6",
+            tile_scheduler_metadata=object(),
+            num_splits=object(),
+        )
+        fresh_scheduler = SimpleNamespace(
+            have_initialized=False,
+            config=None,
+            tile_scheduler_metadata=None,
+            num_splits=None,
+        )
+        destination = DSAFlashMLAMetadata(captured_scheduler, None)
+        source = DSAFlashMLAMetadata(fresh_scheduler, None)
+
+        refreshed = refresh_flashmla_metadata(
+            destination,
+            source,
+            slice(0, 6),
+            is_hcu=True,
+        )
+
+        self.assertIs(refreshed, source)
+        self.assertIs(refreshed.flashmla_metadata, fresh_scheduler)
+        self.assertIs(destination.flashmla_metadata, captured_scheduler)
+
+    def test_tensor_refresh_keeps_destination_storage(self):
+        destination = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.zeros(2, dtype=torch.int32),
+            num_splits=torch.zeros(3, dtype=torch.int32),
+        )
+        source = DSAFlashMLAMetadata(
+            flashmla_metadata=torch.tensor([1, 2], dtype=torch.int32),
+            num_splits=torch.tensor([3, 4], dtype=torch.int32),
+        )
+        destination_metadata = destination.flashmla_metadata
+        destination_splits = destination.num_splits
+
+        refreshed = refresh_flashmla_metadata(
+            destination,
+            source,
+            slice(0, 2),
+            is_hcu=False,
+        )
+
+        self.assertIs(refreshed.flashmla_metadata, destination_metadata)
+        self.assertEqual(refreshed.num_splits.data_ptr(), destination_splits.data_ptr())
+        self.assertTrue(
+            torch.equal(refreshed.flashmla_metadata, source.flashmla_metadata)
+        )
+        self.assertTrue(torch.equal(refreshed.num_splits, source.num_splits))
+
+    def test_hcu_refresh_does_not_share_schedulers_across_steps(self):
+        destination = DSAFlashMLAMetadata(SimpleNamespace(), None)
+        first = DSAFlashMLAMetadata(SimpleNamespace(have_initialized=False), None)
+        second = DSAFlashMLAMetadata(SimpleNamespace(have_initialized=False), None)
+
+        first_refreshed = refresh_flashmla_metadata(
+            destination, first, slice(0, 6), is_hcu=True
+        )
+        second_refreshed = refresh_flashmla_metadata(
+            destination, second, slice(0, 6), is_hcu=True
+        )
+
+        self.assertIsNot(
+            first_refreshed.flashmla_metadata,
+            second_refreshed.flashmla_metadata,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
+++ b/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
@@ -5,11 +5,26 @@ from types import SimpleNamespace
 
 from sglang.srt.layers.attention.dsa.forward_batch_utils import (
     effective_forward_mode,
+    get_flashmla_kv_valid_rows,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _Mode:
+    def __init__(self, kind):
+        self.kind = kind
+
+    def is_decode_or_idle(self):
+        return self.kind in ("decode", "idle")
+
+    def is_target_verify(self):
+        return self.kind == "target_verify"
+
+    def is_draft_extend_v2(self):
+        return self.kind == "draft_extend_v2"
 
 
 class TestDSAForwardBatchUtils(CustomTestCase):
@@ -37,6 +52,67 @@ class TestDSAForwardBatchUtils(CustomTestCase):
         forward_batch = SimpleNamespace(forward_mode=current_mode)
 
         self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+    def test_target_verify_uses_planned_five_of_six_rows(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=1,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_draft_extend_v2_uses_original_layout_without_preplan(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("draft_extend_v2"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=None,
+            forward_metadata_planned_num_tokens=None,
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_decode_uses_request_rows_instead_of_transient_token_rows(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("decode"),
+            _original_batch_size=5,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=5,
+            forward_metadata_planned_num_tokens=25,
+            spec_info=SimpleNamespace(num_tokens_per_req=1),
+        )
+
+        self.assertEqual(get_flashmla_kv_valid_rows(forward_batch, 6), 5)
+
+    def test_inconsistent_plan_does_not_trim(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=2,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertIsNone(get_flashmla_kv_valid_rows(forward_batch, 6))
+
+    def test_unpadded_rows_do_not_trigger_repad(self):
+        forward_batch = SimpleNamespace(
+            forward_mode=_Mode("extend"),
+            _original_forward_mode=_Mode("target_verify"),
+            _original_batch_size=1,
+            _original_num_tokens=5,
+            forward_metadata_planned_bs=1,
+            forward_metadata_planned_num_tokens=5,
+        )
+
+        self.assertIsNone(get_flashmla_kv_valid_rows(forward_batch, 5))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
+++ b/test/registered/unit/layers/attention/test_dsa_forward_batch_utils.py
@@ -1,0 +1,43 @@
+"""Unit tests for DSA forward-batch layout helpers."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.layers.attention.dsa.forward_batch_utils import (
+    effective_forward_mode,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDSAForwardBatchUtils(CustomTestCase):
+    def test_effective_mode_uses_original_mode_during_mlp_sync(self):
+        current_mode = object()
+        original_mode = object()
+        forward_batch = SimpleNamespace(
+            forward_mode=current_mode,
+            _original_forward_mode=original_mode,
+        )
+
+        self.assertIs(effective_forward_mode(forward_batch), original_mode)
+
+    def test_effective_mode_handles_explicit_none(self):
+        current_mode = object()
+        forward_batch = SimpleNamespace(
+            forward_mode=current_mode,
+            _original_forward_mode=None,
+        )
+
+        self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+    def test_effective_mode_handles_missing_original_field(self):
+        current_mode = object()
+        forward_batch = SimpleNamespace(forward_mode=current_mode)
+
+        self.assertIs(effective_forward_mode(forward_batch), current_mode)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_w8a8_int8_hcu_layout.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_w8a8_int8_hcu_layout.py
@@ -1,0 +1,94 @@
+"""HCU W8A8 method-3 weight-layout regression tests."""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+from compressed_tensors.quantization import QuantizationStrategy
+from torch.nn import Parameter
+
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    compressed_tensors_w8a8_int8 as w8a8_int8,
+)
+from sglang.test.ci.ci_register import register_hcu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_hcu_ci(est_time=5, suite="stage-b-test-1-hcu-small")
+
+
+class TestCompressedTensorsW8A8Int8HCULayout(CustomTestCase):
+    @staticmethod
+    def _make_scheme():
+        with mock.patch.dict(os.environ, {"W8A8_SUPPORT_METHODS": "3"}):
+            return w8a8_int8.CompressedTensorsW8A8Int8(
+                strategy=QuantizationStrategy.CHANNEL,
+                is_static_input_scheme=False,
+                input_symmetric=False,
+            )
+
+    @staticmethod
+    def _make_layer(weight: torch.Tensor):
+        layer = torch.nn.Module()
+        layer.weight = Parameter(weight.clone(), requires_grad=False)
+        layer.weight_scale = Parameter(
+            torch.ones((weight.shape[0], 1), dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.logical_widths = [weight.shape[0]]
+        return layer
+
+    def test_only_gfx928_selects_kme(self):
+        cuda_device = SimpleNamespace(type="cuda")
+        cases = {
+            "gfx928:sramecc+:xnack-": True,
+            "gfx936:sramecc+:xnack-": False,
+            "gfx938:sramecc+:xnack-": False,
+            "sm_90": False,
+        }
+
+        for arch, expected in cases.items():
+            with self.subTest(arch=arch), mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(gcnArchName=arch),
+            ):
+                self.assertEqual(w8a8_int8._use_kme_hipblaslt(cuda_device), expected)
+
+        with mock.patch.object(torch.cuda, "get_device_properties") as get_props:
+            self.assertFalse(w8a8_int8._use_kme_hipblaslt(SimpleNamespace(type="cpu")))
+            get_props.assert_not_called()
+
+    def test_method3_layout_and_azp_reduction_match(self):
+        weight = torch.tensor(
+            [[1, 2, 3, 4], [5, -1, 0, 2], [-3, 7, 1, -2]],
+            dtype=torch.int8,
+        )
+        expected_azp = weight.sum(dim=1, keepdim=False, dtype=torch.int32).unsqueeze(0)
+
+        for use_kme in (True, False):
+            with self.subTest(use_kme=use_kme):
+                layer = self._make_layer(weight)
+                scheme = self._make_scheme()
+
+                with mock.patch.object(
+                    w8a8_int8, "_use_kme_hipblaslt", return_value=use_kme
+                ), mock.patch.object(w8a8_int8.W8A8_TRITONJSON, "gen_model_json"):
+                    scheme.process_weights_after_loading(layer)
+
+                if use_kme:
+                    self.assertEqual(layer.weight.shape, (4, 3))
+                    self.assertEqual(layer.weight.stride(), (1, 4))
+                    self.assertTrue(torch.equal(layer.weight, weight.t()))
+                else:
+                    self.assertEqual(layer.weight.shape, (3, 4))
+                    self.assertTrue(layer.weight.is_contiguous())
+                    self.assertTrue(torch.equal(layer.weight, weight))
+
+                self.assertEqual(layer.azp_adj.shape, (1, 3))
+                self.assertTrue(torch.equal(layer.azp_adj, expected_azp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_eagle_worker_v2_graph_support.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_graph_support.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch
+
+import sglang.srt.speculative.eagle_worker_v2 as eagle_worker_v2
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestEagleWorkerV2GraphSupport(CustomTestCase):
+    def test_hcu_uses_cuda_style_graph_runner(self):
+        with (
+            patch.object(eagle_worker_v2, "_is_cuda", False),
+            patch.object(eagle_worker_v2, "_is_hcu", True),
+            patch.object(eagle_worker_v2, "_is_musa", False),
+        ):
+            self.assertTrue(eagle_worker_v2._supports_cuda_graph_runner())
+
+    def test_plain_hip_does_not_use_cuda_style_graph_runner(self):
+        with (
+            patch.object(eagle_worker_v2, "_is_cuda", False),
+            patch.object(eagle_worker_v2, "_is_hcu", False),
+            patch.object(eagle_worker_v2, "_is_musa", False),
+        ):
+            self.assertFalse(eagle_worker_v2._supports_cuda_graph_runner())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -15,6 +15,7 @@ from transformers.image_processing_utils import BaseImageProcessor
 
 import sglang.srt.utils.hf_transformers.processor as processor_utils
 from sglang.srt.utils import hf_transformers_patches
+from sglang.srt.utils.hf_transformers import config as config_utils
 from sglang.srt.utils.hf_transformers.common import (
     _is_deepseek_ocr2_model,
     _is_deepseek_ocr_model,
@@ -30,8 +31,54 @@ from sglang.srt.utils.hf_transformers.common import (
 from sglang.srt.utils.hf_transformers.tokenizer import _fix_special_tokens_pattern
 from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_compat
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+# ---------------------------------------------------------------------------
+# GLM MoE DSA config compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestGlmMoeDsaConfigCompatibility(CustomTestCase):
+    @patch.object(config_utils.PretrainedConfig, "get_config_dict")
+    def test_restores_fields_clobbered_by_transformers(self, get_config_dict):
+        get_config_dict.return_value = (
+            {
+                "qk_rope_head_dim": 64,
+                "index_topk_freq": 6,
+            },
+            {},
+        )
+        config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            qk_nope_head_dim=192,
+            qk_rope_head_dim=192,
+            qk_head_dim=384,
+            index_topk_freq=1,
+        )
+
+        config_utils._restore_glm_moe_dsa_raw_config_fields(
+            config, "test-model", revision="test-revision"
+        )
+
+        self.assertEqual(config.qk_rope_head_dim, 64)
+        self.assertEqual(config.qk_head_dim, 256)
+        self.assertEqual(config.index_topk_freq, 6)
+        get_config_dict.assert_called_once_with(
+            "test-model", revision="test-revision"
+        )
+
+    @patch.object(config_utils.PretrainedConfig, "get_config_dict")
+    def test_ignores_other_architectures(self, get_config_dict):
+        config = SimpleNamespace(architectures=["DeepseekV3ForCausalLM"])
+
+        config_utils._restore_glm_moe_dsa_raw_config_fields(
+            config, "test-model", revision=None
+        )
+
+        get_config_dict.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -66,9 +66,7 @@ class TestGlmMoeDsaConfigCompatibility(CustomTestCase):
         self.assertEqual(config.qk_rope_head_dim, 64)
         self.assertEqual(config.qk_head_dim, 256)
         self.assertEqual(config.index_topk_freq, 6)
-        get_config_dict.assert_called_once_with(
-            "test-model", revision="test-revision"
-        )
+        get_config_dict.assert_called_once_with("test-model", revision="test-revision")
 
     @patch.object(config_utils.PretrainedConfig, "get_config_dict")
     def test_ignores_other_architectures(self, get_config_dict):


### PR DESCRIPTION
## Summary

- Add `concat_mla_absorb_q_hcu.cu` to the `setup_hip.py` source list.
- Fix `sgl_kernel` import failure caused by an unresolved `concat_mla_absorb_q` symbol when the HCU implementation is omitted from `common_ops`.

## Validation

- `python3 -m py_compile python/sglang/kernels/aot/setup_hip.py`
- `git diff --check`
- HCU runtime rebuild/import validation to be covered by CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->