### PR TITLE
[CI] Update HCU model asset paths on main

### DIFF
--- a/README_HCU.md
+++ b/README_HCU.md
@@ -63,7 +63,7 @@ pip install -e "python[all_hip]" --no-deps --no-build-isolation --no-index
 
 使用方式：进入 GitHub Actions，选择 `Manual HCU Unattended Model Test`，点击 `Run workflow`。GitHub 页面上的分支下拉框决定默认测试 ref；也可以通过 `test_branch` 输入分支、tag、ref 或 SHA 覆盖。默认 suite 为 `nightly-hcu-accuracy`，可通过 `suite` 改成 `nightly-hcu`、`nightly-hcu-vlm`、`nightly-hcu-4-gpu` 等已注册 HCU suite。若只跑单个文件，填写 `include_file`，例如 `test/registered/hcu/accuracy/bw1100/test_gsm8k_eval_hcu.py`。
 
-常用输入包括：`timeout_per_file`（默认 4200 秒，沿用现有 HCU accuracy 长测配置）、`auto_partition_id` 和 `auto_partition_size`（必须成对填写）、`continue_on_error`（默认 true，表示 `run_suite.py` 内部尽量继续跑后续文件，但 workflow 仍会在最终失败时显示失败）、`runner_label`、`container_name` 和 `image`。`model_name` 会传给 `SGLANG_HCU_GSM8K_MODEL`、`SGLANG_HCU_MMLU_MODEL` 和 `SGLANG_TEST_DEFAULT_MODEL_NAME`，可用于测试其它本地模型路径，例如 `/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct`。`run_suite.py` 尚无 `--model-name` 过滤参数，因此这里通过测试文件已支持的环境变量选择模型。
+常用输入包括：`timeout_per_file`（默认 4200 秒，沿用现有 HCU accuracy 长测配置）、`auto_partition_id` 和 `auto_partition_size`（必须成对填写）、`continue_on_error`（默认 true，表示 `run_suite.py` 内部尽量继续跑后续文件，但 workflow 仍会在最终失败时显示失败）、`runner_label`、`container_name` 和 `image`。`model_name` 会传给 `SGLANG_HCU_GSM8K_MODEL`、`SGLANG_HCU_MMLU_MODEL` 和 `SGLANG_TEST_DEFAULT_MODEL_NAME`，可用于测试其它本地模型路径，例如 `/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B`。`run_suite.py` 尚无 `--model-name` 过滤参数，因此这里通过测试文件已支持的环境变量选择模型。
 
 快速验证其它模型时，可填写 `model_name`，并将 `eval_num_examples` 设为较小值（例如 `10`）；也可用 `include_file` 只跑 `test/registered/hcu/accuracy/bw1100/test_gsm8k_eval_hcu.py` 或 `test/registered/hcu/accuracy/bw1100/test_mmlu_eval_hcu.py`。如模型精度阈值不同，可通过 `gsm8k_threshold`、`mmlu_threshold` 临时覆盖。`mmlu_num_threads` 默认 128，这是在 HCU runner 上手动验证过的稳定配置。
 

--- a/python/sglang/test/hcu_cookbook_utils.py
+++ b/python/sglang/test/hcu_cookbook_utils.py
@@ -619,7 +619,9 @@ QWEN3_32B_4GPU = HcuCookbookModelConfig(
 QWEN3_30B_A3B_W8A8_4GPU = HcuCookbookModelConfig(
     name="Qwen3-30B-A3B-w8a8",
     env_name="SGLANG_HCU_QWEN3_30B_A3B_W8A8_MODEL",
-    default_path="/public/opendas/DL_DATA/llm-models/vllm-w8a8-models/Qwen3-30B-A3B-w8a8",
+    default_path=(
+        "/public/opendas/DL_DATA/llm-models/vllm-w8a8-models/Qwen3-30B-A3B.w8a8"
+    ),
     tp_size=4,
     timeout=3600,
     dtype_or_quant="w8a8",
@@ -657,7 +659,7 @@ QWEN35_397B_A17B_CHANNEL_FP8_4GPU = HcuCookbookModelConfig(
     name="Qwen3.5-397B-A17B-Channel-FP8",
     env_name="SGLANG_HCU_QWEN35_397B_A17B_CHANNEL_FP8_MODEL",
     default_path=(
-        "/public/opendas/DL_DATA/llm-models/qwen3.5/Qwen3.5-397B-A17B-Channel-FP8"
+        "/public/opendas/DL_DATA/llm-models/Qwen3.5-397B-A17B-Channel-FP8-w8a8"
     ),
     tp_size=4,
     timeout=7200,
@@ -669,7 +671,10 @@ QWEN35_397B_A17B_CHANNEL_FP8_4GPU = HcuCookbookModelConfig(
 GLM51_CHANNEL_FP8_8GPU = HcuCookbookModelConfig(
     name="GLM-5.1-Channel-FP8",
     env_name="SGLANG_HCU_GLM51_CHANNEL_FP8_MODEL",
-    default_path="/public4/share/GLM-5.1-Channel-fp8",
+    default_path=(
+        "/public/opendas/DL_DATA/llm-models/glm5.1/models/hygon/"
+        "GLM-5.1-Channel-FP8-w8a8"
+    ),
     tp_size=8,
     timeout=7200,
     dtype_or_quant="w8a8_fp8",
@@ -713,7 +718,7 @@ DEEPSEEK_V32_CHANNEL_INT8_8GPU = HcuCookbookModelConfig(
 MINIMAX_M25_FP8_8GPU = HcuCookbookModelConfig(
     name="MiniMax-M2.5",
     env_name="SGLANG_HCU_MINIMAX_M25_FP8_MODEL",
-    default_path="/public/opendas/DL_DATA/llm-models/MiniMax-M2.5",
+    default_path="/public/opendas/DL_DATA/llm-models/MiniMax-M2.5-Channel-FP8-w8a8",
     tp_size=8,
     timeout=7200,
     dtype_or_quant="fp8",
@@ -735,7 +740,7 @@ MINIMAX_M25_W8A8_8GPU = HcuCookbookModelConfig(
 KIMI_K26_8GPU = HcuCookbookModelConfig(
     name="Kimi-K2.6",
     env_name="SGLANG_HCU_KIMI_K26_MODEL",
-    default_path="/public4/opendas/DL_DATA/llm-models/Kimi-K2.6",
+    default_path="/public/opendas/DL_DATA/llm-models/Kimi-K2.6",
     tp_size=8,
     timeout=7200,
     dtype_or_quant="w4a16",

--- a/scripts/ci/hcu/hcu_ci_exec.sh
+++ b/scripts/ci/hcu/hcu_ci_exec.sh
@@ -36,7 +36,7 @@ declare -A ENV_MAP=(
 # by sglang.test.test_utils and keep broad registered tests from falling back
 # to gated or remote Hugging Face model names. A caller can still override any
 # value with -e KEY=VALUE.
-ENV_MAP[SGLANG_TEST_DEFAULT_MODEL_NAME]="${SGLANG_TEST_DEFAULT_MODEL_NAME:-/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct}"
+ENV_MAP[SGLANG_TEST_DEFAULT_MODEL_NAME]="${SGLANG_TEST_DEFAULT_MODEL_NAME:-/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B}"
 ENV_MAP[SGLANG_TEST_DEFAULT_SMALL_MODEL_NAME]="${SGLANG_TEST_DEFAULT_SMALL_MODEL_NAME:-/public/opendas/DL_DATA/llm-models/vllm-optest-models/llama3.2/Llama-3.2-1B-Instruct}"
 ENV_MAP[SGLANG_TEST_DEFAULT_SMALL_MODEL_NAME_BASE]="${SGLANG_TEST_DEFAULT_SMALL_MODEL_NAME_BASE:-/public/opendas/DL_DATA/llm-models/vllm-optest-models/llama3.2/Llama-3.2-1B}"
 ENV_MAP[SGLANG_TEST_DEFAULT_SMALL_MODEL_NAME_SCORE]="${SGLANG_TEST_DEFAULT_SMALL_MODEL_NAME_SCORE:-/public/opendas/DL_DATA/llm-models/qwen3/Qwen3-Reranker-0.6B}"

--- a/test/registered/hcu/accuracy/bw1100/test_gsm8k_eval_hcu.py
+++ b/test/registered/hcu/accuracy/bw1100/test_gsm8k_eval_hcu.py
@@ -33,7 +33,7 @@ from sglang.test.test_utils import (
 register_hcu_ci(est_time=3600, suite="nightly-hcu-accuracy-text", nightly=True)
 
 DEFAULT_HCU_GSM8K_MODEL = (
-    "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct"
+    "/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B"
 )
 DEFAULT_HCU_GSM8K_DATA_PATH = (
     "/public/opendas/DL_DATA/opencompass_data/gsm8k/test.jsonl"

--- a/test/registered/hcu/accuracy/bw1100/test_mmlu_eval_hcu.py
+++ b/test/registered/hcu/accuracy/bw1100/test_mmlu_eval_hcu.py
@@ -37,7 +37,7 @@ from sglang.test.test_utils import (
 register_hcu_ci(est_time=3600, suite="nightly-hcu-accuracy-text", nightly=True)
 
 DEFAULT_HCU_MMLU_MODEL = (
-    "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct"
+    "/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B"
 )
 DEFAULT_HCU_MMLU_DATASET_PATH = "/public/opendas/DL_DATA/llm-models/datasets/mmlu"
 DEFAULT_HCU_SERVER_ARGS = [

--- a/test/registered/hcu/backends/bw1100/test_torch_compile_cuda_graph_hcu.py
+++ b/test/registered/hcu/backends/bw1100/test_torch_compile_cuda_graph_hcu.py
@@ -18,7 +18,7 @@ from sglang.test.test_utils import find_available_port
 register_hcu_ci(est_time=1200, suite="nightly-hcu-1", nightly=True)
 
 DEFAULT_MODEL = (
-    "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct"
+    "/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B"
 )
 
 

--- a/test/registered/hcu/distributed/bw1100/test_hicache_pp_hcu.py
+++ b/test/registered/hcu/distributed/bw1100/test_hicache_pp_hcu.py
@@ -25,7 +25,7 @@ register_hcu_ci(
 )
 
 DEFAULT_MODEL = (
-    "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct"
+    "/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B"
 )
 
 

--- a/test/registered/hcu/distributed/bw1100/test_pp_consistency_hcu.py
+++ b/test/registered/hcu/distributed/bw1100/test_pp_consistency_hcu.py
@@ -22,7 +22,7 @@ register_hcu_ci(
 )
 
 DEFAULT_MODEL = (
-    "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct"
+    "/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B"
 )
 PROMPTS = (
     ("The capital of France is", "paris"),

--- a/test/registered/hcu/distributed/bw1100/test_tp_dp_consistency_hcu.py
+++ b/test/registered/hcu/distributed/bw1100/test_tp_dp_consistency_hcu.py
@@ -18,7 +18,7 @@ from sglang.test.test_utils import find_available_port
 register_hcu_ci(est_time=900, suite="nightly-hcu-2", nightly=True)
 
 DEFAULT_MODEL = (
-    "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct"
+    "/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B"
 )
 PROMPTS = (
     ("The capital of France is", "paris"),

--- a/test/registered/hcu/spec/test_ngram_speculative_decoding_hcu.py
+++ b/test/registered/hcu/spec/test_ngram_speculative_decoding_hcu.py
@@ -41,7 +41,9 @@ register_hcu_ci(
     ),
 )
 
-DEFAULT_HCU_NGRAM_MODEL = "/public/opendas/DL_DATA/llm-models/qwen2.5/Qwen2.5-7B-Instruct"
+DEFAULT_HCU_NGRAM_MODEL = (
+    "/public/opendas/DL_DATA/llm-models/vllm-gptq-models/qwen2.5/Qwen2.5-7B"
+)
 
 
 class TestNgramSpeculativeDecodingHCU(unittest.TestCase):


### PR DESCRIPTION
Update retained HCU model paths to their current shared-storage locations. No product code or workflow behavior is changed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->