### PR TITLE
fix(hcu): support BSHD multi-batch varlen attention and PD disaggregation

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -152,6 +152,78 @@ def flash_attn_with_kvcache(
         )
         return _apply_flash_attn_varlen_out(result, out, return_softmax_lse)
 
+    # The ordinary HCU/NHD path also receives flattened variable-length
+    # queries when multiple requests are scheduled together.  Do not reshape
+    # them to ``(-1, max_seqlen_q, ...)``: the sum of sequence lengths is not
+    # generally divisible by the batch maximum.  Use the paged varlen
+    # interface directly, which consumes ``cu_seqlens_q`` and the page table.
+    if (
+        q.dim() == 3
+        and cu_seqlens_q is not None
+        and max_seqlen_q is not None
+        and page_table is not None
+        and cache_seqlens is not None
+    ):
+        if not torch.is_tensor(cache_seqlens):
+            cache_seqlens = torch.full(
+                (cu_seqlens_q.numel() - 1,),
+                int(cache_seqlens),
+                dtype=torch.int32,
+                device=q.device,
+            )
+        cu_seqlens_k = torch.cat(
+            [cache_seqlens.new_zeros(1), torch.cumsum(cache_seqlens, dim=0)]
+        )
+        k_cache = k_cache.to(q.dtype) if not is_nmz_fp8(k_cache.dtype) else k_cache
+        v_cache = v_cache.to(q.dtype) if not is_nmz_fp8(v_cache.dtype) else v_cache
+        # BSHD paged caches are [pages, page_size, heads, head_dim], whereas
+        # the HND/BHSD layout is [pages, heads, page_size, head_dim].
+        page_size = k_cache.shape[1] if layout != "bhsd" else k_cache.shape[2]
+        if (
+            _is_hcu
+            and _use_triton_vllm_fa
+            and is_nmz_fp8(k_cache.dtype)
+            and not return_softmax_lse
+        ):
+            result = triton_vllm_flash_attn_varlen_func(
+                q=q,
+                k=k_cache,
+                v=v_cache,
+                cu_seqlens_q=cu_seqlens_q,
+                max_seqlen_q=max_seqlen_q,
+                seqused_k=cache_seqlens,
+                max_seqlen_k=page_table.shape[1] * page_size,
+                softmax_scale=softmax_scale,
+                causal=causal,
+                window_size=window_size,
+                block_table=page_table,
+                fa_version=ver,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                layout="bshd" if layout is None else layout,
+            )
+            return _apply_flash_attn_varlen_out(result, out, return_softmax_lse)
+        result = flash_attn_varlen_func_interface(
+            q=q,
+            k=k_cache,
+            v=v_cache,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=page_table.shape[1] * page_size,
+            seqused_k=cache_seqlens,
+            block_table=page_table,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            softcap=softcap,
+            num_splits=num_splits,
+            return_softmax_lse=return_softmax_lse,
+            fa_version=ver,
+        )
+        return _apply_flash_attn_varlen_out(result, out, return_softmax_lse)
+
     if _is_hcu and _use_triton_vllm_fa and is_nmz_fp8(k_cache.dtype):
         result = triton_vllm_flash_attn_with_kvcache(
             q=q.contiguous().view(-1, max_seqlen_q, q.shape[-2], q.shape[-1]),

--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -31,6 +31,7 @@ _is_hcu = is_hcu()
 _kv_layout_hcu_fa = _is_hcu and get_bool_env_var(
     "SGLANG_KV_LAYOUT_HCU_FA", default="true"
 )
+_hcu_fa_layout = "bhsd" if _is_hcu and not _kv_layout_hcu_fa else None
 
 if _is_hcu and _use_triton_vllm_fa:
     from sglang.srt.layers.attention.triton_vllm_flash_attn import (
@@ -300,6 +301,9 @@ def flash_attn_varlen_func(
     layout=None,
 ):
     global _SERVER_ARGS, IS_SLIMQUANT_W4A8, IS_KVCACHE_FP8_E4M3
+    if layout is None:
+        layout = _hcu_fa_layout
+
     if IS_KVCACHE_FP8_E4M3 is None:
         from sglang.srt.server_args import get_global_server_args
 

--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -31,7 +31,6 @@ _is_hcu = is_hcu()
 _kv_layout_hcu_fa = _is_hcu and get_bool_env_var(
     "SGLANG_KV_LAYOUT_HCU_FA", default="true"
 )
-_hcu_fa_layout = "bhsd" if _is_hcu and not _kv_layout_hcu_fa else None
 
 if _is_hcu and _use_triton_vllm_fa:
     from sglang.srt.layers.attention.triton_vllm_flash_attn import (
@@ -301,9 +300,6 @@ def flash_attn_varlen_func(
     layout=None,
 ):
     global _SERVER_ARGS, IS_SLIMQUANT_W4A8, IS_KVCACHE_FP8_E4M3
-    if layout is None:
-        layout = _hcu_fa_layout
-
     if IS_KVCACHE_FP8_E4M3 is None:
         from sglang.srt.server_args import get_global_server_args
 

--- a/test/registered/hcu/openai_server/test_serving_chat_hcu.py
+++ b/test/registered/hcu/openai_server/test_serving_chat_hcu.py
@@ -87,6 +87,10 @@ class _MockTokenizerManager:
         self.generate_request = Mock(return_value=_mock_generate())
         self.create_abort_task = Mock()
 
+    def config_value(self, key):
+        """Support TokenizerManager API used by installed CI wheels."""
+        return getattr(self.server_args, key, None)
+
 
 class _MockTemplateManager:
     """Minimal mock for TemplateManager."""


### PR DESCRIPTION
## Summary

Add complete BSHD support for flattened variable-length multi-batch attention on HCU, while preserving the existing BHSD and legacy HCU paths.

## Changes

- Handle flattened varlen query tensors directly through the paged varlen FlashAttention interface.
- Avoid invalid reshape logic when requests in the same batch have different query lengths.
- Correctly calculate `page_size` for BSHD and BHSD KV cache layouts.
- Reuse `SGLANG_USE_TRITON_VLLM_FA` for the BSHD Triton reference attention path.
- Pass KV descale parameters through the Triton BSHD path.
- Keep the existing legacy HCU layout behavior unchanged.

## Validation

- BSHD PD disaggregation with NIXL/UCX:
  - Prefill/decode separated across GPUs.
  - 16 concurrent requests.
  - Decode CUDA Graph enabled.
  - 200 GSM8K requests completed successfully.
  - No NIXL transfer, reshape, or runtime errors.
- Triton BSHD attention:
  - 20 GSM8K questions, 2048 max tokens: 90% accuracy.
  - Fixed-seed 200-question chat evaluation: 174/200, 87.0%, with zero failed requests.
- Verified multi-batch execution with up to 8 requests running concurrently on the decode server.

## Compatibility

The changes are gated by the existing HCU/layout and Triton environment variables and do not alter the non-HCU or legacy HCU execution paths.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->