### PR TITLE
ci(hcu): restore run suite file filters

### DIFF
--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -666,6 +666,17 @@ def main():
         help="Path to sglang-ci-stats model.json for live LPT est; missing/malformed -> in-source est_time fallback.",
     )
     parser.add_argument(
+        "--include-file",
+        action="append",
+        default=[],
+        help="Restrict execution to a registered file. May be repeated.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Only list selected tests; do not execute them.",
+    )
+    parser.add_argument(
         "--fork-worker-batch-size",
         type=int,
         default=1,


### PR DESCRIPTION
## Summary

- restore the `--include-file` argument used by HCU PR test allowlists
- restore the `--list` argument used for selection-only validation
- retain the upstream `--fork-worker-batch-size` behavior

## Root cause

The main sync kept `args.include_file` and `args.list` call sites and the HCU workflow arguments, but dropped their argparse declarations. This caused Stage A/B to exit with `unrecognized arguments: --include-file`.

## Validation

- `python3.12 test/run_suite.py --help`
- Stage A selection with `--include-file ... --list` selected exactly one file
- Stage B selection with `--include-file ... --list` selected exactly one file
- `git diff --check`

This intentionally does not remove or broaden the existing HCU workflow allowlists.