### PR TITLE
[BugFix] Remove the dependency of prefill radix-cache with decode-pre…

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -917,7 +917,7 @@ class CommonKVManager(BaseKVManager):
             "rank_ip": self.local_ip,
             "rank_port": self.rank_port,
             "page_size": self.kv_args.page_size,
-            "kv_cache_layout": getattr(self.kv_mgr, "kv_cache_layout", None),
+            "kv_cache_layout": self.kv_cache_layout,
             "kv_cache_dtype": self.kv_cache_dtype_str,
             "load_balance_method": get_parallel().load_balance_method,
             "enable_dsa_cache_layer_split": get_parallel().enable_dsa_cache_layer_split,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -533,14 +533,25 @@ class PrefillBootstrapQueue:
         req.start_send_idx = decode_prefix_len
         # Base of the staging chunk grid (suffix-relative send coordinates).
         req.disagg_decode_prefix_len = decode_prefix_len
-        # Cap this request's radix prefix reuse at the prefix decode already
-        # holds: a reused prefix is never forwarded, so it yields no hidden rows
-        # for DSpark's PD hidden transfer. Gated on the server-level algorithm so
-        # every rank computes the same cap -- gating on per-request metadata lets
-        # ranks disagree and deadlocks the MoE dispatch collective.
-        if self.scheduler.server_args.speculative_algorithm is not None and str(
-            self.scheduler.server_args.speculative_algorithm
-        ).upper().endswith("DSPARK"):
+        # The optional raw-hidden fallback cannot reconstruct hidden rows for a
+        # radix hit, so it must not let prefill reuse past the prefix decode
+        # already owns. The default DSpark PD path transfers the prefill-side
+        # draft KV instead: those cached target/draft rows stay addressable
+        # through req_to_token and are shipped by _send_cached_prefix_early, so
+        # decode missing the prefix costs transfer, not a prefill recompute.
+        #
+        # Gate on the server-level state ABI, never on per-request bootstrap
+        # metadata: req_to_pd_hidden_meta is filled only on the rank hosting the
+        # bootstrap server (same block as req_to_decode_prefix_len, which needs
+        # an all_reduce backfill for exactly that reason), so a per-request gate
+        # makes ranks derive different caps and deadlocks the MoE dispatch.
+        if (
+            self.scheduler.server_args.speculative_algorithm is not None
+            and str(self.scheduler.server_args.speculative_algorithm)
+            .upper()
+            .endswith("DSPARK")
+            and StateType.PD_HIDDEN in self.kv_manager.kv_args.state_types
+        ):
             req.pd_hidden_max_prefix_len = int(decode_prefix_len)
         num_kv_indices_to_send = num_kv_indices - decode_prefix_len
         num_pages = kv_to_page_num(
@@ -2232,7 +2243,7 @@ class SchedulerDisaggregationPrefillMixin:
                     if streaming_pd_hidden
                     else pd_hidden_state(req).src_indices,
                 )
-            elif req.disagg_kv_sender._source_event is None:
+            elif getattr(req.disagg_kv_sender, "_source_event", None) is None:
                 # PP + chunked prefill (overlap off) sends intermediate chunks
                 # from process_prefill_chunk while the writer is still on
                 # forward_stream. Record the barrier here so source_event is

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1345,6 +1345,7 @@ class Req(ReqDllmMixin):
         # stored in the radix tree, so a reused prefix carries stale SWA. Cap the
         # match by the trailing sliding window so it gets re-prefilled, rewriting
         # this request's SWA ring. No-op for other layouts.
+        reprefill_tail = 0
         if tree_cache is not None:
             reprefill_tail = tree_cache.swa_reprefill_tail_tokens()
             if reprefill_tail:
@@ -1360,14 +1361,6 @@ class Req(ReqDllmMixin):
         if tree_cache is not None:
             if cow_mamba is None:
                 cow_mamba = tree_cache.supports_mamba()
-            # unified_kv SWA lives in a per-request ring that is not content-stable
-            # and never cached in the radix tree, so a reused prefix carries stale
-            # SWA. Cap the match by the trailing sliding window so it is re-prefilled
-            # into this request's ring. No-op for other layouts (returns 0).
-            reprefill_tail = tree_cache.swa_reprefill_tail_tokens()
-            if reprefill_tail:
-                capped = max(0, input_len - reprefill_tail)
-                key_limit = capped if key_limit is None else min(key_limit, capped)
             match_result = tree_cache.match_prefix(
                 MatchPrefixParams(
                     key=RadixKey(
@@ -1378,6 +1371,11 @@ class Req(ReqDllmMixin):
                     ),
                     req=self,
                     cow_mamba=cow_mamba,
+                    # unified_kv's SWA is request-private and intentionally
+                    # absent from the tree. Match the reusable full-attention
+                    # prefix; the key_limit above leaves one SWA window to
+                    # re-prefill into this request's ring.
+                    return_full_match=bool(reprefill_tail),
                 )
             )
             if envs.SGLANG_RADIX_FORCE_MISS.get():

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -163,6 +163,7 @@ def match_prefix_for_req(
             ),
             cow_mamba=cow_mamba,
             req=req if include_req else None,
+            return_full_match=bool(reprefill_tail),
         )
     )
     if envs.SGLANG_RADIX_FORCE_MISS.get():

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2700,20 +2700,27 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def swa_reprefill_tail_tokens(self) -> int:
         """
-        Only unified_kv + HiCache needs this: SWA lives in a per-request ring
-        (state_slot/pos), not content-stable and never offloaded to host, so a
-        reused prefix's trailing sliding window would read another request's
-        stale ring slots. Re-prefilling that window rewrites this request's ring
-        (what plain radix reuse does via its SWA match gate). 0 for every other
-        layout.
+        unified_kv keeps SWA in a per-request ring (state_slot/pos), not in
+        content-stable radix slots. This is true with or without HiCache. Reuse
+        only the full-attention prefix and re-prefill one trailing SWA window
+        into the new request's ring. Return 0 for index-addressed SWA layouts.
         """
         swa = self.components.get(ComponentType.SWA)
+        if swa is None:
+            return 0
+        # Compress-only HiCache: SWA is never offloaded, so a host-restored
+        # prefix carries no SWA at all.
         unified_compress_only_hicache = (
             self.cache_controller is not None
-            and swa is not None
             and not self.tree_core.has_swa_host_pool
         )
-        return swa.sliding_window_size if unified_compress_only_hicache else 0
+        # unified_kv layout: SWA lives in a per-request ring keyed by
+        # (state_slot, pos), so another request's slots are not reusable.
+        kv_cache = self.token_to_kv_pool_allocator.get_kvcache()
+        request_private_swa_ring = bool(getattr(kv_cache, "_unified_kv", False))
+        if unified_compress_only_hicache or request_private_swa_ring:
+            return swa.sliding_window_size
+        return 0
 
     def swa_retain_floor(self, req) -> int | None:
         if not self.is_mamba_enabled or self._sliding_window_size is None:


### PR DESCRIPTION
一、问题描述
DSpark 的 PD 分离与 radix-cache 同时启用时，原实现存在以下问题：
1. P 端 radix 命中长度被 D 端 decode_prefix_len 限制。
   - D 未命中时，decode_prefix_len=0。
   - P 即使本地已有 KV，也会被迫重新计算整个 prompt。
   - P 端缓存无法独立发挥作用。
2. P 端复用前缀后，可能无法产生对应的 hidden states。
   - raw hidden 传输路径需要 P 发送 [D_hit, prompt_end) 的 hidden。
   - P 如果复用了超过 D 已持有的部分，就没有对应 hidden rows。
3. DeepSeek-V4 unified-KV 的 SWA 使用 request-private ring。
   - SWA 不具备普通 full KV 那样的内容稳定性。
   - 直接 full-only 命中可能读取新请求未初始化的 SWA/C128 状态。
4. D 端 radix-cache 按 DP rank 独立保存。
   - 使用 round-robin routing 时，同一 prompt 需要在每个 D rank 上分别预热。

二、原因分析
1. 原始 P≤D 限制过于宽泛
原代码在 DSpark 下无条件设置：
req.pd_hidden_max_prefix_len = decode_prefix_len
这实际上把两种不同协议混在了一起：
- PD_HIDDEN：P 需要发送 hidden states，命中前缀不能超过 D 已有前缀。
- 默认 DSpark draft-KV：P 可以直接发送缓存中的 target/draft KV，D 未命中只会增加传输量，不需要 P 重算。
因此，原限制对 raw-hidden 路径是正确性保护，但对默认 draft-KV 路径是不必要的。
2. 不能使用 rank-local 的请求元数据做全局判断
req_to_pd_hidden_meta 和 decode_prefix_len 只在 bootstrap server 所在 rank 上天然可见。若各 rank 根据请求元数据独立决定是否限幅，可能导致：
- 不同 rank 得到不同的 P cache 上限；
- batch 组成不一致；
- MoE/CP 集合通信死锁。
因此必须使用所有 rank 一致的 server-level state_types 判断。
3. unified-KV 的 SWA 不能直接复用
unified-KV 中：
- Full KV 可以通过 radix tree 的 token index 复用；
- SWA KV 保存在每个 request 的 ring 中；
- 新请求拥有新的 req_pool_idx，不能直接读取旧请求的 SWA ring。
所以需要：
复用 full-attention 前缀
+
重新计算最后一个 SWA window
此外，DSV4 的 C128 压缩状态也存在 request-scoped ring，边界、page 对齐和 req-slot 复用都需要额外验证。

三、代码改动
1. P 端 cap 改为条件门控
文件：
python/sglang/srt/disaggregation/prefill.py
现在只有同时满足以下条件才限制 P reuse：
speculative_algorithm == DSpark
and StateType.PD_HIDDEN in kv_args.state_types
效果：
- raw hidden 路径继续保证 P_hit ≤ D_hit；
- 默认 DSpark draft-KV 路径允许 P 独立命中；
- D miss 时由 P 发送更多 KV，而不是触发 P 重算；
- 使用 server-level ABI，避免 rank 间分歧。
2. 调整 full-only radix match
文件：
python/sglang/srt/managers/schedule_batch.py
python/sglang/srt/managers/schedule_policy.py
新增：
- reprefill_tail 计算；
- 命中长度扣除 SWA 重算尾部；
- unified-KV 场景使用 return_full_match=True；
- 调度预匹配和实际 batch 匹配保持一致。
3. 增强 SWA 尾部检测
文件：
python/sglang/srt/mem_cache/unified_radix_cache.py
swa_reprefill_tail_tokens() 现在识别：
- HiCache 中没有 SWA host pool 的情况；
- unified-KV 的 request-private SWA ring。
返回 SWA window 大小，使 P 在复用 full KV 后重新计算尾部窗口。
4. 修复相关兼容性问题
- common/conn.py：使用正确的 self.kv_cache_layout。
- prefill.py：通过 getattr(..., None) 兼容 FakeKV sender。
- mhc.py：TileLang 缺少 Allocate 时跳过兼容 patch。

验证
<img width="679" height="729" alt="image" src="https://github.com/user-attachments/assets/ea489179-bc65-495a-b0ef-0f6dd58c165c" />


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
