### PR TITLE
fix(speculative): remove unsupported server args

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -246,7 +246,6 @@ class FlashAttentionBackend(AttentionBackend):
             # Static verify width; NOTE: overwrites the config-named attr in place.
             self.speculative_num_draft_tokens = resolve_num_tokens_per_req(
                 phase="target_verify",
-                server_args=model_runner.server_args,
                 spec_algorithm=SpeculativeAlgorithm.from_string(
                     model_runner.server_args.speculative_algorithm
                 ),


### PR DESCRIPTION
## 动机

在启用 Speculative Decoding 和 FA3 Attention Backend 时，Scheduler 初始化会因为参数签名不一致而启动失败。

`resolve_num_tokens_per_req()` 已不再接收 `server_args` 参数，但 `FlashAttentionBackend` 初始化时仍然传入了该参数，导致服务启动阶段抛出：

```text
TypeError: resolve_num_tokens_per_req() got an unexpected keyword argument 'server_args'
```

本 PR 修复该调用，使 `release/20260825_v0.5.18` 分支上的 Speculative Decoding 服务能够正常继续初始化。

## 修改内容

删除 `FlashAttentionBackend` 调用 `resolve_num_tokens_per_req()` 时多余的 `server_args` 参数。

修改文件：

```text
python/sglang/srt/layers/attention/flashattention_backend.py
```

该 PR 仅包含一处参数删除，没有修改其他逻辑。


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->