### PR TITLE
[perf] add opt-in LightOp KV allocation kernel

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -450,6 +450,8 @@ class Envs:
     # ===================================================================
     SGLANG_DETECT_SLOW_RANK = EnvBool(False)
     SGLANG_DEBUG_MEMORY_POOL = EnvBool(False)
+    # Use the LightOp kernel for paged KV-cache extend allocation.
+    SGLANG_LIGHTOP_KVALLOC_KERNEL = EnvBool(False)
     # NaN-fill the unified memory pool at boot (debug repro switch).
     SGLANG_DEBUG_POISON_POOL = EnvBool(False)
     SGLANG_DEBUG_REVERT_PR = EnvInt(0)

--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -28,6 +28,7 @@ from sglang.kernels.ops.memory.allocator import (
     alloc_decode_kernel,
     alloc_extend_kernel,
 )
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
 from sglang.srt.utils import (
     get_bool_env_var,
@@ -35,12 +36,38 @@ from sglang.srt.utils import (
     is_hip,
     next_power_of_2,
 )
-from sgl_kernel.kvcacheio import hcu_alloc_decode_kernel, hcu_alloc_extend_kernel
+from sgl_kernel.kvcacheio import (
+    hcu_alloc_decode_kernel,
+    hcu_alloc_extend_kernel as sgl_kernel_alloc_extend_kernel,
+)
 
 _is_hip = is_hip()
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
+
+
+_LIGHTOP_ALLOC_EXTEND_KERNEL = None
+_LIGHTOP_ALLOC_EXTEND_KERNEL_CHECKED = False
+
+
+def _get_lightop_alloc_extend_kernel():
+    global _LIGHTOP_ALLOC_EXTEND_KERNEL, _LIGHTOP_ALLOC_EXTEND_KERNEL_CHECKED
+
+    if _LIGHTOP_ALLOC_EXTEND_KERNEL_CHECKED:
+        return _LIGHTOP_ALLOC_EXTEND_KERNEL
+
+    _LIGHTOP_ALLOC_EXTEND_KERNEL_CHECKED = True
+    try:
+        from lightop import op as lightop_op
+
+        _LIGHTOP_ALLOC_EXTEND_KERNEL = getattr(
+            lightop_op, "hcu_alloc_extend_kernel", None
+        )
+    except Exception:
+        _LIGHTOP_ALLOC_EXTEND_KERNEL = None
+
+    return _LIGHTOP_ALLOC_EXTEND_KERNEL
 
 
 def alloc_extend_naive(
@@ -128,6 +155,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.sglang_kvalloc_kernel = get_bool_env_var(
             "SGLANG_KVALLOC_KERNEL", default="true"
         )
+        self.lightop_kvalloc_kernel = envs.SGLANG_LIGHTOP_KVALLOC_KERNEL.get()
         self.seen_max_num_extend_tokens_next_power_of_2 = 1
 
         # Pre-warm the torch.unique HIP kernel used in free(). When a request
@@ -199,14 +227,22 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
         if self.sglang_kvalloc_kernel:
-            hcu_alloc_extend_kernel(
-                pre_lens_ptr = prefix_lens.to(torch.int64),
-                seq_lens_ptr = seq_lens.to(torch.int64),
-                last_loc_ptr = last_loc.to(torch.int64),
-                free_page_ptr = self.free_pages.to(torch.int64),
-                out_indices = out_indices,
-                bs = bs,
-                page_size = self.page_size,
+            alloc_extend_kernel_impl = (
+                _get_lightop_alloc_extend_kernel()
+                if self.lightop_kvalloc_kernel
+                else None
+            )
+            if alloc_extend_kernel_impl is None:
+                alloc_extend_kernel_impl = sgl_kernel_alloc_extend_kernel
+
+            alloc_extend_kernel_impl(
+                pre_lens_ptr=prefix_lens.to(torch.int64),
+                seq_lens_ptr=seq_lens.to(torch.int64),
+                last_loc_ptr=last_loc.to(torch.int64),
+                free_page_ptr=self.free_pages.to(torch.int64),
+                out_indices=out_indices,
+                bs=bs,
+                page_size=self.page_size,
             )
         else:
             alloc_extend_kernel[(bs,)](


### PR DESCRIPTION
## Motivation

Add an opt-in LightOp kernel for paged KV-cache extend allocation, while preserving the existing allocation path by default.

## Modifications

- Register `SGLANG_LIGHTOP_KVALLOC_KERNEL` in `environ.py`, defaulting to `False`.
- Lazily load and cache `lightop.op.hcu_alloc_extend_kernel` when enabled.
- Fall back to the existing `sgl_kernel` implementation if LightOp cannot be loaded or the required kernel is unavailable.
- Keep the decode allocation path unchanged.

Enable the LightOp extend-allocation path with:

```bash
export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->