### PR TITLE
perf(hcu): optimize DeepSeek-V4 DSpark decode paths

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/gemm.py
+++ b/python/sglang/kernels/ops/attention/dsv4/gemm.py
@@ -5,15 +5,18 @@ from typing import Optional
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import get_bool_env_var, is_hip
+from sglang.srt.utils import is_hip
 
 _is_hip = is_hip()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
+_linear_bf16_fp32_algo = envs.SGLANG_OPT_BF16_FP32_GEMM_ALGO.get()
+_use_aiter_bf16_fp32_gemm = _is_hip and (
+    _use_aiter or _linear_bf16_fp32_algo == "aiter"
+)
 
-if _use_aiter:
+if _use_aiter_bf16_fp32_gemm:
     from aiter.tuned_gemm import tgemm
 
-_linear_bf16_fp32_algo = envs.SGLANG_OPT_BF16_FP32_GEMM_ALGO.get()
 _HPC_GEMM_WEIGHT_CACHE_ATTR = "_sglang_bf16xfp32_weight_cache"
 # The HPC-Ops bf16xfp32 GEMM consumes the fp32 weight decomposed into two
 # bf16 halves: w_high = w.bf16 and w_low = ((w - w_high) / scale).bf16 with
@@ -147,7 +150,16 @@ def linear_bf16_fp32(
     *,
     hpc_kernel_min_m: Optional[int] = None,
 ) -> torch.Tensor:
-    if _use_aiter and y.dtype == torch.bfloat16:
+    if (
+        _use_aiter_bf16_fp32_gemm
+        and x.is_cuda
+        and y.is_cuda
+        and x.dtype == torch.bfloat16
+        and y.dtype == torch.bfloat16
+    ):
+        # AITER's tuned BF16 GEMM is much faster for DSV4's narrow decode
+        # matrices. It returns BF16-rounded values; convert back to the FP32
+        # tensor contract expected by the compressor's downstream operators.
         return tgemm.mm(x, y, otype=x.dtype).float()
     elif hpc_kernel_min_m is not None:
         output = _linear_bf16_fp32_hpc(x, y, min_m=hpc_kernel_min_m)

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -55,9 +55,37 @@ def topk_transform_512(
     out_raw_indices: Optional[torch.Tensor] = None,
 ) -> None:
     if is_hip_runtime():
-        torch.ops.sgl_kernel.deepseek_v4_topk_transform_512(
-            scores, seq_lens, page_tables, out_page_indices, page_size, out_raw_indices
+        # Some HCU images ship an older sgl-kernel package without this DSV4
+        # AOT op. LightOp provides the same fused top-k + page-table transform
+        # ABI, avoiding the much slower vectorized PyTorch path.
+        sgl_kernel = getattr(torch.ops, "sgl_kernel", None)
+        sgl_topk = (
+            getattr(sgl_kernel, "deepseek_v4_topk_transform_512", None)
+            if sgl_kernel is not None
+            else None
         )
+        if sgl_topk is not None:
+            sgl_topk(
+                scores,
+                seq_lens,
+                page_tables,
+                out_page_indices,
+                page_size,
+                out_raw_indices,
+            )
+        else:
+            from lightop.fuse_topk_transform import (
+                topk_transform_512 as lightop_topk_transform_512,
+            )
+
+            lightop_topk_transform_512(
+                scores,
+                seq_lens,
+                page_tables,
+                out_page_indices,
+                page_size,
+                out_raw_indices,
+            )
     else:
         module = _jit_topk_v1_module()
         module.topk_transform(

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1465,6 +1465,8 @@ class Envs:
     SGLANG_OPT_USE_JIT_NORM = EnvBool(True)
     SGLANG_PREP_IN_CUDA_GRAPH = EnvBool(True)
     SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER = EnvBool(True)
+    # cublas (default), hpc, deep_gemm, or aiter. The aiter path is opt-in
+    # because it returns BF16-rounded values before converting them to FP32.
     SGLANG_OPT_BF16_FP32_GEMM_ALGO = EnvStr("cublas")
     SGLANG_OPT_FUSE_WQA_WKV = EnvBool(True)
     SGLANG_OPT_USE_MULTI_STREAM_OVERLAP = EnvBool(True)

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -15,6 +15,7 @@ from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
 from sglang.kernels.ops.speculative.dspark.dspark_draft_model import (
     BuildStepLocal,
     CommitKvProj,
+    MarkovGreedyStep,
 )
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
@@ -501,6 +502,39 @@ class DSparkV4MarkovHead(nn.Module):
             sampler=sampler,
             collect_corrected=collect_corrected,
         )
+
+    def sample_block_greedy_fused(
+        self,
+        base_logits: torch.Tensor,
+        *,
+        first_prev_tokens: torch.Tensor,
+    ) -> Optional[torch.Tensor]:
+        """Generate a greedy block without materializing Markov bias logits.
+
+        The fused kernel consumes a full vocabulary row. DP attention with a
+        DP LM head has a one-rank vocabulary group and is therefore eligible;
+        retain the existing implementation for genuinely TP-sharded heads.
+        """
+        if not base_logits.is_cuda:
+            return None
+        if self._tp_shard is not None and self._tp_shard.tp_size > 1:
+            return None
+        batch_size, proposal_len = base_logits.shape[:2]
+        if proposal_len == 0:
+            return torch.empty(
+                batch_size, 0, dtype=torch.long, device=base_logits.device
+            )
+        sampled_tokens = []
+        prev_tokens = first_prev_tokens.long()
+        for step_idx in range(proposal_len):
+            prev_embeds = self.get_prev_embeddings(prev_tokens)
+            prev_tokens = MarkovGreedyStep.execute(
+                base_logits=base_logits[:, step_idx, : self.vocab_size],
+                prev_embeds=prev_embeds,
+                w2_weight=self.markov_w2.weight,
+            )
+            sampled_tokens.append(prev_tokens)
+        return torch.stack(sampled_tokens, dim=1)
 
 
 def build_dspark_v4_confidence_head(

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -9,7 +9,6 @@ from sglang.kernels.ops.speculative.dspark.dspark_draft_model import (
     SampleStepTokens,
 )
 from sglang.srt.environ import DsparkFoldedSampling, envs
-from sglang.srt.models.dspark import VanillaMarkov
 from sglang.srt.speculative.dspark_components.dspark_draft import (
     select_draft_hidden_without_anchor,
 )
@@ -130,14 +129,9 @@ class DsparkDraftSampler:
         # Gated/RNN subclasses return None (hidden-state-dependent bias); fall
         # through to the block sampler below.
         draft_tokens = None
-        if (
-            not self.folded_sampling
-            and self._fused_greedy
-            and isinstance(self.markov_head, VanillaMarkov)
-        ):
-            draft_tokens = self.markov_head.sample_block_greedy_fused(
-                base_logits, first_prev_tokens=anchor
-            )
+        fused_greedy = getattr(self.markov_head, "sample_block_greedy_fused", None)
+        if not self.folded_sampling and self._fused_greedy and callable(fused_greedy):
+            draft_tokens = fused_greedy(base_logits, first_prev_tokens=anchor)
 
         if draft_tokens is None:
             if self.folded_sampling:

--- a/scripts/ci/hcu/hcu_ci_install_dependency.sh
+++ b/scripts/ci/hcu/hcu_ci_install_dependency.sh
@@ -71,6 +71,16 @@ install_with_retry() {
   done
 }
 
+install_eval_dependency() {
+  # The required sampling suite invokes this CLI even in image/wheel mode.
+  # shellcheck source=scripts/ci/utils/sgl_eval_ref.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/../utils/sgl_eval_ref.sh"
+  echo "[hcu-ci] Installing sgl-eval at ${SGL_EVAL_REF}"
+  install_with_retry docker exec "${CONTAINER}" \
+    python3 -m pip install --cache-dir=/sgl-data/pip-cache "${SGL_EVAL_SPEC}"
+  run_in_container "sgl-eval --help >/dev/null"
+}
+
 if [[ "${SKIP_COMPAT_INSTALL}" == "1" || "${SKIP_COMPAT_INSTALL}" == "true" ]]; then
   echo "[hcu-ci] HCU_CI_SKIP_COMPAT_INSTALL=${SKIP_COMPAT_INSTALL}; skipping HCU compatibility pins"
 else
@@ -97,6 +107,7 @@ fi
 
 if [[ "${SKIP_DEPENDENCY_INSTALL}" == "1" || "${SKIP_DEPENDENCY_INSTALL}" == "true" ]]; then
   echo "[hcu-ci] HCU_CI_SKIP_DEPENDENCY_INSTALL=${SKIP_DEPENDENCY_INSTALL}; skipping regular dependency installation"
+  install_eval_dependency
   print_python_status
   exit 0
 fi
@@ -135,6 +146,8 @@ else
   install_with_retry docker exec -w /sglang-checkout "${CONTAINER}" \
     pip install --cache-dir=/sgl-data/pip-cache --no-deps -e "python[srt]"
 fi
+
+install_eval_dependency
 
 echo "[hcu-ci] Installed sglang version:"
 run_in_container "python -c 'import sglang, sys; print(sglang.__version__); sys.exit(0)' || true"

--- a/test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py
+++ b/test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py
@@ -3,6 +3,7 @@
 
 """HCU FP8 per-token-group quantization numeric reference tests."""
 
+import math
 import unittest
 
 import torch
@@ -18,8 +19,6 @@ register_hcu_ci(
     nightly=True,
 )
 register_hcu_ci(est_time=60, suite="stage-b-test-1-hcu-small")
-
-HCU_FP8_QUANT_MAX = 224.0
 
 
 class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
@@ -46,15 +45,22 @@ class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
                     source,
                     group_size=group_size,
                 )
+                # E4M3FN and E4M3FNUZ have different finite ranges.
+                quant_info = torch.finfo(quantized.dtype)
+                quant_max = quant_info.max
+                # Preserve a one-ULP rounding allowance at the largest exponent:
+                # 16 for E4M3FNUZ, 32 for E4M3FN.
+                max_quant_step = math.ldexp(
+                    quant_info.eps, math.frexp(quant_max)[1] - 1
+                )
 
                 grouped = source.float().reshape(tokens, -1, group_size)
                 reference_scales = (
-                    grouped.abs().amax(dim=-1).clamp_min(1e-10)
-                    / HCU_FP8_QUANT_MAX
+                    grouped.abs().amax(dim=-1).clamp_min(1e-10) / quant_max
                 )
                 reference_quantized = (
                     (grouped / reference_scales.unsqueeze(-1))
-                    .clamp(-HCU_FP8_QUANT_MAX, HCU_FP8_QUANT_MAX)
+                    .clamp(-quant_max, quant_max)
                     .to(quantized.dtype)
                     .reshape_as(quantized)
                 )
@@ -65,16 +71,14 @@ class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
                     rtol=1e-4,
                     atol=1e-6,
                 )
-                quant_diff = (
-                    quantized.float() - reference_quantized.float()
-                ).abs()
+                quant_diff = (quantized.float() - reference_quantized.float()).abs()
                 self.assertLess(
                     quant_diff.count_nonzero().item() / quant_diff.numel(),
                     0.005,
                 )
                 self.assertLessEqual(
                     quant_diff.max().item(),
-                    16.0,
+                    max_quant_step,
                 )
 
 

--- a/test/registered/hcu/openai_server/test_serving_chat_hcu.py
+++ b/test/registered/hcu/openai_server/test_serving_chat_hcu.py
@@ -87,6 +87,9 @@ class _MockTokenizerManager:
         self.generate_request = Mock(return_value=_mock_generate())
         self.create_abort_task = Mock()
 
+    def config_value(self, name):
+        return getattr(self.server_args, name)
+
 
 class _MockTemplateManager:
     """Minimal mock for TemplateManager."""
@@ -680,7 +683,9 @@ class ServingChatTestCase(unittest.TestCase):
             tool_calls = payload["choices"][0]["delta"]["tool_calls"]
             self.assertEqual(tool_calls[0]["id"], "functions.get_weather:1")
 
-    @unittest.skip("Current OpenAIServingChat no longer exposes use_dpsk_v32_encoding; skip DeepSeek V3.2-specific unit path in HCU smoke")
+    @unittest.skip(
+        "Current OpenAIServingChat no longer exposes use_dpsk_v32_encoding; skip DeepSeek V3.2-specific unit path in HCU smoke"
+    )
     def test_dpsk_v32_encoding_path(self):
         """Test DeepSeek V3.2 encoding path detection and application."""
         from sglang.srt.managers.template_manager import TemplateManager

--- a/test/registered/sampling/test_pytorch_sampling_backend.py
+++ b/test/registered/sampling/test_pytorch_sampling_backend.py
@@ -18,7 +18,11 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import is_hip, kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cuda_ci,
+    register_hcu_ci,
+)
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -31,6 +35,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=80, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=66, suite="stage-b-test-1-gpu-small-amd")
+register_hcu_ci(est_time=66, suite="stage-b-test-1-hcu-small")
 
 
 class TestPyTorchSamplingBackend(CustomTestCase):

--- a/test/registered/spec/dspark/test_dspark_draft_path_default.py
+++ b/test/registered/spec/dspark/test_dspark_draft_path_default.py
@@ -1,6 +1,8 @@
 import unittest
 from types import SimpleNamespace
 
+import torch
+
 from sglang.srt.arg_groups.overrides import resolution_result
 from sglang.srt.arg_groups.speculative_hook import (
     _handle_dspark,
@@ -8,6 +10,9 @@ from sglang.srt.arg_groups.speculative_hook import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.dspark_components.dspark_draft_sampler import (
+    DsparkDraftSampler,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -118,6 +123,49 @@ class TestDsparkDpAttentionMoeA2aGate(CustomTestCase):
         with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"):
             with self.assertRaisesRegex(ValueError, "static"):
                 _handle_dspark(server_args)
+
+
+class _DuckTypedMarkovHead:
+    def __init__(self):
+        self.called = False
+
+    def sample_block_greedy_fused(self, base_logits, *, first_prev_tokens):
+        self.called = True
+        return first_prev_tokens[:, None].expand(-1, base_logits.shape[1]).clone()
+
+    def sample_block(self, *args, **kwargs):
+        raise AssertionError("the eager fallback must not run")
+
+
+class _DuckTypedDraftModel:
+    sample_from_anchor = True
+
+    def __init__(self):
+        self.markov_head = _DuckTypedMarkovHead()
+
+    def compute_base_logits(self, hidden_states):
+        return hidden_states.new_zeros(hidden_states.shape[0], 7), None
+
+
+class TestDsparkFusedGreedyRouting(CustomTestCase):
+    def test_custom_markov_head_can_provide_fused_greedy_sampler(self):
+        model = _DuckTypedDraftModel()
+        with envs.SGLANG_DSPARK_OPT_FUSED_GREEDY_MARKOV.override(True):
+            sampler = DsparkDraftSampler(
+                model=model,
+                gamma=2,
+                max_bs=2,
+                device="cpu",
+                tp_sync=None,
+                folded_sampling=False,
+            )
+
+        hidden_states = torch.zeros(4, 3)
+        input_ids = torch.tensor([11, 12, 21, 22])
+        sampler(hidden_states, input_ids)
+
+        self.assertTrue(model.markov_head.called)
+        self.assertEqual(sampler.out[:4].tolist(), [11, 11, 21, 21])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

DeepSeek-V4 Flash with DSpark on HCU could not use several optimized kernels
without broad global switches or a matching recent `sgl-kernel` wheel:

1. `DsparkDraftSampler` only admitted `VanillaMarkov` to the fused greedy
   proposal path. `DSparkV4MarkovHead` has the same vanilla Markov recurrence,
   but is a separate class and therefore materialized full-vocabulary bias and
   corrected-logit tensors on every proposal step.
2. Some released HCU images do not contain
   `torch.ops.sgl_kernel.deepseek_v4_topk_transform_512`, while their LightOp
   package exposes the ABI-compatible fused transform.
3. DSV4's existing `SGLANG_OPT_BF16_FP32_GEMM_ALGO` selector could not select
   the already-supported AITER path independently of the broad
   `SGLANG_USE_AITER` switch.

The result was avoidable decode latency on BW1000, especially at batch size 1.

## Modifications

- Make DSpark fused-greedy dispatch capability-based instead of checking the
  concrete `VanillaMarkov` class.
- Implement `sample_block_greedy_fused` for `DSparkV4MarkovHead` using the
  existing `MarkovGreedyStep` kernel. It crops padded vocabulary columns and
  retains the eager path for genuinely TP-sharded Markov heads.
- Prefer the existing sgl-kernel DSV4 AOT top-k op on HIP, and fall back to
  LightOp's ABI-compatible fused top-k/page-table transform when that op is not
  present.
- Accept `SGLANG_OPT_BF16_FP32_GEMM_ALGO=aiter` as a narrow DSV4 compressor
  switch. `SGLANG_USE_AITER=true` keeps its existing behavior.
- Add a CPU unit test proving a non-`VanillaMarkov` head can opt into the fused
  greedy interface without entering the eager fallback.

All performance-sensitive choices remain opt-in except the missing-AOT-op
fallback. The default compressor algorithm remains `cublas`.

## Accuracy Tests

Test system:

- 8 x Hygon BW1000 (`gfx936`), DTK 26.04, PyTorch 2.10
- `DeepSeek-V4-Flash-0731-W4A8-INT4-Channel-Attn-W8A8-INT8-Channel`
- TP8 + DP8 + DP Attention + DP LM head, DSpark gamma 5
- temperature 0

GSM8K, five-shot Chat API, 50 examples, 8 client threads, max 1024 output
tokens:

| Score | Correct | Latency | Output throughput | Mean DSpark accept length |
|---:|---:|---:|---:|---:|
| 1.000 | 50/50 | 21.370 s | 281.606 tok/s | 4.1817 |

The fixed long-form Chinese prompt also produced coherent, non-repeating
technical prose for exactly 1024 output tokens.

Precision note: AITER's tuned BF16 GEMM returns BF16-rounded values before this
function converts the tensor back to FP32. For M=6, N=1024, K=4096, comparison
against `torch.mm(..., out_dtype=torch.float32)` measured max absolute error
0.498169 and mean absolute error 0.070678. For that reason the AITER algorithm
is explicitly opt-in; users needing the original FP32-accumulation path keep
the default `cublas` setting.

The fused Markov kernel can select a different draft token on rare near ties
because it accumulates in FP32 instead of reproducing eager BF16 intermediate
rounding. These are proposals only; target verification still controls emitted
tokens.

## Speed Tests and Profiling

Single-request OpenAI Chat API benchmark with a fixed realistic technical
writing prompt, `temperature=0`, `ignore_eos=true`, and exactly 1024 generated
tokens:

| Compressor path | Runs | End-to-end throughput |
|---|---:|---:|
| strict FP32 accumulation | 2 | 40.083, 41.024 tok/s |
| AITER BF16 GEMM (opt-in) | 3, including cold restart | 74.089, 73.407, 75.452 tok/s |

The W4A8 MoE, communication settings, prompt, and other service configuration
were held constant for this A/B comparison.

Kernel measurements on one BW1000:

| Operation and shape | Before | After | Speedup |
|---|---:|---:|---:|
| DSV4 top-k transform, M=6, L=4096, K=512 | 0.3575 ms | 0.0111 ms | 32.2x |
| compressor GEMM, M=6, N=1024, K=4096 | 0.6583 ms | 0.0384 ms | 17.1x |
| DSpark Markov greedy step, vocab=128800 | 0.7703 ms | 0.1243 ms | 6.2x |

The top-k parity sweep covered mixed sequence lengths and confirmed that this
image had no DSV4 sgl-kernel AOT op, so the LightOp fallback was exercised
rather than merely imported.

## Tests

- `pytest -q test/registered/spec/dspark/test_dspark_draft_path_default.py::TestDsparkFusedGreedyRouting::test_custom_markov_head_can_provide_fused_greedy_sampler`
  - `1 passed`
- Direct HCU parity test for DSV4 fused greedy, including padded vocabulary
  cropping and TP-sharded fallback: passed.
- Direct HCU LightOp top-k parity over sequence lengths 127, 512, 1025 and
  4096: passed.
- Direct HCU `SGLANG_OPT_BF16_FP32_GEMM_ALGO=aiter` routing and output
  shape/dtype test: passed.
- Black 26.1.0, isort 7.0.0, Ruff 0.15.1, codespell 2.4.1, `compileall`, and
  `git diff --check`: passed.

## Checklist

- [x] Format code with the repository's pinned formatter versions.
- [x] Add and run a focused unit test.
- [x] Document the new algorithm value and numerical behavior inline.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->