### PR TITLE
feat(hcu): integrate AITER-layout W4A8 DeepEP kernels

### DIFF
--- a/python/sglang/kernels/jit/csrc/moe/w4a8_deepep_aiter.hip
+++ b/python/sglang/kernels/jit/csrc/moe/w4a8_deepep_aiter.hip
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 gencheng liu
+// SPDX-License-Identifier: MIT
+//
+// The MMAC main loop is instantiated from the MIT-licensed AITER headers that
+// ship in the Hygon SGLang image.  This wrapper removes AITER's TP-only
+// stride_bse == 256 dispatch restriction and presents already-dispatched
+// DeepEP rows as a top-k=1 sorted-token problem.
+
+#include <ATen/ATen.h>
+#include <hip/hip_runtime.h>
+#include <torch/all.h>
+
+#include <cstdint>
+
+// AITER's monolithic moe_c.hip includes a WNA16 header before the W4A8
+// implementation.  Besides WNA16 helpers, that header supplies the generic
+// vector aliases (vec<T, N>, vec_element_8, ... ) consumed by W4A8.  Include
+// it explicitly because this translation unit intentionally instantiates only
+// the W4A8 path.
+// clang-format off: moe_wna16_utils.h defines vec<T, N> for the W4A8 header.
+#include "moe_wna16_utils.h"
+#include "moe_w4a8_opt_hip.h"
+// clang-format on
+
+namespace {
+
+constexpr int64_t kMaskedBlockM = 16;
+
+class AiterHipDeviceGuard {
+ public:
+  explicit AiterHipDeviceGuard(int device) : previous_device_(-1), changed_(false) {
+    TORCH_CHECK(hipGetDevice(&previous_device_) == hipSuccess, "hipGetDevice failed");
+    if (previous_device_ != device) {
+      TORCH_CHECK(hipSetDevice(device) == hipSuccess, "hipSetDevice failed for device ", device);
+      changed_ = true;
+    }
+  }
+
+  ~AiterHipDeviceGuard() {
+    if (changed_) {
+      (void)hipSetDevice(previous_device_);
+    }
+  }
+
+ private:
+  int previous_device_;
+  bool changed_;
+};
+
+__global__ void prepare_deepep_metadata_kernel(
+    const int32_t* __restrict__ m_indices,
+    int32_t* __restrict__ sorted_token_ids,
+    int32_t* __restrict__ block_experts,
+    int32_t* __restrict__ num_tokens_post_pad,
+    uint32_t m,
+    uint32_t block_m) {
+  const uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index < m) {
+    sorted_token_ids[index] = static_cast<int32_t>(index);
+  }
+  if (index < m / block_m) {
+    // DeepEP normal dispatch pads every expert to 256 rows, so a 32-row
+    // or 64-row MMAC tile cannot cross an expert boundary.
+    block_experts[index] = m_indices[index * block_m];
+  }
+  if (index == 0) {
+    *num_tokens_post_pad = static_cast<int32_t>(m);
+  }
+}
+
+// DeepEP low-latency dispatch stores a fixed-capacity [E, T, K] tensor and a
+// device-side valid-row count for every expert.  Compact those already sorted
+// rows into AITER's metadata format without a host synchronization.  A single
+// workgroup is intentional: E <= 256 and it gives us a cheap device prefix
+// sum while remaining CUDA/HIP graph capturable.
+__global__ void prepare_deepep_masked_metadata_kernel(
+    const int32_t* __restrict__ masked_m,
+    int32_t* __restrict__ sorted_token_ids,
+    int32_t* __restrict__ block_experts,
+    int32_t* __restrict__ num_tokens_post_pad,
+    uint32_t num_experts,
+    uint32_t rows_per_expert,
+    uint32_t total_rows,
+    uint32_t metadata_rows) {
+  __shared__ uint32_t block_offsets[257];
+  const uint32_t tid = threadIdx.x;
+
+  for (uint32_t i = tid; i < metadata_rows; i += blockDim.x) {
+    sorted_token_ids[i] = static_cast<int32_t>(total_rows);
+  }
+  for (uint32_t i = tid; i < metadata_rows / kMaskedBlockM; i += blockDim.x) {
+    block_experts[i] = -1;
+  }
+
+  if (tid < num_experts) {
+    const int32_t raw_count = masked_m[tid];
+    const uint32_t count = raw_count <= 0 ? 0U : min(static_cast<uint32_t>(raw_count), rows_per_expert);
+    block_offsets[tid] = (count + kMaskedBlockM - 1) / kMaskedBlockM;
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    uint32_t prefix = 0;
+    for (uint32_t expert = 0; expert < num_experts; ++expert) {
+      const uint32_t blocks = block_offsets[expert];
+      block_offsets[expert] = prefix;
+      prefix += blocks;
+    }
+    block_offsets[num_experts] = prefix;
+    const uint32_t padded_rows = prefix * kMaskedBlockM;
+    *num_tokens_post_pad = padded_rows <= metadata_rows ? static_cast<int32_t>(padded_rows) : 0;
+  }
+  __syncthreads();
+
+  if (tid < num_experts) {
+    const int32_t raw_count = masked_m[tid];
+    const uint32_t count = raw_count <= 0 ? 0U : min(static_cast<uint32_t>(raw_count), rows_per_expert);
+    const uint32_t first_block = block_offsets[tid];
+    const uint32_t last_block = block_offsets[tid + 1];
+    const uint32_t first_row = first_block * kMaskedBlockM;
+    const uint32_t last_row = last_block * kMaskedBlockM;
+    if (last_row <= metadata_rows) {
+      for (uint32_t block = first_block; block < last_block; ++block) {
+        block_experts[block] = static_cast<int32_t>(tid);
+      }
+      for (uint32_t row = 0; row < count; ++row) {
+        sorted_token_ids[first_row + row] = static_cast<int32_t>(tid * rows_per_expert + row);
+      }
+    }
+  }
+}
+
+void launch_w4a8_mmac(
+    const at::Tensor& a,
+    const at::Tensor& a_scale,
+    const at::Tensor& weight,
+    const at::Tensor& weight_scale,
+    const int32_t* sorted_token_ids,
+    const int32_t* block_experts,
+    const int32_t* num_tokens_post_pad,
+    at::Tensor& out,
+    int64_t block_m,
+    uint32_t sorted_token_lens = 0,
+    int64_t kernel_variant = 0) {
+  const auto m = static_cast<uint32_t>(a.size(0));
+  const auto k = static_cast<uint32_t>(a.size(1));
+  const auto n = static_cast<uint32_t>(weight.size(1));
+  constexpr uint32_t kTopK = 1;
+  if (sorted_token_lens == 0) {
+    sorted_token_lens = m;
+  }
+
+  GemmParams_w4a8<char, bhalf_t> params(
+      reinterpret_cast<const char*>(a.data_ptr<int8_t>()),
+      reinterpret_cast<const char*>(weight.data_ptr<int8_t>()),
+      reinterpret_cast<bhalf_t*>(out.data_ptr<at::BFloat16>()),
+      const_cast<float*>(a_scale.data_ptr<float>()),
+      const_cast<float*>(weight_scale.data_ptr<float>()),
+      nullptr,
+      sorted_token_ids,
+      block_experts,
+      0,
+      num_tokens_post_pad,
+      m,
+      n,
+      k,
+      static_cast<uint32_t>(a_scale.stride(0)),
+      a_scale.dim() == 1 ? 0U : static_cast<uint32_t>(a_scale.stride(1)),
+      static_cast<uint32_t>(weight_scale.stride(0)),
+      static_cast<uint32_t>(weight_scale.stride(1)),
+      weight_scale.dim() == 2 ? 0U : static_cast<uint32_t>(weight_scale.stride(2)),
+      sorted_token_lens,
+      kTopK,
+      kTopK,
+      true);
+
+  // Only the three schedules selected by the gfx936 production tuner are
+  // instantiated. This keeps startup compilation and the code object small.
+  switch (kernel_variant) {
+    case 6:
+      TORCH_CHECK(block_m == 16, "decode variant 6 requires BLOCK_M=16");
+      launch_moe_w4a8_first_stage_prefill_GEMM1Nloop<1, 16, 128, 64, 16, 32, 64, 2>(params);
+      return;
+    case 11:
+      TORCH_CHECK(block_m == 32, "prefill variant 11 requires BLOCK_M=32");
+      launch_moe_w4a8_first_stage_prefill_GEMM1Nloop<2, 32, 128, 64, 32, 32, 64, 2>(params);
+      return;
+    case 15:
+      TORCH_CHECK(block_m == 64, "prefill variant 15 requires BLOCK_M=64");
+      launch_moe_w4a8_first_stage_prefill_GEMM1Nloop<4, 64, 128, 64, 64, 32, 64, 2>(params);
+      return;
+    default:
+      TORCH_CHECK(false, "unsupported W4A8 MMAC kernel_variant=", kernel_variant);
+  }
+}
+
+}  // namespace
+
+void w4a8_mmac_contiguous_out_hip(
+    const at::Tensor& a,
+    const at::Tensor& a_scale,
+    const at::Tensor& weight,
+    const at::Tensor& weight_scale,
+    const at::Tensor& m_indices,
+    at::Tensor& workspace,
+    at::Tensor& out,
+    int64_t kernel_variant) {
+  const AiterHipDeviceGuard device_guard(a.get_device());
+  const auto m = static_cast<uint32_t>(a.size(0));
+  if (m == 0) {
+    return;
+  }
+
+  const uint32_t block_m = kernel_variant >= 13 && kernel_variant <= 15 ? 64U : 32U;
+  int32_t* const workspace_ptr = workspace.data_ptr<int32_t>();
+  int32_t* const sorted_token_ids = workspace_ptr;
+  int32_t* const block_experts = sorted_token_ids + m;
+  int32_t* const num_tokens_post_pad = block_experts + m / block_m;
+
+  constexpr uint32_t kThreads = 256;
+  const dim3 grid((m + kThreads - 1) / kThreads);
+  const hipStream_t stream = at::cuda::getCurrentHIPStream();
+  hipLaunchKernelGGL(
+      prepare_deepep_metadata_kernel,
+      grid,
+      dim3(kThreads),
+      0,
+      stream,
+      m_indices.data_ptr<int32_t>(),
+      sorted_token_ids,
+      block_experts,
+      num_tokens_post_pad,
+      m,
+      block_m);
+  auto error = hipGetLastError();
+  TORCH_CHECK(error == hipSuccess, "DeepEP W4A8 metadata setup launch failed: ", hipGetErrorString(error));
+
+  launch_w4a8_mmac(
+      a,
+      a_scale,
+      weight,
+      weight_scale,
+      sorted_token_ids,
+      block_experts,
+      num_tokens_post_pad,
+      out,
+      block_m,
+      0,
+      kernel_variant);
+  error = hipGetLastError();
+  TORCH_CHECK(
+      error == hipSuccess, "AITER-derived W4A8 DeepEP contiguous MMAC launch failed: ", hipGetErrorString(error));
+}
+
+void w4a8_mmac_masked_out_hip(
+    const at::Tensor& a,
+    const at::Tensor& a_scale,
+    const at::Tensor& weight,
+    const at::Tensor& weight_scale,
+    const at::Tensor& masked_m,
+    at::Tensor& workspace,
+    at::Tensor& out,
+    int64_t metadata_rows,
+    int64_t kernel_variant) {
+  const AiterHipDeviceGuard device_guard(a.get_device());
+  const auto num_experts = static_cast<uint32_t>(a.size(0));
+  const auto rows_per_expert = static_cast<uint32_t>(a.size(1));
+  const auto k = a.size(2);
+  const auto total_rows = num_experts * rows_per_expert;
+
+  int32_t* const workspace_ptr = workspace.data_ptr<int32_t>();
+  int32_t* const sorted_token_ids = workspace_ptr;
+  int32_t* const block_experts = sorted_token_ids + metadata_rows;
+  int32_t* const num_tokens_post_pad = block_experts + metadata_rows / kMaskedBlockM;
+
+  const hipStream_t stream = at::cuda::getCurrentHIPStream();
+  hipLaunchKernelGGL(
+      prepare_deepep_masked_metadata_kernel,
+      dim3(1),
+      dim3(256),
+      0,
+      stream,
+      masked_m.data_ptr<int32_t>(),
+      sorted_token_ids,
+      block_experts,
+      num_tokens_post_pad,
+      num_experts,
+      rows_per_expert,
+      total_rows,
+      static_cast<uint32_t>(metadata_rows));
+  auto error = hipGetLastError();
+  TORCH_CHECK(error == hipSuccess, "DeepEP masked W4A8 metadata setup launch failed: ", hipGetErrorString(error));
+
+  auto a_flat = a.view({static_cast<int64_t>(total_rows), k});
+  auto a_scale_flat = a_scale.view({static_cast<int64_t>(total_rows), 1});
+  auto out_flat = out.view({static_cast<int64_t>(total_rows), weight.size(1)});
+  launch_w4a8_mmac(
+      a_flat,
+      a_scale_flat,
+      weight,
+      weight_scale,
+      sorted_token_ids,
+      block_experts,
+      num_tokens_post_pad,
+      out_flat,
+      kMaskedBlockM,
+      static_cast<uint32_t>(metadata_rows),
+      kernel_variant);
+  error = hipGetLastError();
+  TORCH_CHECK(error == hipSuccess, "AITER-derived W4A8 DeepEP masked MMAC launch failed: ", hipGetErrorString(error));
+}

--- a/python/sglang/kernels/jit/csrc/moe/w4a8_deepep_binding.cpp
+++ b/python/sglang/kernels/jit/csrc/moe/w4a8_deepep_binding.cpp
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 gencheng liu
+// SPDX-License-Identifier: Apache-2.0
+
+#include <torch/extension.h>
+
+void w4a8_mmac_contiguous_out_hip(
+    const torch::Tensor& a,
+    const torch::Tensor& a_scale,
+    const torch::Tensor& weight,
+    const torch::Tensor& weight_scale,
+    const torch::Tensor& m_indices,
+    torch::Tensor& workspace,
+    torch::Tensor& out,
+    int64_t kernel_variant);
+
+void w4a8_mmac_masked_out_hip(
+    const torch::Tensor& a,
+    const torch::Tensor& a_scale,
+    const torch::Tensor& weight,
+    const torch::Tensor& weight_scale,
+    const torch::Tensor& masked_m,
+    torch::Tensor& workspace,
+    torch::Tensor& out,
+    int64_t metadata_rows,
+    int64_t kernel_variant);
+
+namespace {
+void w4a8_mmac_contiguous_out(
+    const torch::Tensor& a,
+    const torch::Tensor& a_scale,
+    const torch::Tensor& weight,
+    const torch::Tensor& weight_scale,
+    const torch::Tensor& m_indices,
+    torch::Tensor workspace,
+    torch::Tensor out,
+    int64_t kernel_variant) {
+  TORCH_CHECK(
+      a.is_cuda() && a.scalar_type() == torch::kInt8 && a.dim() == 2 && a.is_contiguous(),
+      "a must be contiguous GPU int8 [M,K]");
+  TORCH_CHECK(
+      a_scale.is_cuda() && a_scale.scalar_type() == torch::kFloat32 && a_scale.is_contiguous() &&
+          a_scale.numel() == a.size(0),
+      "a_scale must contain one contiguous float32 value per row");
+  TORCH_CHECK(
+      weight.is_cuda() && weight.scalar_type() == torch::kInt8 && weight.dim() == 3 && weight.is_contiguous(),
+      "weight must be AITER-shuffled contiguous GPU int8 [E,N,K/2]");
+  TORCH_CHECK(weight.size(2) * 2 == a.size(1), "weight K dimension does not match a");
+  TORCH_CHECK(
+      weight_scale.is_cuda() && weight_scale.scalar_type() == torch::kFloat32 && weight_scale.is_contiguous() &&
+          (weight_scale.dim() == 2 || (weight_scale.dim() == 3 && weight_scale.size(2) == 1)) &&
+          weight_scale.size(0) == weight.size(0) && weight_scale.size(1) == weight.size(1) &&
+          weight_scale.numel() == weight.size(0) * weight.size(1),
+      "weight_scale must be contiguous float32 [E,N] or [E,N,1]");
+  TORCH_CHECK(
+      m_indices.is_cuda() && m_indices.scalar_type() == torch::kInt32 && m_indices.dim() == 1 &&
+          m_indices.is_contiguous() && m_indices.numel() == a.size(0),
+      "m_indices must be contiguous GPU int32 [M]");
+  TORCH_CHECK(a.size(0) % 32 == 0, "M must be divisible by BLOCK_M=32 (DeepEP aligns to 256)");
+  TORCH_CHECK(a.size(1) == 2048 || a.size(1) == 4096, "optimized MMAC kernel supports K=2048 or K=4096");
+  TORCH_CHECK(weight.size(1) % 512 == 0, "optimized MMAC kernel requires N divisible by 512");
+  const auto required_workspace = a.size(0) + a.size(0) / 32 + 1;
+  TORCH_CHECK(
+      workspace.is_cuda() && workspace.scalar_type() == torch::kInt32 && workspace.is_contiguous() &&
+          workspace.numel() >= required_workspace,
+      "workspace must be contiguous GPU int32 with at least ",
+      required_workspace,
+      " elements");
+  TORCH_CHECK(
+      out.is_cuda() && out.scalar_type() == torch::kBFloat16 && out.is_contiguous() && out.dim() == 2 &&
+          out.size(0) == a.size(0) && out.size(1) == weight.size(1),
+      "out must be contiguous GPU bfloat16 [M,N]");
+  TORCH_CHECK(
+      a.device() == a_scale.device() && a.device() == weight.device() && a.device() == weight_scale.device() &&
+          a.device() == m_indices.device() && a.device() == workspace.device() && a.device() == out.device(),
+      "all tensors must be on the same GPU");
+  // Auto-tuned on gfx936/BW1000.  DeepEP-normal pads each active expert to
+  // 256 rows, so M is a stable dispatch key and remains known on the host.
+  const auto resolved_variant =
+      kernel_variant < 0 ? ((a.size(1) == 4096 ? a.size(0) <= 1024 : a.size(0) <= 2048) ? 11 : 15) : kernel_variant;
+  w4a8_mmac_contiguous_out_hip(a, a_scale, weight, weight_scale, m_indices, workspace, out, resolved_variant);
+}
+
+void w4a8_mmac_masked_out(
+    const torch::Tensor& a,
+    const torch::Tensor& a_scale,
+    const torch::Tensor& weight,
+    const torch::Tensor& weight_scale,
+    const torch::Tensor& masked_m,
+    torch::Tensor workspace,
+    torch::Tensor out,
+    int64_t metadata_rows,
+    int64_t kernel_variant) {
+  TORCH_CHECK(
+      a.is_cuda() && a.scalar_type() == torch::kInt8 && a.dim() == 3 && a.is_contiguous(),
+      "a must be contiguous GPU int8 [E,T,K]");
+  const auto experts = a.size(0);
+  const auto rows_per_expert = a.size(1);
+  const auto k = a.size(2);
+  const auto total_rows = experts * rows_per_expert;
+  TORCH_CHECK(experts > 0 && experts <= 256, "masked MMAC supports 1..256 local experts");
+  TORCH_CHECK(
+      rows_per_expert > 0 && rows_per_expert % 16 == 0,
+      "masked MMAC requires a positive DeepEP row capacity divisible by 16");
+  TORCH_CHECK(
+      a_scale.is_cuda() && a_scale.scalar_type() == torch::kFloat32 && a_scale.is_contiguous() &&
+          a_scale.numel() == total_rows,
+      "a_scale must contain one contiguous float32 value per row");
+  TORCH_CHECK(
+      weight.is_cuda() && weight.scalar_type() == torch::kInt8 && weight.dim() == 3 && weight.is_contiguous() &&
+          weight.size(0) == experts && weight.size(2) * 2 == k,
+      "weight must be AITER-shuffled int8 [E,N,K/2]");
+  TORCH_CHECK(
+      weight_scale.is_cuda() && weight_scale.scalar_type() == torch::kFloat32 && weight_scale.is_contiguous() &&
+          (weight_scale.dim() == 2 || (weight_scale.dim() == 3 && weight_scale.size(2) == 1)) &&
+          weight_scale.size(0) == experts && weight_scale.size(1) == weight.size(1) &&
+          weight_scale.numel() == experts * weight.size(1),
+      "weight_scale must be contiguous float32 [E,N] or [E,N,1]");
+  TORCH_CHECK(
+      masked_m.is_cuda() && masked_m.scalar_type() == torch::kInt32 && masked_m.is_contiguous() &&
+          masked_m.numel() == experts,
+      "masked_m must be contiguous GPU int32 [E]");
+  TORCH_CHECK(k == 2048 || k == 4096, "optimized MMAC kernel supports K=2048 or K=4096");
+  TORCH_CHECK(weight.size(1) % 512 == 0, "optimized MMAC kernel requires N divisible by 512");
+  TORCH_CHECK(
+      metadata_rows > 0 && metadata_rows <= total_rows && metadata_rows % 16 == 0,
+      "metadata_rows must be a positive multiple of 16 <= E*T");
+  const auto required_workspace = metadata_rows + metadata_rows / 16 + 1;
+  TORCH_CHECK(
+      workspace.is_cuda() && workspace.scalar_type() == torch::kInt32 && workspace.is_contiguous() &&
+          workspace.numel() >= required_workspace,
+      "workspace must contain at least ",
+      required_workspace,
+      " contiguous GPU int32 elements");
+  TORCH_CHECK(
+      out.is_cuda() && out.scalar_type() == torch::kBFloat16 && out.dim() == 3 && out.is_contiguous() &&
+          out.size(0) == experts && out.size(1) == rows_per_expert && out.size(2) == weight.size(1),
+      "out must be contiguous GPU bfloat16 [E,T,N]");
+  TORCH_CHECK(
+      a.device() == a_scale.device() && a.device() == weight.device() && a.device() == weight_scale.device() &&
+          a.device() == masked_m.device() && a.device() == workspace.device() && a.device() == out.device(),
+      "all tensors must be on the same GPU");
+  // Variant 6 is the verified sparse-decode schedule across 1..48 local
+  // assignments.  Keep an explicit override for the standalone tuner.
+  const auto resolved_variant = kernel_variant < 0 ? 6 : kernel_variant;
+  w4a8_mmac_masked_out_hip(a, a_scale, weight, weight_scale, masked_m, workspace, out, metadata_rows, resolved_variant);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+  module.def(
+      "w4a8_mmac_contiguous_out",
+      &w4a8_mmac_contiguous_out,
+      "W4A8 contiguous grouped GEMM for DeepEP m_indices (gfx936 MMAC)",
+      pybind11::arg("a"),
+      pybind11::arg("a_scale"),
+      pybind11::arg("weight"),
+      pybind11::arg("weight_scale"),
+      pybind11::arg("m_indices"),
+      pybind11::arg("workspace"),
+      pybind11::arg("out"),
+      pybind11::arg("kernel_variant") = -1);
+  module.def(
+      "w4a8_mmac_masked_out",
+      &w4a8_mmac_masked_out,
+      "W4A8 masked grouped GEMM for DeepEP low latency (gfx936 MMAC)",
+      pybind11::arg("a"),
+      pybind11::arg("a_scale"),
+      pybind11::arg("weight"),
+      pybind11::arg("weight_scale"),
+      pybind11::arg("masked_m"),
+      pybind11::arg("workspace"),
+      pybind11::arg("out"),
+      pybind11::arg("metadata_rows"),
+      pybind11::arg("kernel_variant") = -1);
+}

--- a/python/sglang/kernels/ops/moe/w4a8_deepep_aiter.py
+++ b/python/sglang/kernels/ops/moe/w4a8_deepep_aiter.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 gencheng liu
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime-built AITER W4A8 kernels for HCU DeepEP layouts."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from functools import lru_cache
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+import torch
+
+_SOURCE_DIR = Path(__file__).resolve().parents[2] / "jit" / "csrc" / "moe"
+_REQUIRED_AITER_HEADERS = ("moe_w4a8_opt_hip.h", "moe_wna16_utils.h")
+_LOAD_LOCK = Lock()
+
+# Match the options used by AITER's module_moe_c_kernel HCU build. The
+# extended VGPR option is required by the selected decode/N-loop schedules.
+_AITER_HCU_FLAGS = (
+    "-DDTK_ENV",
+    "-DGPU_ENABLE_FP8",
+    "-D__HIP_PLATFORM_HCC__=1",
+    "-U__HIP_NO_HALF_CONVERSIONS__",
+    "-U__HIP_NO_HALF_OPERATORS__",
+    "-Wno-macro-redefined",
+    "-Wno-switch-bool",
+    "-Wno-undefined-func-template",
+    "-Wno-unused-result",
+    "-Wno-vla-cxx-extension",
+    "-fgpu-flush-denormals-to-zero",
+    "-fno-offload-uniform-block",
+    "-mllvm",
+    "-support-768-vgprs=true",
+    "-mllvm",
+    "-disable-machine-sink",
+    "-mllvm",
+    "--amdgpu-kernarg-preload-count=16",
+    "-mllvm",
+    "--lsr-drop-solution=1",
+    "-mllvm",
+    "-amdgpu-coerce-illegal-types=1",
+    "-mllvm",
+    "-amdgpu-early-inline-all=true",
+    "-mllvm",
+    "-amdgpu-function-calls=false",
+    "-mllvm",
+    "-enable-post-misched=0",
+)
+
+
+def _has_required_headers(path: Path) -> bool:
+    return all((path / header).is_file() for header in _REQUIRED_AITER_HEADERS)
+
+
+def _find_aiter_moe_sources() -> Path:
+    override = os.getenv("AITER_MOE_SRC")
+    if override:
+        candidate = Path(override).expanduser().resolve()
+        if _has_required_headers(candidate):
+            return candidate
+        raise FileNotFoundError(
+            f"AITER_MOE_SRC={candidate} does not contain "
+            f"{', '.join(_REQUIRED_AITER_HEADERS)}"
+        )
+
+    spec = importlib.util.find_spec("aiter")
+    if spec is None or spec.origin is None:
+        raise FileNotFoundError(
+            "AITER is required for the HCU W4A8 DeepEP backend. Install the "
+            "HYGON AITER package or set AITER_MOE_SRC to its generated MoE sources."
+        )
+    root = Path(spec.origin).resolve().parent
+    candidates = (
+        root / "jit" / "build" / "module_moe_c_kernel" / "build" / "srcs",
+        root / "jit" / "build" / "module_moe_c_kernel" / "build" / "include",
+    )
+    for candidate in candidates:
+        if _has_required_headers(candidate):
+            return candidate
+    raise FileNotFoundError(
+        "The installed AITER package does not contain generated W4A8 MoE "
+        "headers. Build AITER's module_moe_c_kernel once or set AITER_MOE_SRC."
+    )
+
+
+def _target_arch() -> str:
+    configured = os.getenv("PYTORCH_ROCM_ARCH")
+    if configured:
+        arch = configured.split(";")[0].split(":")[0]
+    elif torch.cuda.is_available():
+        arch = str(torch.cuda.get_device_properties(0).gcnArchName).split(":")[0]
+    else:
+        raise RuntimeError(
+            "No HCU device is visible. Set PYTORCH_ROCM_ARCH when cross-compiling."
+        )
+    if not arch.startswith("gfx"):
+        raise RuntimeError(f"Unexpected HCU architecture name: {arch!r}")
+    return arch
+
+
+@lru_cache(maxsize=1)
+def _load_extension() -> Any:
+    with _LOAD_LOCK:
+        from torch.utils.cpp_extension import load
+
+        compiler = Path(
+            os.getenv("HCU_EXTENSION_COMPILER", "/opt/dtk/bin/aicc")
+        ).expanduser()
+        if not compiler.is_file():
+            raise FileNotFoundError(
+                "The HCU W4A8 kernel requires DTK's AI compiler. Set "
+                f"HCU_EXTENSION_COMPILER; not found at {compiler}."
+            )
+        arch = _target_arch()
+        previous_compiler = os.environ.get("PYTORCH_NVCC")
+        previous_arch = os.environ.get("PYTORCH_ROCM_ARCH")
+        os.environ["PYTORCH_NVCC"] = str(compiler)
+        os.environ["PYTORCH_ROCM_ARCH"] = arch
+        try:
+            return load(
+                name=f"sglang_w4a8_deepep_aiter_{arch}",
+                sources=[
+                    str(_SOURCE_DIR / "w4a8_deepep_binding.cpp"),
+                    str(_SOURCE_DIR / "w4a8_deepep_aiter.hip"),
+                ],
+                extra_cflags=["-O3", "-std=c++17"],
+                extra_cuda_cflags=[
+                    "-O3",
+                    "-std=c++17",
+                    f"--offload-arch={arch}",
+                    *_AITER_HCU_FLAGS,
+                ],
+                extra_include_paths=[str(_find_aiter_moe_sources())],
+                with_cuda=True,
+                verbose=os.getenv("SGLANG_W4A8_JIT_VERBOSE", "0") == "1",
+            )
+        finally:
+            if previous_compiler is None:
+                os.environ.pop("PYTORCH_NVCC", None)
+            else:
+                os.environ["PYTORCH_NVCC"] = previous_compiler
+            if previous_arch is None:
+                os.environ.pop("PYTORCH_ROCM_ARCH", None)
+            else:
+                os.environ["PYTORCH_ROCM_ARCH"] = previous_arch
+
+
+def preload_w4a8_deepep_aiter() -> None:
+    """Compile and load the extension before CUDA graph capture."""
+    _load_extension()
+
+
+def w4a8_mmac_contiguous_out(*args: Any, **kwargs: Any) -> None:
+    _load_extension().w4a8_mmac_contiguous_out(*args, **kwargs)
+
+
+def w4a8_mmac_masked_out(*args: Any, **kwargs: Any) -> None:
+    _load_extension().w4a8_mmac_masked_out(*args, **kwargs)

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -802,7 +802,14 @@ class DeepEPMoE(FusedMoE):
             if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and self.use_fp8_w8a8:
                 output = self.forward_deepgemm_contiguous(dispatch_output)
             elif self.use_w4a8_marlin:
-                output = self.forward_deepgemm_w4a8_marlin_contiguous(dispatch_output)
+                apply_deepep_normal = getattr(
+                    self.quant_method, "apply_deepep_normal", None
+                )
+                output = (
+                    apply_deepep_normal(layer=self, dispatch_output=dispatch_output)
+                    if callable(apply_deepep_normal)
+                    else self.forward_deepgemm_w4a8_marlin_contiguous(dispatch_output)
+                )
             elif self.use_w8a8_marlin:
                 output = self.forward_groupgemm_w8a8_marlin_contiguous(dispatch_output)
             elif self.use_fp8_w8a8:
@@ -825,7 +832,16 @@ class DeepEPMoE(FusedMoE):
             elif self.use_w4afp8:
                 output = self.forward_cutlass_w4afp8_masked(dispatch_output)
             elif self.use_w4a8_marlin:
-                output = self.forward_groupgemm_w4a8_marlin_masked(dispatch_output)
+                apply_deepep_low_latency = getattr(
+                    self.quant_method, "apply_deepep_low_latency", None
+                )
+                output = (
+                    apply_deepep_low_latency(
+                        layer=self, dispatch_output=dispatch_output
+                    )
+                    if callable(apply_deepep_low_latency)
+                    else self.forward_groupgemm_w4a8_marlin_masked(dispatch_output)
+                )
             elif self.use_w8a8_marlin:
                 output = self.forward_groupgemm_w8a8_marlin_masked(dispatch_output)
             elif self.use_fp8_w8a8:

--- a/python/sglang/srt/layers/moe/ep_moe/w4a8_deepep_aiter.py
+++ b/python/sglang/srt/layers/moe/ep_moe/w4a8_deepep_aiter.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 gencheng liu
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepEP glue for the HCU AITER-layout W4A8 grouped GEMM."""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.kernels.ops.moe import w4a8_deepep_aiter as _w4a8
+
+
+@torch.no_grad()
+@torch._dynamo.disable()
+def forward_w4a8_deepep_normal(layer, dispatch_output):
+    # Import lazily: this function is called after ep_moe.layer finished
+    # importing, which avoids a module initialization cycle.
+    from sglang.srt.layers.moe.ep_moe import layer as ep_layer
+
+    (
+        hidden_states,
+        hidden_states_scale,
+        topk_ids,
+        topk_weights,
+        num_recv_tokens_per_expert,
+    ) = dispatch_output
+
+    if num_recv_tokens_per_expert is None:
+        return hidden_states.bfloat16()
+    all_tokens = sum(num_recv_tokens_per_expert)
+    if all_tokens <= 0:
+        return hidden_states.bfloat16()
+    if hidden_states.dtype != torch.int8 or hidden_states_scale is None:
+        raise RuntimeError(
+            "W4A8 DeepEP normal requires int8 dispatch activations and fp32 "
+            "per-token scales"
+        )
+    if any(count % 256 for count in num_recv_tokens_per_expert):
+        raise RuntimeError(
+            "W4A8 MMAC requires DeepEP expert_alignment=256; received counts "
+            f"{num_recv_tokens_per_expert}"
+        )
+
+    _, hidden_size = hidden_states.shape
+    gate_up_size = layer.w13_weight.size(1)
+    device = hidden_states.device
+    a1 = torch.empty((all_tokens, hidden_size), dtype=torch.int8, device=device)
+    a1_scale = torch.empty(
+        (all_tokens, hidden_states_scale.shape[-1]),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    if ep_layer.get_offloader().forbid_copy_engine_usage:
+        counts_gpu = ep_layer.copy_list_to_gpu_no_ce(num_recv_tokens_per_expert)
+    else:
+        counts_gpu = torch.tensor(
+            num_recv_tokens_per_expert,
+            dtype=torch.int32,
+            pin_memory=True,
+            device="cpu",
+        ).cuda(non_blocking=True)
+
+    m_indices, output_index = ep_layer._ep_scatter_with_optional_lightop(
+        hidden_states,
+        hidden_states_scale,
+        topk_ids,
+        counts_gpu,
+        a1,
+        a1_scale,
+        all_tokens,
+        counts_are_aligned=True,
+    )
+
+    # The metadata workspace is tiny (about 4.125 bytes per expert-aligned
+    # row) and can be reused by the two sequential GEMMs on the same stream.
+    workspace = torch.empty(
+        all_tokens + all_tokens // 32 + 1,
+        dtype=torch.int32,
+        device=device,
+    )
+    gate_up = torch.empty(
+        (all_tokens, gate_up_size), dtype=torch.bfloat16, device=device
+    )
+    _w4a8.w4a8_mmac_contiguous_out(
+        a1,
+        a1_scale,
+        layer.w13_weight,
+        layer.w13_weight_scale,
+        m_indices,
+        workspace,
+        gate_up,
+    )
+    del a1, a1_scale
+
+    # DeepSeek-V4 clamps the two SwiGLU halves before activation.  Use the
+    # LightOp fused clamp + SiLU + multiply + dynamic INT8 quantizer when the
+    # model requests it, avoiding two standalone clamp launches.
+    runner_config = getattr(layer, "moe_runner_config", None)
+    swiglu_limit = getattr(runner_config, "swiglu_limit", None)
+    if swiglu_limit is None:
+        a2, a2_scale = ep_layer.fuse_silu_mul_quant(gate_up)
+    else:
+        from lightop.fuse_silu_mul_quant import fuse_silu_mul_clamp_quant
+
+        a2, a2_scale = fuse_silu_mul_clamp_quant(gate_up, float(swiglu_limit))
+    del gate_up
+    down = torch.empty((all_tokens, hidden_size), dtype=torch.bfloat16, device=device)
+    _w4a8.w4a8_mmac_contiguous_out(
+        a2,
+        a2_scale,
+        layer.w2_weight,
+        layer.w2_weight_scale,
+        m_indices,
+        workspace,
+        down,
+    )
+    del a2, a2_scale, workspace
+
+    # Zero initialization preserves the behavior for receive rows whose local
+    # top-k entries are all invalid.
+    gathered = torch.zeros_like(hidden_states, dtype=torch.bfloat16)
+    ep_layer._ep_gather_with_optional_lightop(
+        down, topk_ids, topk_weights, output_index, gathered
+    )
+    return gathered
+
+
+@torch.no_grad()
+@torch._dynamo.disable()
+def forward_w4a8_deepep_low_latency(layer, dispatch_output):
+    """Run W4A8 directly on DeepEP's masked [E,T,K] decode layout."""
+    (
+        hidden_states,
+        hidden_states_scale,
+        _topk_ids,
+        _topk_weights,
+        masked_m,
+        expected_m,
+    ) = dispatch_output
+
+    if hidden_states.dtype != torch.int8 or hidden_states_scale is None:
+        raise RuntimeError(
+            "W4A8 DeepEP low-latency requires int8 dispatch activations "
+            "and fp32 per-token scales"
+        )
+    if hidden_states.dim() != 3:
+        raise RuntimeError(
+            "W4A8 DeepEP low-latency expects hidden_states [E,T,K], got "
+            f"{tuple(hidden_states.shape)}"
+        )
+
+    num_experts, rows_per_expert, hidden_size = hidden_states.shape
+    total_rows = num_experts * rows_per_expert
+    block_m = 16
+
+    # expected_m is derived from the global token/expert ratio.  A safe launch
+    # bound is all globally possible valid rows plus one partial BM tile for
+    # each local expert.  The metadata kernel computes the exact compact list
+    # from masked_m entirely on device, so this does not synchronize the host.
+    runner_config = layer.moe_runner_config
+    global_num_experts = runner_config.num_experts
+    max_valid_rows = max(1, int(expected_m)) * global_num_experts
+    metadata_rows = min(
+        total_rows,
+        max_valid_rows + num_experts * (block_m - 1),
+    )
+    metadata_rows = min(
+        total_rows,
+        ((metadata_rows + block_m - 1) // block_m) * block_m,
+    )
+    workspace = torch.empty(
+        metadata_rows + metadata_rows // block_m + 1,
+        dtype=torch.int32,
+        device=hidden_states.device,
+    )
+
+    gate_up_size = layer.w13_weight.size(1)
+    gate_up = torch.empty(
+        (num_experts, rows_per_expert, gate_up_size),
+        dtype=torch.bfloat16,
+        device=hidden_states.device,
+    )
+    _w4a8.w4a8_mmac_masked_out(
+        hidden_states,
+        hidden_states_scale,
+        layer.w13_weight,
+        layer.w13_weight_scale,
+        masked_m,
+        workspace,
+        gate_up,
+        metadata_rows,
+    )
+
+    swiglu_limit = getattr(runner_config, "swiglu_limit", None)
+    if swiglu_limit is None:
+        from lightop.activation import fuse_silu_mul_quant_ep
+
+        a2, a2_scale = fuse_silu_mul_quant_ep(
+            gate_up, masked_m, expect_m=int(expected_m)
+        )
+    else:
+        from lightop.fuse_silu_mul_quant import fuse_silu_mul_clamp_quant_ep
+
+        a2, a2_scale = fuse_silu_mul_clamp_quant_ep(
+            gate_up,
+            float(swiglu_limit),
+            masked_m,
+            expect_m=int(expected_m),
+        )
+    del gate_up
+
+    down = torch.empty(
+        (num_experts, rows_per_expert, hidden_size),
+        dtype=torch.bfloat16,
+        device=hidden_states.device,
+    )
+    _w4a8.w4a8_mmac_masked_out(
+        a2,
+        a2_scale,
+        layer.w2_weight,
+        layer.w2_weight_scale,
+        masked_m,
+        workspace,
+        down,
+        metadata_rows,
+    )
+    return down

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -646,7 +646,8 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
                 expert_alignment=(
                     256
                     if (
-                        get_global_server_args().quantization == "slimquant_marlin"
+                        get_global_server_args().quantization
+                        in ("slimquant_marlin", "slimquant_w4a8_marlin")
                         or _use_fp8_w8a8_moe
                         or _use_marlin_w16a16_moe
                     )

--- a/python/sglang/srt/layers/quantization/slimquant_w4a8_marlin.py
+++ b/python/sglang/srt/layers/quantization/slimquant_w4a8_marlin.py
@@ -604,6 +604,7 @@ class SlimQuantW4A8Int8AiterMoEMethod:
 
     def __init__(self, quant_config):
         self.quant_config = quant_config
+        self.use_deepep = get_moe_a2a_backend().is_deepep()
 
     def create_weights(
         self,
@@ -662,6 +663,15 @@ class SlimQuantW4A8Int8AiterMoEMethod:
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self.use_deepep:
+            from sglang.kernels.ops.moe.w4a8_deepep_aiter import (
+                preload_w4a8_deepep_aiter,
+            )
+
+            # Compile before graph capture. All ranks share torch's extension
+            # cache and its build lock, so only one process performs the build.
+            preload_w4a8_deepep_aiter()
+
         E = layer.w13_weight.shape[0]
         layer.w13_weight = Parameter(
             repack_and_shuffle_w4a8(layer.w13_weight.data, E), requires_grad=False
@@ -682,6 +692,20 @@ class SlimQuantW4A8Int8AiterMoEMethod:
     ):
         self.moe_runner_config = moe_runner_config
         self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
+
+    def apply_deepep_normal(self, layer: torch.nn.Module, dispatch_output):
+        from sglang.srt.layers.moe.ep_moe.w4a8_deepep_aiter import (
+            forward_w4a8_deepep_normal,
+        )
+
+        return forward_w4a8_deepep_normal(layer, dispatch_output)
+
+    def apply_deepep_low_latency(self, layer: torch.nn.Module, dispatch_output):
+        from sglang.srt.layers.moe.ep_moe.w4a8_deepep_aiter import (
+            forward_w4a8_deepep_low_latency,
+        )
+
+        return forward_w4a8_deepep_low_latency(layer, dispatch_output)
 
     @torch._dynamo.disable()
     def apply(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -101,6 +101,7 @@ def _pre_warm_nccl_help() -> str:
         "for NVIDIA/CUDA (NCCL)."
     )
 
+
 # --------------------------------------------------------------------------
 # Extension points: out-of-tree platforms and plugins extend these lists
 # before ServerArgs is constructed. Each list owns its adder on the line
@@ -170,6 +171,9 @@ QUANTIZATION_CHOICES = [
     "compressed-tensors",  # for Ktransformers
     "modelslim",  # for NPU
     "mxfp_w4a8",  # for NPU W4A8 (MXFP4 weights + MXFP8 activations)
+    "slimquant_w4a8",
+    "slimquant_w4a8_marlin",
+    "slimquant_marlin",
     "quark",  # AMD Quark quantizer (FP8 / MXFP4 / Int4FP8 etc.)
     "quark_int4fp8_moe",
     "quark_mxfp4",  # Online MOE + linear quantization (incl. NVFP4 -> MXFP4 requantization).

--- a/scripts/ci/hcu/hcu_ci_install_dependency.sh
+++ b/scripts/ci/hcu/hcu_ci_install_dependency.sh
@@ -71,6 +71,16 @@ install_with_retry() {
   done
 }
 
+install_eval_dependency() {
+  # The required sampling suite invokes this CLI even in image/wheel mode.
+  # shellcheck source=scripts/ci/utils/sgl_eval_ref.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/../utils/sgl_eval_ref.sh"
+  echo "[hcu-ci] Installing sgl-eval at ${SGL_EVAL_REF}"
+  install_with_retry docker exec "${CONTAINER}" \
+    python3 -m pip install --cache-dir=/sgl-data/pip-cache "${SGL_EVAL_SPEC}"
+  run_in_container "sgl-eval --help >/dev/null"
+}
+
 if [[ "${SKIP_COMPAT_INSTALL}" == "1" || "${SKIP_COMPAT_INSTALL}" == "true" ]]; then
   echo "[hcu-ci] HCU_CI_SKIP_COMPAT_INSTALL=${SKIP_COMPAT_INSTALL}; skipping HCU compatibility pins"
 else
@@ -97,6 +107,7 @@ fi
 
 if [[ "${SKIP_DEPENDENCY_INSTALL}" == "1" || "${SKIP_DEPENDENCY_INSTALL}" == "true" ]]; then
   echo "[hcu-ci] HCU_CI_SKIP_DEPENDENCY_INSTALL=${SKIP_DEPENDENCY_INSTALL}; skipping regular dependency installation"
+  install_eval_dependency
   print_python_status
   exit 0
 fi
@@ -135,6 +146,8 @@ else
   install_with_retry docker exec -w /sglang-checkout "${CONTAINER}" \
     pip install --cache-dir=/sgl-data/pip-cache --no-deps -e "python[srt]"
 fi
+
+install_eval_dependency
 
 echo "[hcu-ci] Installed sglang version:"
 run_in_container "python -c 'import sglang, sys; print(sglang.__version__); sys.exit(0)' || true"

--- a/test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py
+++ b/test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py
@@ -3,6 +3,7 @@
 
 """HCU FP8 per-token-group quantization numeric reference tests."""
 
+import math
 import unittest
 
 import torch
@@ -18,8 +19,6 @@ register_hcu_ci(
     nightly=True,
 )
 register_hcu_ci(est_time=60, suite="stage-b-test-1-hcu-small")
-
-HCU_FP8_QUANT_MAX = 224.0
 
 
 class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
@@ -46,15 +45,22 @@ class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
                     source,
                     group_size=group_size,
                 )
+                # E4M3FN and E4M3FNUZ have different finite ranges.
+                quant_info = torch.finfo(quantized.dtype)
+                quant_max = quant_info.max
+                # Preserve a one-ULP rounding allowance at the largest exponent:
+                # 16 for E4M3FNUZ, 32 for E4M3FN.
+                max_quant_step = math.ldexp(
+                    quant_info.eps, math.frexp(quant_max)[1] - 1
+                )
 
                 grouped = source.float().reshape(tokens, -1, group_size)
                 reference_scales = (
-                    grouped.abs().amax(dim=-1).clamp_min(1e-10)
-                    / HCU_FP8_QUANT_MAX
+                    grouped.abs().amax(dim=-1).clamp_min(1e-10) / quant_max
                 )
                 reference_quantized = (
                     (grouped / reference_scales.unsqueeze(-1))
-                    .clamp(-HCU_FP8_QUANT_MAX, HCU_FP8_QUANT_MAX)
+                    .clamp(-quant_max, quant_max)
                     .to(quantized.dtype)
                     .reshape_as(quantized)
                 )
@@ -65,16 +71,14 @@ class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
                     rtol=1e-4,
                     atol=1e-6,
                 )
-                quant_diff = (
-                    quantized.float() - reference_quantized.float()
-                ).abs()
+                quant_diff = (quantized.float() - reference_quantized.float()).abs()
                 self.assertLess(
                     quant_diff.count_nonzero().item() / quant_diff.numel(),
                     0.005,
                 )
                 self.assertLessEqual(
                     quant_diff.max().item(),
-                    16.0,
+                    max_quant_step,
                 )
 
 

--- a/test/registered/hcu/kernels/test_w4a8_deepep_aiter_hcu.py
+++ b/test/registered/hcu/kernels/test_w4a8_deepep_aiter_hcu.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026 gencheng liu
+# SPDX-License-Identifier: Apache-2.0
+
+"""HCU DeepEP W4A8 MMAC checks against DeepGEMM."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.kernels.ops.moe.w4a8_deepep_aiter import (
+    w4a8_mmac_contiguous_out,
+    w4a8_mmac_masked_out,
+)
+from sglang.srt.layers.quantization.slimquant_w4a8_marlin import (
+    repack_and_shuffle_w4a8,
+)
+from sglang.srt.layers.quantization.w4a8_utils import (
+    weight4bit_nt_kpack2_marlin2_qqq_from_packed_mem_efficient,
+)
+from sglang.test.ci.ci_register import register_hcu_ci
+
+register_hcu_ci(
+    est_time=600,
+    suite="nightly-hcu-core-functional",
+    nightly=True,
+)
+
+
+def _pack_int4(weight: torch.Tensor) -> torch.Tensor:
+    unsigned = weight.to(torch.int16) & 0xF
+    packed = (unsigned[..., 0::2] << 4) | unsigned[..., 1::2]
+    return packed.to(torch.uint8).view(torch.int8)
+
+
+def _make_weights(experts: int, n: int, k: int):
+    logical = torch.randint(-8, 8, (experts, n, k), dtype=torch.int8, device="cuda")
+    checkpoint = _pack_int4(logical)
+    aiter_layout = repack_and_shuffle_w4a8(checkpoint.clone(), experts)
+    deepgemm_layout = weight4bit_nt_kpack2_marlin2_qqq_from_packed_mem_efficient(
+        checkpoint
+    )
+    scales = torch.rand((experts, n, 1), dtype=torch.float32, device="cuda") / 128
+    return aiter_layout, deepgemm_layout, scales
+
+
+class TestHCUW4A8DeepEPAiter(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(20260905)
+
+    def test_contiguous_matches_masked_deepgemm(self):
+        from deepgemm import m_grouped_w4a8_gemm_nt_masked
+
+        experts, rows, n, k = 2, 256, 512, 2048
+        total_rows = experts * rows
+        weight, reference_weight, weight_scale = _make_weights(experts, n, k)
+        activation = torch.randint(
+            -127, 128, (total_rows, k), dtype=torch.int8, device="cuda"
+        )
+        activation_scale = (
+            torch.rand((total_rows, 1), dtype=torch.float32, device="cuda") / 127
+        )
+        m_indices = torch.arange(experts, dtype=torch.int32, device="cuda")
+        m_indices = m_indices.repeat_interleave(rows)
+        workspace = torch.empty(
+            total_rows + total_rows // 32 + 1,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        actual = torch.empty((total_rows, n), dtype=torch.bfloat16, device="cuda")
+        w4a8_mmac_contiguous_out(
+            activation,
+            activation_scale,
+            weight,
+            weight_scale,
+            m_indices,
+            workspace,
+            actual,
+        )
+
+        reference = torch.empty((experts, rows, n), dtype=torch.bfloat16, device="cuda")
+        masked_m = torch.full((experts,), rows, dtype=torch.int32, device="cuda")
+        m_grouped_w4a8_gemm_nt_masked(
+            (
+                activation.view(experts, rows, k),
+                activation_scale.view(experts, rows, 1),
+            ),
+            (reference_weight, weight_scale),
+            reference,
+            masked_m,
+            rows,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            actual, reference.view(total_rows, n), rtol=1e-2, atol=0.25
+        )
+
+    def test_masked_matches_deepgemm_and_replays_graph(self):
+        from deepgemm import m_grouped_w4a8_gemm_nt_masked
+
+        experts, rows, n, k = 4, 32, 512, 2048
+        counts = [0, 1, 17, 31]
+        weight, reference_weight, weight_scale = _make_weights(experts, n, k)
+        activation = torch.randint(
+            -127,
+            128,
+            (experts, rows, k),
+            dtype=torch.int8,
+            device="cuda",
+        )
+        activation_scale = (
+            torch.rand((experts, rows, 1), dtype=torch.float32, device="cuda") / 127
+        )
+        masked_m = torch.tensor(counts, dtype=torch.int32, device="cuda")
+        metadata_rows = experts * rows
+        workspace = torch.empty(
+            metadata_rows + metadata_rows // 16 + 1,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        actual = torch.empty((experts, rows, n), dtype=torch.bfloat16, device="cuda")
+
+        def run_kernel():
+            w4a8_mmac_masked_out(
+                activation,
+                activation_scale,
+                weight,
+                weight_scale,
+                masked_m,
+                workspace,
+                actual,
+                metadata_rows,
+            )
+
+        run_kernel()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run_kernel()
+        graph.replay()
+
+        reference = torch.empty_like(actual)
+        m_grouped_w4a8_gemm_nt_masked(
+            (activation, activation_scale),
+            (reference_weight, weight_scale),
+            reference,
+            masked_m,
+            rows,
+        )
+        torch.cuda.synchronize()
+        actual_valid = torch.cat(
+            [actual[index, :count] for index, count in enumerate(counts) if count]
+        )
+        reference_valid = torch.cat(
+            [reference[index, :count] for index, count in enumerate(counts) if count]
+        )
+        torch.testing.assert_close(actual_valid, reference_valid, rtol=1e-2, atol=0.25)
+
+    def test_deepep_routes_through_quant_method_capabilities(self):
+        from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPLLDispatchOutput,
+            DeepEPNormalDispatchOutput,
+        )
+
+        layer = DeepEPMoE.__new__(DeepEPMoE)
+        torch.nn.Module.__init__(layer)
+        layer.deprecate_flag = False
+        layer.use_fp8_w8a8 = False
+        layer.use_w4afp8 = False
+        layer.use_w4a8_marlin = True
+        layer.quant_config = object()
+
+        normal_result = torch.tensor([1.0], device="cuda")
+        low_latency_result = torch.tensor([2.0], device="cuda")
+        calls = []
+
+        def apply_normal(*, layer, dispatch_output):
+            calls.append(("normal", layer, dispatch_output))
+            return normal_result
+
+        def apply_low_latency(*, layer, dispatch_output):
+            calls.append(("low_latency", layer, dispatch_output))
+            return low_latency_result
+
+        layer.quant_method = SimpleNamespace(
+            apply_deepep_normal=apply_normal,
+            apply_deepep_low_latency=apply_low_latency,
+        )
+        topk_ids = torch.zeros((1, 1), dtype=torch.int64, device="cuda")
+        topk_weights = torch.ones((1, 1), dtype=torch.float32, device="cuda")
+        normal_dispatch = DeepEPNormalDispatchOutput(
+            torch.empty((1, 1), device="cuda"),
+            None,
+            topk_ids,
+            topk_weights,
+            [0],
+        )
+        low_latency_dispatch = DeepEPLLDispatchOutput(
+            torch.empty((1, 1, 1), device="cuda"),
+            None,
+            topk_ids,
+            topk_weights,
+            torch.zeros(1, dtype=torch.int32, device="cuda"),
+            1,
+        )
+
+        self.assertIs(layer.run_moe_core(normal_dispatch).hidden_states, normal_result)
+        self.assertIs(
+            layer.run_moe_core(low_latency_dispatch).hidden_states,
+            low_latency_result,
+        )
+        self.assertEqual([call[0] for call in calls], ["normal", "low_latency"])
+        self.assertTrue(all(call[1] is layer for call in calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/hcu/openai_server/test_serving_chat_hcu.py
+++ b/test/registered/hcu/openai_server/test_serving_chat_hcu.py
@@ -87,6 +87,9 @@ class _MockTokenizerManager:
         self.generate_request = Mock(return_value=_mock_generate())
         self.create_abort_task = Mock()
 
+    def config_value(self, name):
+        return getattr(self.server_args, name)
+
 
 class _MockTemplateManager:
     """Minimal mock for TemplateManager."""
@@ -680,7 +683,9 @@ class ServingChatTestCase(unittest.TestCase):
             tool_calls = payload["choices"][0]["delta"]["tool_calls"]
             self.assertEqual(tool_calls[0]["id"], "functions.get_weather:1")
 
-    @unittest.skip("Current OpenAIServingChat no longer exposes use_dpsk_v32_encoding; skip DeepSeek V3.2-specific unit path in HCU smoke")
+    @unittest.skip(
+        "Current OpenAIServingChat no longer exposes use_dpsk_v32_encoding; skip DeepSeek V3.2-specific unit path in HCU smoke"
+    )
     def test_dpsk_v32_encoding_path(self):
         """Test DeepSeek V3.2 encoding path detection and application."""
         from sglang.srt.managers.template_manager import TemplateManager

--- a/test/registered/quant/test_w4a8_deepep_aiter_loader.py
+++ b/test/registered/quant/test_w4a8_deepep_aiter_loader.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 gencheng liu
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from sglang.kernels.ops.moe import w4a8_deepep_aiter
+
+
+class TestW4A8DeepEPAiterLoader(unittest.TestCase):
+    def tearDown(self):
+        w4a8_deepep_aiter._load_extension.cache_clear()
+
+    def test_aiter_source_override(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for header in w4a8_deepep_aiter._REQUIRED_AITER_HEADERS:
+                (root / header).touch()
+            with patch.dict(os.environ, {"AITER_MOE_SRC": directory}):
+                self.assertEqual(
+                    w4a8_deepep_aiter._find_aiter_moe_sources(), root.resolve()
+                )
+
+    def test_target_arch_uses_first_configured_target(self):
+        with patch.dict(os.environ, {"PYTORCH_ROCM_ARCH": "gfx936:sramecc-;gfx938"}):
+            self.assertEqual(w4a8_deepep_aiter._target_arch(), "gfx936")
+
+    def test_wrappers_delegate_to_loaded_extension(self):
+        extension = Mock()
+        with patch.object(w4a8_deepep_aiter, "_load_extension", return_value=extension):
+            w4a8_deepep_aiter.w4a8_mmac_contiguous_out("normal")
+            w4a8_deepep_aiter.w4a8_mmac_masked_out("masked")
+
+        extension.w4a8_mmac_contiguous_out.assert_called_once_with("normal")
+        extension.w4a8_mmac_masked_out.assert_called_once_with("masked")
+
+    def test_loader_restores_compiler_environment(self):
+        w4a8_deepep_aiter._load_extension.cache_clear()
+        with tempfile.TemporaryDirectory() as directory:
+            compiler = Path(directory) / "aicc"
+            compiler.touch()
+            environment = {
+                "HCU_EXTENSION_COMPILER": str(compiler),
+                "PYTORCH_ROCM_ARCH": "gfx936",
+                "PYTORCH_NVCC": "previous-compiler",
+            }
+            extension = object()
+            with (
+                patch.dict(os.environ, environment),
+                patch.object(
+                    w4a8_deepep_aiter,
+                    "_find_aiter_moe_sources",
+                    return_value=Path(directory),
+                ),
+                patch("torch.utils.cpp_extension.load", return_value=extension) as load,
+            ):
+                self.assertIs(w4a8_deepep_aiter._load_extension(), extension)
+                self.assertEqual(os.environ["PYTORCH_NVCC"], "previous-compiler")
+                self.assertEqual(os.environ["PYTORCH_ROCM_ARCH"], "gfx936")
+
+            self.assertEqual(
+                load.call_args.kwargs["name"], "sglang_w4a8_deepep_aiter_gfx936"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/quant/test_w4a8_deepep_aiter_loader.py
+++ b/test/registered/quant/test_w4a8_deepep_aiter_loader.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from sglang.kernels.ops.moe import w4a8_deepep_aiter
+from sglang.test.ci.ci_register import register_hcu_ci
+
+register_hcu_ci(est_time=20, suite="stage-a-test-1-hcu-small")
 
 
 class TestW4A8DeepEPAiterLoader(unittest.TestCase):

--- a/test/registered/sampling/test_pytorch_sampling_backend.py
+++ b/test/registered/sampling/test_pytorch_sampling_backend.py
@@ -18,7 +18,11 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import is_hip, kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cuda_ci,
+    register_hcu_ci,
+)
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -31,6 +35,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=80, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=66, suite="stage-b-test-1-gpu-small-amd")
+register_hcu_ci(est_time=66, suite="stage-b-test-1-hcu-small")
 
 
 class TestPyTorchSamplingBackend(CustomTestCase):


### PR DESCRIPTION
## Motivation

The HYGON `slimquant_w4a8` checkpoint already loads MoE weights through
`SlimQuantW4A8Int8AiterMoEMethod`, but the AITER-shuffled W4A8 layout had no
in-tree DeepEP normal or low-latency grouped-GEMM path on `main`. The local
prototype proved the path with an externally copied `.so` and unconditional
returns in `DeepEPMoE`; those integration shortcuts are not suitable for
upstream use.

This PR makes that experiment self-contained and preserves the native paths as
fallbacks. It does not include the temporary custom-allreduce logging. It also
keeps this W4A8/DeepEP integration separate from the DSpark decode fast paths
in #314.

This is complementary to #265. That release-branch fix repacks DeepEP weights
to the HIPC/DeepGEMM layout and adjusts scales by 16. This implementation keeps
the existing AITER shuffle and channel scales and executes the AITER MMAC
templates directly against DeepEP layouts.

## Modifications

- Add an in-tree runtime-JIT HCU extension with contiguous and masked W4A8
  grouped-GEMM APIs. It uses the generated AITER MoE headers and DTK `aicc`;
  no prebuilt binary is imported or copied into the package.
- Convert normal `m_indices` and low-latency device-side `masked_m` into AITER
  sorted-token metadata. The masked conversion stays on device and is
  CUDA/HIP Graph capturable.
- Instantiate only the locally tuned gfx936 schedules: BM32/N-loop2 and
  BM64/N-loop4 for normal dispatch, and BM16/N-loop1 for masked decode.
- Prebuild the extension while W4A8 weights are post-processed, before graph
  capture. The cache key contains the detected architecture.
- Route DeepEP through optional quant-method capabilities. Quant methods that
  do not expose these capabilities continue to use the existing implementation.
- Request 256-row normal DeepEP alignment for
  `slimquant_w4a8_marlin` and expose the existing slimquant names through the
  server CLI choices.
- Add loader unit tests and registered HCU kernel/routing tests.

Runtime selection:

```bash
export SGLANG_W4A8_TPMOE_BACKEND=aiter
python -m sglang.launch_server \
  --quantization slimquant_w4a8_marlin \
  --moe-a2a-backend deepep \
  --deepep-mode low_latency \
  ...
```

The default runtime lookup uses AITER's generated
`module_moe_c_kernel/build/srcs` directory and `/opt/dtk/bin/aicc`.
`AITER_MOE_SRC` and `HCU_EXTENSION_COMPILER` are available as explicit
overrides.

## Accuracy Tests

Validated on BW1000 / gfx936 in the HYGON DTK 26.04 SGLang image.

```text
test_w4a8_deepep_aiter_loader.py: 4 passed
test_w4a8_deepep_aiter_hcu.py:    3 passed
```

The HCU suite checks contiguous output against DeepGEMM, irregular/zero-count
masked output against DeepGEMM, graph replay, and `DeepEPMoE` capability
routing.

Full two-GEMM integration checks using the PR module:

```text
normal:      M=1024, E=4, K=4096, I=2048, clamp=true, max_abs_error=0.5
low latency: E=4, T=64, K=4096, I=2048, valid_rows=51,
             BM16_rows=96, clamp=true, graph_replay=true,
             max_abs_error=0.0625
```

Both references use independently packed DeepGEMM W4A8 weights. A DTK 26.04
gfx938 cross-build and extension load also passed. Kernel execution and tuning
on BW1100 still need HYGON's hardware CI; no gfx938 numerical result is claimed
here.

## Speed Tests and Profiling

Single-card BW1000 microbenchmarks include device metadata setup:

| Path | Shape/load | This kernel | DeepGEMM masked |
|---|---:|---:|---:|
| normal gate/up | K=4096, M=4096 | 0.32911 ms | 0.39015 ms |
| normal gate/up | K=4096, M=8192 | 0.60603 ms | 0.80270 ms |
| masked gate/up | E=32, T=2048, 6 assignments | 0.04649 ms | 0.05968 ms |
| masked down | E=32, T=2048, 6 assignments | 0.02869 ms | 0.03764 ms |

On the local DP8 + DP Attention + EP8 service, the graph-enabled tuned path
generated 1024 tokens at 16.627 aggregate tok/s for concurrency 1, and 4096
tokens at 63.302 aggregate tok/s for concurrency 4. Those are end-to-end
combined-configuration measurements, not an isolated kernel speedup claim.

## Checklist

- [x] Format code with the repository-pinned Black, isort, clang-format,
  Ruff checks, and codespell.
- [x] Add loader and registered HCU tests.
- [x] Document runtime dependencies and overrides in code and this PR.
- [x] Provide accuracy and speed results.
- [x] Preserve existing DeepEP fallbacks and avoid hard-coded binary imports.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->