### PR TITLE
[Bugfix][HCU] Restore DeepSeek V4 compressor writes for all cache layouts

### DIFF
--- a/.github/workflows/pr-test-hcu.yml
+++ b/.github/workflows/pr-test-hcu.yml
@@ -661,6 +661,7 @@ jobs:
               --hw hcu \
               --suite stage-a-test-1-hcu-small \
               --include-file registered/hcu/interface/test_hcu_smoke.py \
+              --include-file registered/hcu/kernels/test_dsv4_compressor_dispatch_hcu.py \
               --timeout-per-file 120 \
               ${{ needs.validate-config.outputs.continue_on_error_flag }}
 

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -269,50 +269,31 @@ class CompressorBackendMixin:
             )
             bf16_store = True
         else:
-            out_loc = self._get_out_loc(compressor.ratio)
-            use_fp4_indexer = (
-                compressor.is_in_indexer and self.enable_deepseek_v4_fp4_indexer
-            )
-            bf16_store = (
-                token_to_kv_pool.is_bf16_attention_kv_cache
-                and not compressor.is_in_indexer
-            )
-            if compressor.is_in_indexer:
-                kv_cache = token_to_kv_pool.get_index_k_with_scale_buffer(layer_id)
-                page_size = token_to_kv_pool.get_index_k_page_size()
-            elif is_unified_kv_triton():
-                kv_cache = token_to_kv_pool.get_unified_kv(layer_id)
-                page_size = 1
-                out_loc = getattr(
-                    self.forward_metadata.core_metadata.unified,
-                    f"c{compressor.ratio}_out_loc",
-                )
-                bf16_store = True
-            else:
-                _, _, compress_kv_pool = token_to_kv_pool.layer_mapping[layer_id]
-                assert compress_kv_pool is not None
-                kv_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
-                page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
-                if hasattr(compress_kv_pool, "translate_loc_to_hisparse_device"):
-                    out_loc = compress_kv_pool._translate_loc_to_hisparse_device(
-                        out_loc
-                    )
-            self._forward_compress_all_in_one(
-                kv_score_buffer=state_pool.kv_score_buffer.kv_score,
-                kv_score_input=kv_score_input,
-                ape=compressor.ape,
-                head_dim=compressor.head_dim,
-                norm=compressor.norm,
-                freqs_cis_cache=compressor.freqs_cis,
-                kv_cache=kv_cache.view(dtype=torch.uint8),
-                is_indexer=compressor.is_in_indexer,
-                rotate=compressor.rotate,
-                compress_ratio=compressor.ratio,
-                page_size=page_size,
-                out_loc=out_loc,
-                use_fp4_indexer=use_fp4_indexer,
-                bf16_store=bf16_store,
-            )
+            bf16_store = token_to_kv_pool.is_bf16_attention_kv_cache
+            _, _, compress_kv_pool = token_to_kv_pool.layer_mapping[layer_id]
+            assert compress_kv_pool is not None
+            kv_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
+            page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
+            if hasattr(compress_kv_pool, "translate_loc_to_hisparse_device"):
+                out_loc = compress_kv_pool._translate_loc_to_hisparse_device(out_loc)
+
+        # Cache selection must not bypass the indexer or unified-cache writes.
+        self._forward_compress_all_in_one(
+            kv_score_buffer=state_pool.kv_score_buffer.kv_score,
+            kv_score_input=kv_score_input,
+            ape=compressor.ape,
+            head_dim=compressor.head_dim,
+            norm=compressor.norm,
+            freqs_cis_cache=compressor.freqs_cis,
+            kv_cache=kv_cache.view(dtype=torch.uint8),
+            is_indexer=compressor.is_in_indexer,
+            rotate=compressor.rotate,
+            compress_ratio=compressor.ratio,
+            page_size=page_size,
+            out_loc=out_loc,
+            use_fp4_indexer=use_fp4_indexer,
+            bf16_store=bf16_store,
+        )
         online_c128_mtp = getattr(self, "online_c128_mtp", None)
         if online_c128_mtp is not None:
             online_c128_mtp.write_prefix_states(

--- a/scripts/ci/hcu/hcu_ci_install_dependency.sh
+++ b/scripts/ci/hcu/hcu_ci_install_dependency.sh
@@ -71,6 +71,16 @@ install_with_retry() {
   done
 }
 
+install_eval_dependency() {
+  # The required sampling suite invokes this CLI even in image/wheel mode.
+  # shellcheck source=scripts/ci/utils/sgl_eval_ref.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/../utils/sgl_eval_ref.sh"
+  echo "[hcu-ci] Installing sgl-eval at ${SGL_EVAL_REF}"
+  install_with_retry docker exec "${CONTAINER}" \
+    python3 -m pip install --cache-dir=/sgl-data/pip-cache "${SGL_EVAL_SPEC}"
+  run_in_container "sgl-eval --help >/dev/null"
+}
+
 if [[ "${SKIP_COMPAT_INSTALL}" == "1" || "${SKIP_COMPAT_INSTALL}" == "true" ]]; then
   echo "[hcu-ci] HCU_CI_SKIP_COMPAT_INSTALL=${SKIP_COMPAT_INSTALL}; skipping HCU compatibility pins"
 else
@@ -97,6 +107,7 @@ fi
 
 if [[ "${SKIP_DEPENDENCY_INSTALL}" == "1" || "${SKIP_DEPENDENCY_INSTALL}" == "true" ]]; then
   echo "[hcu-ci] HCU_CI_SKIP_DEPENDENCY_INSTALL=${SKIP_DEPENDENCY_INSTALL}; skipping regular dependency installation"
+  install_eval_dependency
   print_python_status
   exit 0
 fi
@@ -135,6 +146,8 @@ else
   install_with_retry docker exec -w /sglang-checkout "${CONTAINER}" \
     pip install --cache-dir=/sgl-data/pip-cache --no-deps -e "python[srt]"
 fi
+
+install_eval_dependency
 
 echo "[hcu-ci] Installed sglang version:"
 run_in_container "python -c 'import sglang, sys; print(sglang.__version__); sys.exit(0)' || true"

--- a/test/registered/hcu/kernels/test_dsv4_compressor_dispatch_hcu.py
+++ b/test/registered/hcu/kernels/test_dsv4_compressor_dispatch_hcu.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 gencheng liu
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for cache selection and writes in the V4 compressor."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.layers.attention.dsv4.compressor_v2 import CompressorBackendMixin
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_hcu_ci
+
+register_hcu_ci(est_time=30, suite="stage-a-test-1-hcu-small")
+
+
+class TestCompressorDispatch(unittest.TestCase):
+    def make_case(self, *, indexer=False, ratio=4, bf16=False, fp4=False):
+        self.index_cache = torch.zeros(2, 64, 132, dtype=torch.uint8)
+        self.unified_cache = torch.zeros(2, 64, 128, dtype=torch.bfloat16)
+        self.extra_cache = torch.zeros(2, 64, 128, dtype=torch.uint8)
+        self.out_loc = torch.tensor([4, 5])
+        self.unified_loc = torch.tensor([6, 7])
+        self.scores = torch.zeros(8, 512)
+        self.state = torch.zeros(1, 4, 512)
+        self.compress_pool = SimpleNamespace()
+        pool = SimpleNamespace(
+            get_index_k_with_scale_buffer=Mock(return_value=self.index_cache),
+            get_index_k_page_size=Mock(return_value=64),
+            get_unified_kv=Mock(return_value=self.unified_cache),
+            get_extra_key_buffer=Mock(return_value=self.extra_cache),
+            get_extra_key_page_size=Mock(return_value=32),
+            is_bf16_attention_kv_cache=bf16,
+            layer_mapping={3: (0, 0, self.compress_pool)},
+        )
+        self.compressor = SimpleNamespace(
+            ratio=ratio,
+            is_in_indexer=indexer,
+            head_dim=128,
+            rotate=True,
+            compute_kv_score=Mock(return_value=self.scores),
+            get_state_pool=Mock(
+                return_value=SimpleNamespace(
+                    kv_score_buffer=SimpleNamespace(kv_score=self.state)
+                )
+            ),
+            ape=object(),
+            norm=object(),
+            freqs_cis=object(),
+        )
+        self.backend = SimpleNamespace(
+            token_to_kv_pool=pool,
+            enable_deepseek_v4_fp4_indexer=fp4,
+            _get_out_loc=Mock(return_value=self.out_loc),
+            _forward_compress_all_in_one=Mock(),
+            forward_metadata=SimpleNamespace(
+                core_metadata=SimpleNamespace(
+                    unified=SimpleNamespace(**{f"c{ratio}_out_loc": self.unified_loc})
+                )
+            ),
+        )
+
+    def forward(self, *, unified=False, mode=ForwardMode.EXTEND, original_mode=None):
+        batch = SimpleNamespace(forward_mode=mode, _original_forward_mode=original_mode)
+        with patch(
+            "sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate.is_unified_kv_triton",
+            return_value=unified,
+        ):
+            CompressorBackendMixin.forward_unified(
+                self.backend, self.scores, batch, 3, self.compressor
+            )
+        return batch
+
+    def test_cache_layouts_and_forward_modes(self):
+        for mode in (
+            ForwardMode.EXTEND,
+            ForwardMode.DECODE,
+            ForwardMode.TARGET_VERIFY,
+            ForwardMode.DRAFT_EXTEND_V2,
+        ):
+            for layout in ("indexer", "unified", "compressed"):
+                for ratio in ((4,) if layout == "indexer" else (4, 128)):
+                    with self.subTest(mode=mode, layout=layout, ratio=ratio):
+                        self.make_case(indexer=layout == "indexer", ratio=ratio)
+                        self.forward(unified=layout == "unified", mode=mode)
+                        write = self.backend._forward_compress_all_in_one
+                        write.assert_called_once()
+                        args = write.call_args.kwargs
+                        cache, loc, page_size = {
+                            "indexer": (self.index_cache, self.out_loc, 64),
+                            "unified": (self.unified_cache, self.unified_loc, 1),
+                            "compressed": (self.extra_cache, self.out_loc, 32),
+                        }[layout]
+                        self.assertEqual(args["kv_cache"].data_ptr(), cache.data_ptr())
+                        self.assertEqual(args["kv_cache"].dtype, torch.uint8)
+                        self.assertIs(args["out_loc"], loc)
+                        self.assertEqual(args["page_size"], page_size)
+                        self.assertEqual(args["compress_ratio"], ratio)
+                        self.assertEqual(args["head_dim"], 128)
+                        self.assertTrue(args["rotate"])
+                        self.assertEqual(args["is_indexer"], layout == "indexer")
+                        self.assertEqual(args["bf16_store"], layout == "unified")
+                        self.assertFalse(args["use_fp4_indexer"])
+                        self.assertIs(args["kv_score_buffer"], self.state)
+                        self.assertIs(args["kv_score_input"], self.scores)
+                        self.assertIs(args["ape"], self.compressor.ape)
+                        self.assertIs(args["norm"], self.compressor.norm)
+                        self.assertIs(
+                            args["freqs_cis_cache"], self.compressor.freqs_cis
+                        )
+
+    def test_indexer_takes_precedence_over_unified_and_bf16(self):
+        for fp4 in (False, True):
+            with self.subTest(fp4=fp4):
+                self.make_case(indexer=True, bf16=True, fp4=fp4)
+                self.forward(unified=True)
+                write = self.backend._forward_compress_all_in_one
+                write.assert_called_once()
+                args = write.call_args.kwargs
+                self.assertEqual(
+                    args["kv_cache"].data_ptr(), self.index_cache.data_ptr()
+                )
+                self.assertIs(args["out_loc"], self.out_loc)
+                self.assertEqual(args["use_fp4_indexer"], fp4)
+                self.assertFalse(args["bf16_store"])
+                self.backend.token_to_kv_pool.get_unified_kv.assert_not_called()
+
+    def test_compressed_bf16_cache(self):
+        self.make_case(bf16=True, fp4=True)
+        self.forward()
+        write = self.backend._forward_compress_all_in_one
+        write.assert_called_once()
+        self.assertTrue(write.call_args.kwargs["bf16_store"])
+        self.assertFalse(write.call_args.kwargs["use_fp4_indexer"])
+
+    def test_hisparse_address_translation(self):
+        self.make_case()
+        translated = torch.tensor([8, 9])
+        self.compress_pool.translate_loc_to_hisparse_device = Mock()
+        self.compress_pool._translate_loc_to_hisparse_device = Mock(
+            return_value=translated
+        )
+        self.forward()
+        translate = self.compress_pool._translate_loc_to_hisparse_device
+        translate.assert_called_once_with(self.out_loc)
+        write = self.backend._forward_compress_all_in_one
+        write.assert_called_once()
+        self.assertIs(write.call_args.kwargs["out_loc"], translated)
+
+    def test_idle_does_not_compute_or_write(self):
+        self.make_case()
+        self.backend.online_c128_mtp = Mock()
+        self.forward(mode=ForwardMode.IDLE)
+        self.compressor.compute_kv_score.assert_not_called()
+        self.compressor.get_state_pool.assert_not_called()
+        self.backend._get_out_loc.assert_not_called()
+        self.backend._forward_compress_all_in_one.assert_not_called()
+        self.backend.online_c128_mtp.write_prefix_states.assert_not_called()
+
+    def test_online_prefix_states_follow_cache_write(self):
+        for layout in ("indexer", "unified", "compressed"):
+            with self.subTest(layout=layout):
+                self.make_case(indexer=layout == "indexer")
+                calls = Mock()
+                calls.attach_mock(self.backend._forward_compress_all_in_one, "cache")
+                self.backend.online_c128_mtp = SimpleNamespace(
+                    write_prefix_states=calls.prefix
+                )
+                self.forward(
+                    unified=layout == "unified",
+                    mode=ForwardMode.DECODE,
+                    original_mode=ForwardMode.TARGET_VERIFY,
+                )
+                self.assertEqual(
+                    [call[0] for call in calls.mock_calls], ["cache", "prefix"]
+                )
+                calls.prefix.assert_called_once_with(
+                    layer_id=3,
+                    compressor=self.compressor,
+                    kv_score_input=self.scores,
+                    logical_forward_mode=ForwardMode.TARGET_VERIFY,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py
+++ b/test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py
@@ -3,6 +3,7 @@
 
 """HCU FP8 per-token-group quantization numeric reference tests."""
 
+import math
 import unittest
 
 import torch
@@ -18,8 +19,6 @@ register_hcu_ci(
     nightly=True,
 )
 register_hcu_ci(est_time=60, suite="stage-b-test-1-hcu-small")
-
-HCU_FP8_QUANT_MAX = 224.0
 
 
 class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
@@ -46,15 +45,22 @@ class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
                     source,
                     group_size=group_size,
                 )
+                # E4M3FN and E4M3FNUZ have different finite ranges.
+                quant_info = torch.finfo(quantized.dtype)
+                quant_max = quant_info.max
+                # Preserve a one-ULP rounding allowance at the largest exponent:
+                # 16 for E4M3FNUZ, 32 for E4M3FN.
+                max_quant_step = math.ldexp(
+                    quant_info.eps, math.frexp(quant_max)[1] - 1
+                )
 
                 grouped = source.float().reshape(tokens, -1, group_size)
                 reference_scales = (
-                    grouped.abs().amax(dim=-1).clamp_min(1e-10)
-                    / HCU_FP8_QUANT_MAX
+                    grouped.abs().amax(dim=-1).clamp_min(1e-10) / quant_max
                 )
                 reference_quantized = (
                     (grouped / reference_scales.unsqueeze(-1))
-                    .clamp(-HCU_FP8_QUANT_MAX, HCU_FP8_QUANT_MAX)
+                    .clamp(-quant_max, quant_max)
                     .to(quantized.dtype)
                     .reshape_as(quantized)
                 )
@@ -65,16 +71,14 @@ class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
                     rtol=1e-4,
                     atol=1e-6,
                 )
-                quant_diff = (
-                    quantized.float() - reference_quantized.float()
-                ).abs()
+                quant_diff = (quantized.float() - reference_quantized.float()).abs()
                 self.assertLess(
                     quant_diff.count_nonzero().item() / quant_diff.numel(),
                     0.005,
                 )
                 self.assertLessEqual(
                     quant_diff.max().item(),
-                    16.0,
+                    max_quant_step,
                 )
 
 

--- a/test/registered/hcu/openai_server/test_serving_chat_hcu.py
+++ b/test/registered/hcu/openai_server/test_serving_chat_hcu.py
@@ -87,6 +87,9 @@ class _MockTokenizerManager:
         self.generate_request = Mock(return_value=_mock_generate())
         self.create_abort_task = Mock()
 
+    def config_value(self, name):
+        return getattr(self.server_args, name)
+
 
 class _MockTemplateManager:
     """Minimal mock for TemplateManager."""
@@ -680,7 +683,9 @@ class ServingChatTestCase(unittest.TestCase):
             tool_calls = payload["choices"][0]["delta"]["tool_calls"]
             self.assertEqual(tool_calls[0]["id"], "functions.get_weather:1")
 
-    @unittest.skip("Current OpenAIServingChat no longer exposes use_dpsk_v32_encoding; skip DeepSeek V3.2-specific unit path in HCU smoke")
+    @unittest.skip(
+        "Current OpenAIServingChat no longer exposes use_dpsk_v32_encoding; skip DeepSeek V3.2-specific unit path in HCU smoke"
+    )
     def test_dpsk_v32_encoding_path(self):
         """Test DeepSeek V3.2 encoding path detection and application."""
         from sglang.srt.managers.template_manager import TemplateManager

--- a/test/registered/sampling/test_pytorch_sampling_backend.py
+++ b/test/registered/sampling/test_pytorch_sampling_backend.py
@@ -18,7 +18,11 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import is_hip, kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cuda_ci,
+    register_hcu_ci,
+)
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -31,6 +35,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=80, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=66, suite="stage-b-test-1-gpu-small-amd")
+register_hcu_ci(est_time=66, suite="stage-b-test-1-hcu-small")
 
 
 class TestPyTorchSamplingBackend(CustomTestCase):


### PR DESCRIPTION
## Motivation

`CompressorBackendMixin.forward_unified()` selects an indexer cache or a unified KV cache, but its compression/store call is nested inside the ordinary compressed-cache `else` branch. Both earlier branches therefore return without writing the compressed data. The ordinary branch also contains duplicate, unreachable indexer/unified selection.

This is a correctness fix for skipped cache writes, not a quantization or performance change. The bug is present in the current HYGON `main` baseline (`0457572a`). It was found while investigating long-history retrieval failures in a DeepSeek-V4-Flash-0731 W4A8 deployment.

## Modifications

- Select the cache layout once, then execute the shared compression/store call for every non-idle path.
- Preserve indexer precedence, output locations, page sizes, FP4/BF16 flags, HiSparse location translation, and the following online C128 prefix-state update.
- Add registered dispatch regressions and explicitly include them in required HCU Stage A.

The functional fix and tests are isolated in commit `52c2fa05`. This branch also carries two independent CI prerequisite commits already submitted in #314/#316: restore the required sampling registration, install the shared pinned `sgl-eval`, update the FP8 reference for the selected format, and repair the serving-chat configuration mock. Without these prerequisites, the current base fails required Stage B for unrelated reasons. No performance/operator changes from #314/#316 are included. No reasoning-profile or API compatibility changes are included.

## Accuracy Tests

Run against the selected checkout with its `python` directory on `PYTHONPATH`:

```bash
python test/registered/hcu/kernels/test_dsv4_compressor_dispatch_hcu.py -v
```

- Before the compressor fix: 16 failing subcases, including indexer/unified writes called zero times and prefix-state updates occurring without a preceding cache write.
- After the fix: all 6 test methods pass, covering all three layouts; C4/C128 where applicable; extend/decode/target-verify/draft-extend dispatch; indexer precedence; FP4/BF16 flags; HiSparse translation; idle; and cache-before-prefix ordering.
- These are mocked dispatch tests with CPU tensors in an HCU environment, not numerical kernel equivalence tests.
- Earlier local deployment validation with this same runtime fix recorded successful 4K/32K/128K retrieval on four BW1000 GPUs and recovery of the original long-history failures on eight GPUs. Those runs also used local deployment settings and optimizations; no new full-model accuracy or near-256K run was performed for this PR.
- CI prerequisites: FP8 numerical test passed all four shapes on gfx936; serving-chat tests passed (17 methods, one existing skip). The pinned evaluation CLI installed successfully in a disposable deployment-image container and both CLI/MMLU help commands succeeded. Installer control flow was checked for regular, skipped-dependency, wheel, and failure paths. This does not constitute a full MMLU accuracy run.

## Speed Tests and Profiling

No new throughput claim. Skipping a required write is not a valid performance baseline. Existing kernels, quantization and GEMM backends are unchanged.

## Checklist

- [x] Added registered regression tests and required workflow selection.
- [x] Checked formatting, imports, lint, spelling, shell syntax and whitespace.
- [x] Kept the functional fix separate from shared CI prerequisites.
- [ ] Full remote HCU CI result (pending).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->