### PR TITLE
fix(hcu): use available RMSNorm kernel op

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1189,7 +1189,7 @@ class GemmaRMSNorm(BaseFusedOp):
                     )
                     return out, residual_out
             out = torch.empty_like(x)
-            rms_norm(out, x, w, self.variance_epsilon)
+            op.rms_norm_opt(out, x, w, self.variance_epsilon)
             return out
 
     def forward_cpu(


### PR DESCRIPTION
### 问题描述

在 HCU 环境启动 Qwen3.5 MoE 模型时，服务在 CUDA Graph 初始化阶段启动失败。

错误日志如下：

```text
AttributeError: '_OpNamespace' '_C' object has no attribute 'rms_norm'
```

调用链：

```text
GemmaRMSNorm.forward_hip
  -> vllm._custom_ops.rms_norm
  -> torch.ops._C.rms_norm
```

当前 HCU 环境中的 `torch.ops._C` 没有提供 `rms_norm` 算子，导致模型加载完成后，在 CUDA Graph capture 阶段初始化失败，服务无法正常启动。

### 根因分析

HCU 路径复用了 vLLM 的通用 `rms_norm` 接口：

```python
rms_norm(out, x, w, self.variance_epsilon)
```

该接口最终调用：

```python
torch.ops._C.rms_norm
```

但 HCU 后端实际提供的是 SGLang 的优化 RMSNorm 算子 `op.rms_norm_opt`，因此原调用在 HCU 环境下不可用。

### 修改内容

将 HCU 路径中的 RMSNorm 调用替换为当前 HCU 环境可用的算子：

```diff
- rms_norm(out, x, w, self.variance_epsilon)
+ op.rms_norm_opt(out, x, w, self.variance_epsilon)
```

该修改仅影响无 residual 的 Gemma RMSNorm 路径，其他平台和 residual 分支逻辑保持不变。

### 验证结果

已完成以下验证：

- `git diff --check` 通过
- `python -m compileall` 通过
- 确认 `op.rms_norm_opt` 已在当前代码中被使用并可用
- 修复对应启动日志中的实际报错位置

### 影响范围

- 修复 HCU 后端 Gemma RMSNorm 的算子调用
- 解决 Qwen3.5 MoE 模型启动阶段 CUDA Graph 初始化失败问题
- 不改变 CPU、CUDA 及其他 RMSNorm 分支的行为

### 相关提交

`18ecaa4e6 fix(hcu): use available RMSNorm kernel op`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->