### PR TITLE
fix(fst): reclaim device cache after each weight batch

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -1212,6 +1212,10 @@ def fastsafetensors_weights_iterator(
                 fb.close()
         finally:
             loader.close()
+        # Return fully free segments before the next batch can split and pin them.
+        # Keep post-load reclamation for buffers still held by temporary tensors.
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
         if drop_cache_after_load:
             for loaded_file in rank_file_map.get(rank, []):
                 _drop_file_cache_after_load(loaded_file)


### PR DESCRIPTION
## Motivation

Fastsafetensors stages whole checkpoint files in device buffers. After a batch
releases those buffers, allocations for later batches can split the cached
segments and keep them reserved. Reclaiming only after all weights are loaded
can then be too late, reducing the memory available for KV-cache sizing.

## Modifications

Synchronize the current CUDA/HIP device and call `empty_cache()` after each
batch's file buffer and loader have closed, before starting the next batch.
Reclamation is best effort: segments containing live allocations remain reserved.
The existing post-load reclamation remains necessary and is retained.

## Accuracy Tests

- Python compilation, `git diff --check`, isort 7.0.0 and the configured
  Ruff F401/F821/UP037 checks pass.
- Black 26.1.0 reports a pre-existing formatting difference outside this diff.
- Executable code is identical to the device-tested per-batch snapshot.
- Earlier GLM-5.2 TP8/CP8 hardware validation of this change compared two
  independent patched loads with the auto loader: token IDs and text matched on
  3 prompts × 48 tokens, with maximum logprob difference 0. This was a smoke test
  on the deployed code, not a full accuracy benchmark of this checkout.
- Single-device testing during this review used the branch's actual iterator and
  expert-backup function bodies with real torch/fastsafetensors operations and
  synthetic 16 MiB checkpoint shards. It identified the compatibility limitation
  below; it does not constitute a passing full-server expert-backup test.

## Speed Tests and Profiling

Earlier GLM-5.2 TP8/CP8 validation on DCU:

| Measurement | Fastsafetensors baseline | Per-batch reclamation |
|---|---:|---:|
| KV token capacity | 111,552 | 269,568 |
| Available memory across ranks | 28.57–34.56 GiB | 34.70–34.74 GiB |
| Weight loading time | About 72.5 s | 68.49–69.53 s across two runs |

These measurements are from prior deployment experiments; this review did not
rerun the full GLM-5.2 benchmark.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->