### PR TITLE
feat(dsv4,hcu): support BF16/FP8 and INT8/INT8 indexer paths on gfx936

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/fused_norm_rope_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/fused_norm_rope_v2.cuh
@@ -64,7 +64,8 @@ enum class ForwardMode : bool {
 // Each warp's 32 lanes cover the full 128-elem head_dim (kVecSize = 4 each).
 // Cache layout: 132 bytes/token (128 fp8 nope + 4 fp32 scale).
 // ----------------------------------------------------------------------------
-template <typename DType, ForwardMode kMode, int32_t kPageBits, bool kUsePDL, int32_t kPreshuffleSize = 0>
+template <typename DType, ForwardMode kMode, int32_t kPageBits, bool kUsePDL,
+          int32_t kPreshuffleSize = 0, bool kInt8Store = false>
 INDEXER_KERNEL void fused_norm_rope_indexer(const __grid_constant__ FusedNormRopeStoreParams params) {
   using namespace device;
   using enum ForwardMode;
@@ -191,10 +192,39 @@ INDEXER_KERNEL void fused_norm_rope_indexer(const __grid_constant__ FusedNormRop
       data[i] *= kHadamardScale;
   }
 
-  // part 4: per-warp UE8M0 quant + store. The whole warp emits one fp8 group
-  // (= 128 elements) plus a single fp32 scale, matching the indexer cache
-  // layout (`fused_store_indexer_cache`).
-  {
+  if constexpr (kInt8Store) {
+    static_assert(kPreshuffleSize == 0, "INT8 cache uses the unshuffled paged layout");
+    // Preserve set_index_int8's BF16 rounding before per-token INT8 quantization.
+    // The original plan checks above also guard INT8 stores: invalid prefill
+    // rows and non-boundary decode rows return without touching the cache.
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      data[i] = cast<float>(cast<bf16_t>(data[i]));
+    }
+    float local_max = math::abs(data[0]);
+#pragma unroll
+    for (int i = 1; i < kVecSize; ++i) {
+      local_max = math::max(local_max, math::abs(data[i]));
+    }
+    // INDEX_K_EPSILON in hcu_int8_index_k_cache.py is 1e-6.
+    const float scale = fmaxf(1e-6f, warp::reduce_max(local_max)) / 127.0f;
+    AlignedVector<int8_t, kVecSize> result;
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      const float scaled = data[i] / scale;
+      const float rounded = scaled >= 0.0f ? floorf(scaled + 0.5f) : ceilf(scaled - 0.5f);
+      result[i] = static_cast<int8_t>(fminf(127.0f, fmaxf(-127.0f, rounded)));
+    }
+    const int64_t page = out_loc >> kPageBits;
+    const int64_t offset = out_loc & ((1 << kPageBits) - 1);
+    const auto page_ptr = params.kvcache + page * kPageBytes;
+    PDLTriggerSecondary<kUsePDL>();
+    result.store(page_ptr + offset * 128, lane_id);
+    if (lane_id == 0) {
+      *reinterpret_cast<float*>(page_ptr + (128 << kPageBits) + offset * 4) = scale;
+    }
+  } else {
+    // FP8 group (= 128 elements) plus one FP32 scale, matching the packed cache.
     using OutStorage = AlignedVector<fp8x2_e4m3_t, 2>;
     float local_max = math::abs(data[0]);
 #pragma unroll
@@ -518,11 +548,13 @@ template <
     uint32_t kPageSize,
     bool kUsePDL,
     int32_t kPreshuffleSize = 0,
-    bool kBf16Store = false>
+    bool kBf16Store = false,
+    bool kInt8Store = false>
 struct FusedNormRopeKernel {
   static constexpr int32_t kLogPageSize = std::countr_zero(kPageSize);
   static constexpr bool kIsIndexer = (kHeadDim == 128);
   static_assert(!(kIsIndexer && kBf16Store), "bf16 store only for flashmla head_dim=512");
+  static_assert(!kInt8Store || (kIsIndexer && !kBf16Store), "INT8 store only for indexer head_dim=128");
   static constexpr int64_t kIndexerBytes = 132 * kPageSize;
   static constexpr int64_t kFlashMLABytes = host::div_ceil(584 * kPageSize, 576) * 576;
   static constexpr int64_t kBf16Bytes = kHeadDim * 2 * kPageSize;  // plain bf16 cache
@@ -535,7 +567,7 @@ struct FusedNormRopeKernel {
   template <ForwardMode kMode>
   static constexpr auto select_kernel() {
     if constexpr (kIsIndexer) {
-      return fused_norm_rope_indexer<DType, kMode, kLogPageSize, kUsePDL, kPreshuffleSize>;
+      return fused_norm_rope_indexer<DType, kMode, kLogPageSize, kUsePDL, kPreshuffleSize, kInt8Store>;
     } else {
       return fused_norm_rope_flashmla<DType, kMode, kLogPageSize, kUsePDL, kBf16Store>;
     }

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/main_norm_rope.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/main_norm_rope.cuh
@@ -18,6 +18,7 @@
 
 #include <bit>
 #include <cstdint>
+#include <type_traits>
 
 namespace sglang {
 
@@ -445,10 +446,10 @@ struct FusedKNormRopeFlashMLAKernel {
 
 struct FusedQIndexerRopeHadamardQuantParams {
   const void* __restrict__ q_input;  // (B, num_heads, 128) DType
-  void* __restrict__ q_fp8;          // (B, num_heads, 128) fp8_e4m3
+  void* __restrict__ q_output;       // (B, num_heads, 128) FP8 or unquantized DType
   // weights_out[b, h] = weight[b, h] * weight_scale * q_scale[b, h].
-  // q_scale is computed internally and not exposed -- the only consumer of
-  // it is `weights_out`.
+  // Quantized output folds q_scale into weights_out. Unquantized output
+  // uses q_scale=1 and writes weight * weight_scale.
   const void* __restrict__ weight;  // (B, num_heads) DType
   float* __restrict__ weights_out;  // (B, num_heads) fp32 (== (B, H, 1) flat)
   float weight_scale;               // scalar c4_indexer.weight_scale
@@ -463,7 +464,8 @@ struct FusedQIndexerRopeHadamardQuantParams {
   uint32_t num_heads;
 };
 
-template <typename DType, typename PosT, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true>
+template <typename DType, typename PosT, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true,
+          bool kQuantize = true>
 Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQIndexerRopeHadamardQuantParams params) {
   using namespace device;
 
@@ -574,7 +576,20 @@ Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQ
       data[i] *= kHadamardScale;
   }
 
-  {
+  if constexpr (!kQuantize) {
+    // Keep the same FP32 RoPE/Hadamard arithmetic, then materialize BF16 Q.
+    // There is no Q quantization scale to fold into the head weight.
+    Storage result;
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      result[i] = cast<DType>(data[i]);
+    }
+    auto out_row = static_cast<DType*>(params.q_output) + work_id * kHeadDim;
+    result.store(out_row, lane_id);
+    if (lane_id == 0) {
+      params.weights_out[work_id] = weight_val * params.weight_scale;
+    }
+  } else {
     float local_max = math::abs(data[0]);
 #pragma unroll
     for (int i = 1; i < kVecSize; ++i) {
@@ -588,20 +603,22 @@ Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQ
     result[1] = pack_fp8(data[2] * inv_scale, data[3] * inv_scale);
 
     // q_fp8 row pointer: 128 fp8 / row = 32 OutStorage / row, one per lane.
-    auto out_row = static_cast<uint8_t*>(params.q_fp8) + work_id * kHeadDim;
+    auto out_row = static_cast<uint8_t*>(params.q_output) + work_id * kHeadDim;
     result.store(out_row, lane_id);
     params.weights_out[work_id] = weight_val * params.weight_scale * scale;
   }
 }
 
-template <typename DType, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true>
+template <typename DType, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true,
+          bool kQuantize = true>
 struct FusedQIndexerRopeHadamardQuantKernel {
   template <typename PosT>
-  static constexpr auto kernel = fused_q_indexer_rope_hadamard_quant<DType, PosT, kUsePDL, kRopeFirst, kHadamard>;
+  static constexpr auto kernel =
+      fused_q_indexer_rope_hadamard_quant<DType, PosT, kUsePDL, kRopeFirst, kHadamard, kQuantize>;
 
   static void forward(
       const tvm::ffi::TensorView q_input,
-      const tvm::ffi::TensorView q_fp8,
+      const tvm::ffi::TensorView q_output,
       const tvm::ffi::TensorView weight,
       const tvm::ffi::TensorView weights_out,
       double weight_scale,
@@ -617,7 +634,7 @@ struct FusedQIndexerRopeHadamardQuantKernel {
     device_.set_options<kDLCUDA>();
 
     // Caller path is `wq_b(q_lora).view(-1, H, D)` -> contiguous; the kernel
-    // assumes a flat `(B*H, kHeadDim)` layout for both q_input and q_fp8.
+    // assumes a flat `(B*H, kHeadDim)` layout for both q_input and q_output.
     // Pin the head/innermost strides; assert the batch stride below.
     TensorMatcher({B, H, kHeadDim})  //
         .with_strides({-1, kHeadDim, 1})
@@ -626,9 +643,9 @@ struct FusedQIndexerRopeHadamardQuantKernel {
         .verify(q_input);
     TensorMatcher({B, H, kHeadDim})  //
         .with_strides({-1, kHeadDim, 1})
-        .with_dtype<uint8_t>()
+        .with_dtype<std::conditional_t<kQuantize, uint8_t, DType>>()
         .with_device(device_)
-        .verify(q_fp8);
+        .verify(q_output);
     TensorMatcher({B, H})  //
         .with_strides({-1, 1})
         .with_dtype<DType>()
@@ -660,13 +677,13 @@ struct FusedQIndexerRopeHadamardQuantKernel {
         "q_input must be contiguous (B, H, kHeadDim); got stride[0]=",
         q_input.stride(0));
     RuntimeCheck(
-        q_fp8.stride(0) == expected_batch_stride,
-        "q_fp8 must be contiguous (B, H, kHeadDim); got stride[0]=",
-        q_fp8.stride(0));
+        q_output.stride(0) == expected_batch_stride,
+        "q_output must be contiguous (B, H, kHeadDim); got stride[0]=",
+        q_output.stride(0));
 
     const auto params = FusedQIndexerRopeHadamardQuantParams{
         .q_input = q_input.data_ptr(),
-        .q_fp8 = q_fp8.data_ptr(),
+        .q_output = q_output.data_ptr(),
         .weight = weight.data_ptr(),
         .weights_out = static_cast<float*>(weights_out.data_ptr()),
         .weight_scale = static_cast<float>(weight_scale),

--- a/python/sglang/kernels/ops/attention/dsv4/__init__.py
+++ b/python/sglang/kernels/ops/attention/dsv4/__init__.py
@@ -17,6 +17,7 @@ from .compress_old import fused_norm_rope_inplace
 from .elementwise import (
     fused_k_norm_rope_flashmla,
     fused_q_indexer_rope_first_quant,
+    fused_q_indexer_rope_hadamard,
     fused_q_indexer_rope_hadamard_fp4_quant,
     fused_q_indexer_rope_hadamard_quant,
     fused_q_norm_rope,
@@ -46,6 +47,7 @@ __all__ = [
     "fused_rope_inplace",
     "fused_q_norm_rope",
     "fused_q_indexer_rope_first_quant",
+    "fused_q_indexer_rope_hadamard",
     "fused_q_indexer_rope_hadamard_fp4_quant",
     "fused_q_indexer_rope_hadamard_quant",
     "fused_k_norm_rope_flashmla",

--- a/python/sglang/kernels/ops/attention/dsv4/compress.py
+++ b/python/sglang/kernels/ops/attention/dsv4/compress.py
@@ -64,6 +64,7 @@ def _jit_compress_norm_rope_module(
     rope_dim: int,
     page_size: int,
     bf16_store: bool = False,
+    int8_store: bool = False,
 ) -> Module:
     args = make_cpp_args(
         dtype,
@@ -73,9 +74,10 @@ def _jit_compress_norm_rope_module(
         is_arch_support_pdl(),
         INDEXER_K_CACHE_PRESHUFFLE_TILE if aiter_can_use_preshuffle_paged_mqa() else 0,
         bf16_store,
+        int8_store,
     )
     cuda_wrappers = [("forward", f"FusedNormRopeKernel<{args}>::forward")]
-    if head_dim == 128:
+    if head_dim == 128 and not int8_store:
         cuda_wrappers.append(
             ("forward_fp4", f"FusedNormRopeKernel<{args}>::forward_fp4")
         )
@@ -483,7 +485,10 @@ def compress_norm_rope_store(
     page_size: int,
     use_fp4: bool = False,
     bf16_store: bool = False,
+    int8_store: bool = False,
 ) -> None:
+    if int8_store and (kv.shape[-1] != 128 or use_fp4 or bf16_store or _is_xpu):
+        raise ValueError("INT8 compressed store requires a non-FP4 C4 indexer")
     if use_fp4:
         assert kv.shape[-1] == 128
     freq_cis = torch.view_as_real(freq_cis).flatten(-2)
@@ -503,7 +508,8 @@ def compress_norm_rope_store(
         )
     else:
         module = _jit_compress_norm_rope_module(
-            kv.dtype, kv.shape[-1], freq_cis.shape[-1], page_size, bf16_store
+            kv.dtype, kv.shape[-1], freq_cis.shape[-1], page_size, bf16_store,
+            int8_store,
         )
         fn = module.forward_fp4 if use_fp4 else module.forward
         fn(

--- a/python/sglang/kernels/ops/attention/dsv4/elementwise.py
+++ b/python/sglang/kernels/ops/attention/dsv4/elementwise.py
@@ -99,6 +99,19 @@ def _jit_main_q_indexer_rope_first_quant_module(dtype: torch.dtype):
 
 
 @cache_once
+def _jit_main_q_indexer_rope_hadamard_module(dtype: torch.dtype):
+    args = make_cpp_args(dtype, is_arch_support_pdl(), False, True, False)
+    return load_jit(
+        make_name("main_q_indexer_rope_hadamard_bf16"),
+        *args,
+        cuda_files=["deepseek_v4/main_norm_rope.cuh"],
+        cuda_wrappers=[
+            ("forward", f"FusedQIndexerRopeHadamardQuantKernel<{args}>::forward"),
+        ],
+    )
+
+
+@cache_once
 def _jit_main_q_indexer_rope_hadamard_fp4_quant_module(dtype: torch.dtype):
     args = make_cpp_args(dtype, is_arch_support_pdl())
     return load_jit(
@@ -157,6 +170,37 @@ def fused_q_norm_rope(
     else:
         module = _jit_main_q_norm_rope_module(q_input.dtype, head_dim, rope_dim)
         module.forward(q_input, q_output, freqs_real, positions, eps)
+
+
+def fused_q_indexer_rope_hadamard(
+    q_input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: float,
+    freqs_cis: torch.Tensor,
+    positions: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return BF16 C4 Q and FP32 head weights without Q quantization.
+
+    RoPE and normalized Hadamard retain the FP32 arithmetic of the FP8
+    kernel. Only the output changes: BF16 Q and weight * weight_scale.
+    """
+    if q_input.dtype != torch.bfloat16:
+        raise ValueError("unquantized C4 indexer Q requires BF16 input")
+    q_output = torch.empty_like(q_input, memory_format=torch.contiguous_format)
+    weights_out = torch.empty(
+        (*q_input.shape[:-1], 1), dtype=torch.float32, device=q_input.device
+    )
+    module = _jit_main_q_indexer_rope_hadamard_module(q_input.dtype)
+    module.forward(
+        q_input,
+        q_output,
+        weight,
+        weights_out,
+        float(weight_scale),
+        torch.view_as_real(freqs_cis).flatten(-2),
+        positions,
+    )
+    return q_output, weights_out
 
 
 def fused_q_indexer_rope_hadamard_quant(

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -196,6 +196,7 @@ class CompressorBackendMixin:
         out_loc: torch.Tensor,
         use_fp4_indexer: bool = False,
         bf16_store: bool = False,
+        int8_store: bool = False,
     ) -> None:
         assert compress_ratio == 4 or compress_ratio == 128
         assert rotate == is_indexer == (head_dim == 128)
@@ -237,6 +238,7 @@ class CompressorBackendMixin:
             page_size=page_size,
             use_fp4=use_fp4_indexer,
             bf16_store=bf16_store,
+            int8_store=int8_store,
         )
 
     def forward_unified(
@@ -271,7 +273,10 @@ class CompressorBackendMixin:
         use_fp4_indexer = (
             compressor.is_in_indexer and self.enable_deepseek_v4_fp4_indexer
         )
-        bf16_store = False
+        bf16_store = (
+            token_to_kv_pool.is_bf16_attention_kv_cache
+            and not compressor.is_in_indexer
+        )
         if compressor.is_in_indexer:
             kv_cache = token_to_kv_pool.get_index_k_with_scale_buffer(layer_id)
             page_size = token_to_kv_pool.get_index_k_page_size()
@@ -284,50 +289,35 @@ class CompressorBackendMixin:
             )
             bf16_store = True
         else:
-            out_loc = self._get_out_loc(compressor.ratio)
-            use_fp4_indexer = (
-                compressor.is_in_indexer and self.enable_deepseek_v4_fp4_indexer
-            )
-            bf16_store = (
-                token_to_kv_pool.is_bf16_attention_kv_cache
-                and not compressor.is_in_indexer
-            )
-            if compressor.is_in_indexer:
-                kv_cache = token_to_kv_pool.get_index_k_with_scale_buffer(layer_id)
-                page_size = token_to_kv_pool.get_index_k_page_size()
-            elif is_unified_kv_triton():
-                kv_cache = token_to_kv_pool.get_unified_kv(layer_id)
-                page_size = 1
-                out_loc = getattr(
-                    self.forward_metadata.core_metadata.unified,
-                    f"c{compressor.ratio}_out_loc",
+            _, _, compress_kv_pool = token_to_kv_pool.layer_mapping[layer_id]
+            assert compress_kv_pool is not None
+            kv_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
+            page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
+            if hasattr(compress_kv_pool, "translate_loc_to_hisparse_device"):
+                out_loc = compress_kv_pool._translate_loc_to_hisparse_device(
+                    out_loc
                 )
-                bf16_store = True
-            else:
-                _, _, compress_kv_pool = token_to_kv_pool.layer_mapping[layer_id]
-                assert compress_kv_pool is not None
-                kv_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
-                page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
-                if hasattr(compress_kv_pool, "translate_loc_to_hisparse_device"):
-                    out_loc = compress_kv_pool._translate_loc_to_hisparse_device(
-                        out_loc
-                    )
-            self._forward_compress_all_in_one(
-                kv_score_buffer=state_pool.kv_score_buffer.kv_score,
-                kv_score_input=kv_score_input,
-                ape=compressor.ape,
-                head_dim=compressor.head_dim,
-                norm=compressor.norm,
-                freqs_cis_cache=compressor.freqs_cis,
-                kv_cache=kv_cache.view(dtype=torch.uint8),
-                is_indexer=compressor.is_in_indexer,
-                rotate=compressor.rotate,
-                compress_ratio=compressor.ratio,
-                page_size=page_size,
-                out_loc=out_loc,
-                use_fp4_indexer=use_fp4_indexer,
-                bf16_store=bf16_store,
-            )
+        # All cache modes must execute compression and store. Select the
+        # Indexer encoding without changing the native plan validity checks.
+        self._forward_compress_all_in_one(
+            kv_score_buffer=state_pool.kv_score_buffer.kv_score,
+            kv_score_input=kv_score_input,
+            ape=compressor.ape,
+            head_dim=compressor.head_dim,
+            norm=compressor.norm,
+            freqs_cis_cache=compressor.freqs_cis,
+            kv_cache=kv_cache.view(dtype=torch.uint8),
+            is_indexer=compressor.is_in_indexer,
+            rotate=compressor.rotate,
+            compress_ratio=compressor.ratio,
+            page_size=page_size,
+            out_loc=out_loc,
+            use_fp4_indexer=use_fp4_indexer,
+            bf16_store=bf16_store,
+            int8_store=(
+                compressor.is_in_indexer and token_to_kv_pool.use_int8_index_k_cache
+            ),
+        )
         online_c128_mtp = getattr(self, "online_c128_mtp", None)
         if online_c128_mtp is not None:
             online_c128_mtp.write_prefix_states(

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -18,6 +18,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from sglang.kernels.ops.attention.dsv4 import (
+    fused_q_indexer_rope_hadamard,
     fused_q_indexer_rope_hadamard_fp4_quant,
     fused_q_indexer_rope_hadamard_quant,
     topk_transform_512,
@@ -798,7 +799,7 @@ class C4IndexerBackendMixin:
             )
         else:
             if use_int8_index_k_cache:
-                from lightop.quant import per_token_dynamic_quant_int8
+                from lightop.quant import per_token_quant_int8
 
                 packed_cache = token_to_kv_pool.get_index_k_int8_packed_buffer(
                     layer_id=c4_indexer.layer_id,
@@ -814,25 +815,12 @@ class C4IndexerBackendMixin:
                 # and fold its scale into the existing per-head weight:
                 #   relu((Qi8 * Qs) dot (Ki8 * Ks)) * W
                 # = relu(Qi8 dot Ki8) * (W * Qs) * Ks.
-                q_bf16 = q.to(torch.bfloat16).contiguous()
+                # gfx936 produces BF16 Q directly after RoPE/Hadamard.
+                # Other HCU architectures retain their existing FP8 route.
+                q_bf16 = q if q.dtype == torch.bfloat16 else q.to(torch.bfloat16)
+                q_bf16 = q_bf16.contiguous()
                 q_flat = q_bf16.view(-1, q_bf16.shape[-1])
-                smooth_scale = getattr(
-                    self, "_dsv4_int8_query_smooth_scale", None
-                )
-                if (
-                    smooth_scale is None
-                    or smooth_scale.device != q.device
-                    or smooth_scale.shape[0] != q_bf16.shape[-1]
-                ):
-                    smooth_scale = torch.ones(
-                        q_bf16.shape[-1],
-                        dtype=torch.float32,
-                        device=q.device,
-                    )
-                    self._dsv4_int8_query_smooth_scale = smooth_scale
-                q_int8, q_scales = per_token_dynamic_quant_int8(
-                    q_flat, smooth_scale
-                )
+                q_int8, q_scales = per_token_quant_int8(q_flat)
                 q_int8 = q_int8.view_as(q_bf16)
                 adjusted_weights = (
                     weights.to(torch.float32)
@@ -863,13 +851,26 @@ class C4IndexerBackendMixin:
                     1,
                     head_dim_with_sf,
                 )
+                # LightOp's dense paged ABI takes [B] int32 lengths and
+                # int32 block tables, with no DeepGEMM scheduler metadata.
+                use_lightop = _is_hcu and not (
+                    use_fp4_indexer or _use_tilelang or _use_aiter
+                )
                 logits = fn(
                     q,
                     c4_indexer_kv_cache,
                     weights,
-                    _c4sl,
-                    page_table,
-                    indexer_metadata.deep_gemm_metadata,
+                    (
+                        _c4sl.reshape(-1).to(torch.int32).contiguous()
+                        if use_lightop
+                        else _c4sl
+                    ),
+                    (
+                        page_table.to(torch.int32).contiguous()
+                        if use_lightop
+                        else page_table
+                    ),
+                    None if use_lightop else indexer_metadata.deep_gemm_metadata,
                     indexer_metadata.max_c4_seq_len,
                     False,
                 )
@@ -1043,6 +1044,16 @@ class C4Indexer(nn.Module):
         self.weight_scale: float = self.softmax_scale * self.n_heads**-0.5
 
         self.use_fp4_indexer = get_exec().kernel.enable_deepseek_v4_fp4_indexer
+        # Only gfx936 defaults to BF16 Q for LightOp's FP8-cache path.
+        # Enabling INT8 cache quantizes this BF16 Q at the consumer boundary.
+        self.use_bf16_indexer_q = (
+            _is_hcu
+            and not self.use_fp4_indexer
+            and torch.cuda.get_device_properties().gcnArchName.split(":")[0]
+            == "gfx936"
+        )
+        if self.use_bf16_indexer_q and envs.SGLANG_OPT_USE_TILELANG_INDEXER.get():
+            raise ValueError("gfx936 BF16 C4 indexer Q requires the LightOp backend")
         self.alt_streams = alt_streams
 
     def compute_q(
@@ -1056,6 +1067,10 @@ class C4Indexer(nn.Module):
         if self.use_fp4_indexer:
             return fused_q_indexer_rope_hadamard_fp4_quant(
                 q.contiguous(), weight, self.weight_scale, self.freqs_cis, positions
+            )
+        if self.use_bf16_indexer_q:
+            return fused_q_indexer_rope_hadamard(
+                q, weight, self.weight_scale, self.freqs_cis, positions
             )
         return fused_q_indexer_rope_hadamard_quant(
             q, weight, self.weight_scale, self.freqs_cis, positions

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -1283,7 +1283,10 @@ class DeepEPMoE(FusedMoE):
 
             # This gather restores the normal-dispatch row order and applies
             # top-k weights exactly as the existing FP8/W8A8 paths do.
-            gather_out = torch.zeros(
+            # Both the LightOp and Triton EP gather kernels initialize their
+            # accumulators to zero and overwrite every output element. Avoid a
+            # redundant full-buffer fill before the gather.
+            gather_out = torch.empty(
                 hidden_states_shape,
                 device=hidden_states_device,
                 dtype=torch.bfloat16,


### PR DESCRIPTION
## 背景

DeepSeek V4 C4 Indexer 在 gfx936 上需要支持两条明确的数据类型路径：

1. 默认使用 BF16 Query + FP8 E4M3 Index-K cache；
2. 开启 INT8 Indexer 优化后，使用 INT8 Query + INT8 Index-K cache。

## 主要修改

**- 为 gfx936 增加不量化的 C4 Indexer Query 路径：
  - 保留原有 FP32 RoPE/Hadamard 运算；
  - 最终直接输出 BF16 Query；
  - 避免 `FP8 Q -> BF16 -> INT8` 的冗余转换。**
- 增加可选的 INT8 Query + INT8 Index-K cache 路径：
  - 使用 `lightop.quant.per_token_quant_int8` 对 BF16 Query 做逐 token 对称 INT8 量化；
  - 不创建或传入 `smooth_scale`；
  - 将 Query scale 折入原有的 per-head weight。
- 扩展原生 `fused_norm_rope_indexer`：
  - 在同一个 kernel 中完成 Index-K 的 BF16 舍入、INT8 量化及 cache 写入；
  - 保存 INT8 K 和对应的 FP32 scale；
  - 复用原有 Prefill/Decode plan 有效性判断，不额外生成框架侧 mask。
- 修复 `compressor_v2.forward_unified()` 的 cache 写入控制流：
  - 删除外层 `else` 中重复且不可达的 Indexer/Unified 判断；
  - 将 `_forward_compress_all_in_one()` 移到 cache 选择分支之后；
  - 保证 Indexer、Unified KV 和普通 compressed cache 均执行 compression/store。

## 路由行为

| 设备及配置 | MQA Query | Index-K cache |
|---|---|---|
| gfx936，环境变量关闭 | BF16 | FP8 E4M3 + FP32 scale |
| gfx936，环境变量开启 | INT8 + scale folded into weight | INT8 + FP32 scale |
| 其他架构 | 保持原有实现 | 保持原有实现 |

控制变量：

```bash
SGLANG_DSV4_HCU_INT8_INDEX_K_CACHE=1

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->