### PR TITLE
fix(hcu): avoid gfx936 QSA LDS overflow

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -368,6 +368,23 @@ def _launch_sparse_gqa_chunk_prefill(
     group_size = num_q_heads // num_kv_heads
     block_m = max(16, triton.next_power_of_2(group_size))
     block_n, warps, stages = _get_best_config(total_q)
+    device_arch = getattr(
+        torch.cuda.get_device_properties(q.device), "gcnArchName", ""
+    ).split(":", 1)[0]
+    if (
+        device_arch == "gfx936"
+        and head_dim == 256
+        and not kv_is_fp8
+        and block_n == 64
+        and stages == 2
+    ):
+        # BLOCK_N=64/stages=2 needs 67584 bytes of LDS on gfx936, exceeding
+        # its 65536-byte limit. Keep the faster 64/1 config through 64 query
+        # rows; with more rows the measured 32/2 config is faster.
+        if total_q <= 64:
+            stages = 1
+        else:
+            block_n = 32
     out = torch.empty_like(q)
     _sparse_gqa_chunk_prefill[(grid_m, (cu_q.shape[0] - 1) * num_kv_heads)](
         q,

--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -195,6 +195,22 @@ def sparse_gqa_fwd_interface_triton(
     group_size = num_q_heads // num_kv_heads
     block_m = max(16, triton.next_power_of_2(group_size))
     block_n, warps, stages = _get_best_config(total_q)
+    device_arch = getattr(
+        torch.cuda.get_device_properties(q.device), "gcnArchName", ""
+    ).split(":", 1)[0]
+    if (
+        device_arch == "gfx936"
+        and head_dim == 256
+        and not kv_is_fp8
+        and block_n == 64
+        and stages == 2
+    ):
+        # The non-chunked prefill path has the same gfx936 LDS requirement as
+        # chunk prefill, so apply the same measured size-dependent fallback.
+        if total_q <= 64:
+            stages = 1
+        else:
+            block_n = 32
     out = torch.empty_like(q)
     _sparse_gqa_prefill[(max_seqlen_k, (cu_seqlens.shape[0] - 1) * num_kv_heads)](
         q,


### PR DESCRIPTION
The HD256 non-FP8 chunk-prefill config uses BLOCK_N=64 and two pipeline stages. On gfx936 this compiles to 67584 bytes of LDS, exceeding the 65536-byte hardware limit.

gfx936 selects the legacy MMAC layout (mmacLayout=1), where the chained probability/value dot needs an additional 2048-byte LDS scratch buffer. gfx938, used by BW1101 on nmz, selects the interleaved MMAC layout (mmacLayout=2), needs no such scratch, and compiles to exactly 65536 bytes. Therefore limit the workaround to gfx936.

For gfx936 HD256 non-FP8 chunk prefill, use BLOCK_N=64/stages=1 through 64 query rows and BLOCK_N=32/stages=2 above 64. Both fit in LDS and retain the faster measured config in each row range. Leave gfx938 and the other QSA launch paths unchanged.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->