### PR TITLE
perf(dsv4): optimize EP gather, paged K-cache, and mHC CP split

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1357,6 +1357,7 @@ class Envs:
     SGLANG_OPT_USE_TILELANG_MHC_POST = EnvBool(True)
     SGLANG_OPT_USE_FLASHINFER_MHC = EnvBool(False)
     SGLANG_OPT_FUSE_MHC_POST_PRE = EnvBool(True)
+    SGLANG_DSV4_FUSE_MHC_REPEAT_CP_SPLIT = EnvBool(False)
     SGLANG_OPT_USE_TILELANG_INDEXER = EnvBool(False)
     # Store the DSV4 C4 indexer K cache as signed INT8 plus one FP32 scale
     # per token on HCU gfx936. The packed page ABI remains 132 bytes/token.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -842,6 +842,8 @@ class Envs:
     SGLANG_HACK_FLASHMLA_BACKEND = EnvStr("kernel")  # HCU override
     SGLANG_USE_AITER_FP8_PER_TOKEN = EnvBool(False)
 
+    SGLANG_LIGHTOP_DEQUANTIZE_K_CACHE_PAGED = EnvBool(False)
+
     # DSV4 Aiter flags
     SGLANG_OPT_USE_AITER_SILU_MUL = EnvBool(False)
     SGLANG_OPT_USE_FUSED_QK_NORM_ROPE = EnvBool(True)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -2510,19 +2510,37 @@ class DeepseekV4AttnBackend(
             compressed_slice = workspace[:n_compressed]
             swa_slice = workspace[n_compressed:]
 
-        if compressed_slice is not None:
-            dequantize_k_cache_paged(
-                extra_k_cache,
-                flat_token_ids,
-                page_size=extra_page_size,
-                out=compressed_slice,
+        if envs.SGLANG_LIGHTOP_DEQUANTIZE_K_CACHE_PAGED.get():
+            from lightop.kvcache import dsv4_dequantize_k_cache_paged_out
+
+            # Match the original wrapper's byte view; keep the caller's slices.
+            if compressed_slice is not None:
+                dsv4_dequantize_k_cache_paged_out(
+                    extra_k_cache.view(torch.uint8),
+                    flat_token_ids,
+                    compressed_slice,
+                    extra_page_size,
+                )
+            dsv4_dequantize_k_cache_paged_out(
+                token_to_kv_pool.get_swa_key_buffer_radix(layer_id).view(torch.uint8),
+                cache.swa_token_ids,
+                swa_slice,
+                cache.swa_page_size,
             )
-        dequantize_k_cache_paged(
-            token_to_kv_pool.get_swa_key_buffer_radix(layer_id),
-            cache.swa_token_ids,
-            page_size=cache.swa_page_size,
-            out=swa_slice,
-        )
+        else:
+            if compressed_slice is not None:
+                dequantize_k_cache_paged(
+                    extra_k_cache,
+                    flat_token_ids,
+                    page_size=extra_page_size,
+                    out=compressed_slice,
+                )
+            dequantize_k_cache_paged(
+                token_to_kv_pool.get_swa_key_buffer_radix(layer_id),
+                cache.swa_token_ids,
+                page_size=cache.swa_page_size,
+                out=swa_slice,
+            )
         kv = workspace
 
         o, _, _ = flash_mla_sparse_fwd(

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -1283,7 +1283,10 @@ class DeepEPMoE(FusedMoE):
 
             # This gather restores the normal-dispatch row order and applies
             # top-k weights exactly as the existing FP8/W8A8 paths do.
-            gather_out = torch.zeros(
+            # Both the LightOp and Triton EP gather kernels initialize their
+            # accumulators to zero and overwrite every output element. Avoid a
+            # redundant full-buffer fill before the gather.
+            gather_out = torch.empty(
                 hidden_states_shape,
                 device=hidden_states_device,
                 dtype=torch.bfloat16,

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -216,6 +216,82 @@ def _get_mhc_ops() -> MhcOps:
 
 logger = logging.getLogger(__name__)
 
+_FUSE_MHC_REPEAT_CP_SPLIT = envs.SGLANG_DSV4_FUSE_MHC_REPEAT_CP_SPLIT.get()
+
+
+def _can_defer_mhc_repeat_cp_split(
+    hidden_states: torch.Tensor,
+    forward_batch: ForwardBatch,
+    hc_mult: int,
+    cp_size: int,
+    cp_rank: int,
+) -> bool:
+    """Require an unpadded, equal-sized legacy RR split without device reads."""
+    if (
+        hidden_states.ndim != 2
+        or hidden_states.shape[1] == 0
+        or hc_mult <= 0
+        or cp_size <= 1
+        or not 0 <= cp_rank < cp_size
+    ):
+        return False
+    num_tokens = hidden_states.shape[0]
+    if num_tokens == 0 or num_tokens % cp_size != 0:
+        return False
+    # Existing CPU batch metadata proves logical rows; no device-value reads.
+    extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
+    if not isinstance(extend_lens, (list, tuple)) or not all(
+        isinstance(length, int) and not isinstance(length, bool) and length >= 0
+        for length in extend_lens
+    ):
+        return False
+    if sum(extend_lens) != num_tokens:
+        return False
+    # None is the real ForwardBatch default, set only when padding is applied.
+    original_num_tokens = getattr(forward_batch, "_original_num_tokens", None)
+    if original_num_tokens is not None and original_num_tokens != num_tokens:
+        return False
+    return all(
+        tensor is not None and tensor.ndim > 0 and tensor.shape[0] == num_tokens
+        for tensor in (
+            getattr(forward_batch, "input_ids", None),
+            getattr(forward_batch, "positions", None),
+            getattr(forward_batch, "out_cache_loc", None),
+        )
+    )
+
+
+def _repeat_mhc_input_on_cp_rank(
+    hidden_states: torch.Tensor, hc_mult: int, cp_size: int, cp_rank: int
+) -> torch.Tensor:
+    """Copy directly to local [tokens / CP, hc_mult, hidden] mHC storage."""
+    repeat_ops = _get_mhc_repeat_cp_ops()
+    if repeat_ops is not None and repeat_ops[0](
+        hidden_states, hc_mult, cp_size, cp_rank
+    ):
+        # LightOp owns target size/layout/architecture dispatch. The existing
+        # outer environment flag owns feature enablement; no role/size gate or
+        # host tensor-value read is introduced here.
+        return repeat_ops[1](hidden_states, hc_mult, cp_size, cp_rank)
+    # Slice is a view; repeat is the only output materialization.
+    return hidden_states[cp_rank::cp_size].unsqueeze(1).repeat(1, hc_mult, 1)
+
+
+@functools.cache
+def _get_mhc_repeat_cp_ops():
+    """Optional metadata-only LightOp ABI resolved once per process."""
+    try:
+        from lightop import op as lightop_op
+    except (ImportError, OSError) as exc:
+        logger.warning("DSV4 mHC repeat+CP unavailable; using torch repeat: %s", exc)
+        return None
+    supports = getattr(lightop_op, "supports_mhc_repeat_cp_sglang", None)
+    kernel = getattr(lightop_op, "mhc_repeat_cp_sglang", None)
+    if not callable(supports) or not callable(kernel):
+        return None
+    return supports, kernel
+
+
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 _MHC_POST_MULT_VALUE = 2.0
 
@@ -3102,12 +3178,33 @@ class DeepseekV4Model(nn.Module):
         use_prefill_cp = dsa_use_prefill_cp(forward_batch)
         incoming_pd_aux_hidden_states: List[torch.Tensor] = []
         local_dspark_aux_hidden_states: List[torch.Tensor] = []
+        deferred_mhc_input = None
+        mhc_cp_split_done = False
         if self.pp_group.is_first_rank:
             if input_embeds is None:
                 hidden_states = self.embed_tokens(input_ids)
             else:
                 hidden_states = input_embeds
-            hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+            if (
+                _FUSE_MHC_REPEAT_CP_SPLIT
+                and _is_hcu
+                and use_prefill_cp
+                and not cp_v2_active
+                and is_dsa_prefill_cp_round_robin_split()
+                and forward_batch.forward_mode.is_extend_without_speculative()
+                and _can_defer_mhc_repeat_cp_split(
+                    hidden_states,
+                    forward_batch,
+                    self.hc_mult,
+                    get_parallel().attn_cp_size,
+                    get_parallel().attn_cp_rank,
+                )
+            ):
+                # The intervening DP gather consumes input_ids, not hidden
+                # states. Defer until run_tbo decides whether full rows are needed.
+                deferred_mhc_input = hidden_states
+            else:
+                hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
         else:
             assert pp_proxy_tensors is not None
             hidden_states = pp_proxy_tensors["hidden_states"]
@@ -3164,11 +3261,26 @@ class DeepseekV4Model(nn.Module):
         # execution cannot expose per-layer completed hidden states), so skip
         # TBO when capturing -- a perf-only downgrade, not a correctness one.
         run_tbo = self._can_run_tbo(forward_batch) and not capture_dspark
+        if deferred_mhc_input is not None:
+            if not run_tbo:
+                hidden_states = _repeat_mhc_input_on_cp_rank(
+                    deferred_mhc_input,
+                    self.hc_mult,
+                    get_parallel().attn_cp_size,
+                    get_parallel().attn_cp_rank,
+                )
+                mhc_cp_split_done = True
+            else:
+                # TBO partitions full rows into children before their CP split.
+                hidden_states = deferred_mhc_input.unsqueeze(1).repeat(
+                    1, self.hc_mult, 1
+                )
+            deferred_mhc_input = None
         if use_prefill_cp and not run_tbo:
             if cp_v2_active:
                 input_ids = cp_round_robin_input_ids_v2(input_ids, forward_batch)
             else:
-                if self.pp_group.is_first_rank:
+                if self.pp_group.is_first_rank and not mhc_cp_split_done:
                     hidden_states = cp_split_and_rebuild_data(
                         forward_batch, hidden_states
                     )


### PR DESCRIPTION
## Motivation

Reduce memory initialization, intermediate tensor materialization, and kernel overhead in the DeepSeek-V4 execution path.

## Modifications

- Replace the redundant zero-initialized EP gather output buffer with an uninitialized buffer.
  - Both the LightOp and Triton gather kernels initialize their accumulators and overwrite the output.
- Add an optional LightOp path for fused paged K-cache dequantization.
- Fuse the first mHC repeat operation with legacy round-robin CP rank selection.
  - Avoid materializing the complete repeated hidden-state tensor before CP splitting.
  - Fall back to the existing PyTorch implementation when the LightOp operator is unavailable or the input is unsupported.
- Add the following opt-in environment variables, both disabled by default:
  - `SGLANG_LIGHTOP_DEQUANTIZE_K_CACHE_PAGED=1`
  - `SGLANG_DSV4_FUSE_MHC_REPEAT_CP_SPLIT=1`

## Accuracy Tests

The default execution behavior remains unchanged because both new LightOp paths are disabled by default.

Accuracy results with the optimized paths enabled will be provided separately.

## Speed Tests and Profiling

This PR reduces overhead by:

- Removing a redundant full-buffer zero fill before EP gather.
- Fusing paged K-cache dequantization into a dedicated LightOp kernel.
- Combining mHC repeat with CP rank selection to reduce intermediate memory allocation and data movement.

Detailed benchmark results will be provided separately.

## Dependencies

The two optional fused paths require a compatible LightOp build containing:

- DSV4 paged K-cache dequantization.
- DSV4 mHC repeat with CP split.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->