### PR TITLE
【Feat】Qwen3.6‑35B‑A3B supported dflash2

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1554,6 +1554,8 @@ class FlashAttentionBackend(AttentionBackend):
                         and layer.v_scale is not None
                         else None
                     ),
+                    layout="legacy_bhsd",
+                    out=_fa_out,
                 )
             elif self._use_hcu_legacy_layout:
                 result = vllm_flash_attn_with_kvcache(

--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -32,7 +32,7 @@ _kv_layout_hcu_fa = _is_hcu and get_bool_env_var(
     "SGLANG_KV_LAYOUT_HCU_FA", default="true"
 )
 
-if _is_hcu and _use_triton_vllm_fa:
+if _is_hcu:
     from sglang.srt.layers.attention.triton_vllm_flash_attn import (
         triton_vllm_flash_attn_varlen_func,
         triton_vllm_flash_attn_with_kvcache,
@@ -434,8 +434,15 @@ def vllm_flash_attn_varlen_func(
     k_descale,
     v_descale,
     layout=None,
+    out=None,
 ):
-    if _is_hcu and _use_triton_vllm_fa:
+    use_hcu_fp8_swa_fallback = (
+        _is_hcu
+        and k.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+        and window_size is not None
+        and window_size[0] >= 0
+    )
+    if _is_hcu and (_use_triton_vllm_fa or use_hcu_fp8_swa_fallback):
         return triton_vllm_flash_attn_varlen_func(
             q=q,
             k=k,
@@ -453,6 +460,7 @@ def vllm_flash_attn_varlen_func(
             k_descale=k_descale,
             v_descale=v_descale,
             layout=layout,
+            out=out,
         )
 
     return vllm_flash_attn_varlen_func_interface(

--- a/python/sglang/srt/layers/attention/triton_vllm_flash_attn.py
+++ b/python/sglang/srt/layers/attention/triton_vllm_flash_attn.py
@@ -62,6 +62,8 @@ def _paged_varlen_attn_fwd_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     CAUSAL: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    WINDOW_RIGHT: tl.constexpr,
     Q_STRIDE_T: tl.constexpr,
     Q_STRIDE_H: tl.constexpr,
     Q_STRIDE_D: tl.constexpr,
@@ -159,6 +161,18 @@ def _paged_varlen_attn_fwd_kernel(
         qk = tl.where(q_mask[:, None] & kv_mask[None, :], qk, -float("inf"))
         if CAUSAL:
             qk = tl.where(offs_n[None, :] <= q_abs_pos[:, None], qk, -float("inf"))
+        if WINDOW_LEFT >= 0:
+            qk = tl.where(
+                offs_n[None, :] >= q_abs_pos[:, None] - WINDOW_LEFT,
+                qk,
+                -float("inf"),
+            )
+        if WINDOW_RIGHT >= 0:
+            qk = tl.where(
+                offs_n[None, :] <= q_abs_pos[:, None] + WINDOW_RIGHT,
+                qk,
+                -float("inf"),
+            )
 
         m_new = tl.maximum(m_i, tl.max(qk, axis=1))
         p = tl.exp(qk - m_new[:, None])
@@ -200,11 +214,12 @@ def triton_vllm_flash_attn_varlen_func(
     k_descale: Optional[torch.Tensor],
     v_descale: Optional[torch.Tensor],
     layout: Optional[str] = None,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     if layout is not None and layout not in ("bshd", "bhsd", "legacy_bhsd"):
         raise ValueError(f"Unsupported attention layout: {layout!r}")
-    if window_size != (-1, -1):
-        raise NotImplementedError("Triton reference FA only supports full-context attention.")
+    if len(window_size) != 2 or any(size < -1 for size in window_size):
+        raise ValueError(f"Invalid attention window: {window_size!r}")
     if q.dim() != 3:
         raise ValueError(f"q must be [total_q, Hq, D], got {tuple(q.shape)}")
     if k.dim() != 4 or v.dim() != 4:
@@ -281,8 +296,7 @@ def triton_vllm_flash_attn_varlen_func(
 
     def _normalize_descale(descale: Optional[torch.Tensor], name: str, valid_heads):
         if descale is None:
-            dummy = torch.empty((1, 1), device=q.device, dtype=torch.float32)
-            return dummy, False, 1
+            return q, False, 1
         descale = descale.to(device=q.device, dtype=torch.float32)
         if descale.dim() == 0:
             descale = descale.view(1, 1)
@@ -310,7 +324,13 @@ def triton_vllm_flash_attn_varlen_func(
         v_descale, "v_descale", {1, h_kv}
     )
 
-    out = torch.empty((total_q, h_q, d_v), device=q.device, dtype=out_dtype)
+    if out is None:
+        out = torch.empty((total_q, h_q, d_v), device=q.device, dtype=out_dtype)
+    elif out.shape != (total_q, h_q, d_v) or out.dtype != out_dtype:
+        raise ValueError(
+            f"out must have shape {(total_q, h_q, d_v)} and dtype {out_dtype}, "
+            f"got shape={tuple(out.shape)}, dtype={out.dtype}"
+        )
     block_m = 16
     block_n = 32
     grid = (triton.cdiv(max_seqlen_q, block_m), h_q, batch)
@@ -334,6 +354,8 @@ def triton_vllm_flash_attn_varlen_func(
         block_m,
         block_n,
         causal,
+        window_size[0],
+        window_size[1],
         q.stride(0),
         q.stride(1),
         q.stride(2),

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -1200,7 +1200,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, BaseFusedOp):
                     topk_weights=topk_weights,
                     topk_ids=topk_ids,
                     moe_config=moe_cfg,
-                    inplace=True,
+                    inplace=moe_runner_config.inplace,
                     w1_scale=None,
                     w2_scale=None,
                     activation=activation,

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -40,7 +40,7 @@ from sglang.srt.speculative.dflash_utils import (
     is_dense_head_weight,
     parse_dflash_draft_config,
 )
-from sglang.srt.utils import is_npu
+from sglang.srt.utils import is_hip, is_npu
 from sglang.srt.utils.common import get_compiler_backend
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
@@ -52,6 +52,10 @@ logger = logging.getLogger(__name__)
 try:
     from flashinfer import top_k as _flashinfer_top_k
 except ImportError:
+    _flashinfer_top_k = None
+# flashinfer.top_k JIT-compiles a CUDA kernel via nvcc, which is unavailable on
+# HIP/ROCm images. Force the torch.topk fallback there.
+if _flashinfer_top_k is not None and is_hip():
     _flashinfer_top_k = None
 
 

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -40,11 +40,12 @@ from sglang.srt.speculative.dflash_utils import (
     is_dense_head_weight,
     parse_dflash_draft_config,
 )
-from sglang.srt.utils import is_hip, is_npu
+from sglang.srt.utils import is_hcu, is_hip, is_npu
 from sglang.srt.utils.common import get_compiler_backend
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 _is_npu = is_npu()
+_is_hcu = is_hcu()
 if _is_npu:
     from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import split_qkv_rmsnorm_rope
 logger = logging.getLogger(__name__)
@@ -63,6 +64,10 @@ def _radix_topk(scores: torch.Tensor, k: int) -> Tuple[torch.Tensor, torch.Tenso
     # The selector's largest single cost: it reads the whole logits tensor.
     if _flashinfer_top_k is not None:
         return _flashinfer_top_k(scores, k, sorted=True, deterministic=True)
+    if _is_hcu:
+        from lightop import topk
+
+        return topk(scores, k, dim=-1)
     return torch.topk(scores, k, dim=-1)
 
 


### PR DESCRIPTION
 ## Motivation

  This PR enables Qwen3.6-35B-A3B with DFLASH speculative decoding on HCU/ROCm using the intended production configuration:
 - `--speculative-algorithm DFLASH` and ` --speculative-draft-model-path "$DFLASH2 DRAFT_MODEL_PATH" `
  - `--attention-backend fa3`
  - CUDA Graph enabled
  - `SGLANG_ROCM_USE_AITER_MOE=1`
  - 

  The configuration previously had three correctness and compatibility problems:

  1. DFLASH attempted to use `flashinfer.top_k` on HIP. Its first invocation tried to JIT-compile a CUDA kernel with `nvcc`, which is
  unavailable in the ROCm/HCU image.
  2. FA3 with FP8 paged KV cache and sliding-window draft attention allocated an output tensor inside CUDA Graph capture. HIP
  rejected this with `hipErrorStreamCaptureUnsupported`.
  3. The HCU AITER W16A16 MoE path always used in-place execution. Qwen3.6 has a separate shared-expert gate that still consumes the
  original `hidden_states`, so overwriting that tensor caused layer-by-layer corruption and incoherent model output.

  In addition, this PR routes the DFLASH selector to LightOp `topk` on HCU after FlashInfer is disabled, avoiding the generic
  `torch.topk` fallback on this platform.

  ## Modifications

  ### 1. Disable FlashInfer top-k on HIP

  Commit:

  ```text
  501dd8e08848aba144e5c20a601256e33dca367f
  fix(dflash): force torch.topk fallback on HIP

  Changed file:

  python/sglang/srt/models/dflash.py

  flashinfer.top_k is now disabled on HIP after import. This prevents the FlashInfer CUDA JIT path from invoking the unavailable nvcc
  compiler.

  The existing PyTorch implementation remains the generic fallback, and non-HIP behavior is unchanged.

  ### 2. Make HCU FP8 sliding-window attention graph-safe

  Commit:

  41f930ee40f9c8d7b87e199f684b33d6e51a11b4
  fix(hcu): make FP8 sliding attention graph-safe

  Changed files:

  python/sglang/srt/layers/attention/flashattention_backend.py
  python/sglang/srt/layers/attention/flashattention_interface.py
  python/sglang/srt/layers/attention/triton_vllm_flash_attn.py

  The existing Triton paged varlen attention implementation was extended with:

  - Left and right sliding-window masks.
  - An optional caller-provided output tensor.
  - Validation of the supplied output shape and dtype.
  - Removal of unused descale tensor allocations when scales are absent.
  - Explicit mapping of the HCU custom KV layout to legacy_bhsd.

  Only the following combination is routed to this graph-safe fallback:

  - HCU
  - FP8 KV cache
  - Sliding-window attention
  - FA3 varlen attention entry point

  Other FA3 paths and non-HCU platforms retain their existing behavior.

  Passing the preallocated attention output prevents torch.empty from executing inside the HIP Graph capture region.

  ### 3. Honor the non-inplace AITER MoE contract

  Commit:

  f4606e761de728315aa6ce38fb028c6441a50039
  fix(hcu): honor non-inplace AITER W16A16 MoE

  Changed file:

  python/sglang/srt/layers/quantization/unquant.py

  The HCU AITER W16A16 MoE invocation previously hardcoded:

  inplace=True

  It now uses:

  inplace=moe_runner_config.inplace

  FusedMoE already sets this configuration to False when the original input must remain available to a shared expert.

  This fixes Qwen3.6 output corruption while preserving in-place execution for models and call sites where it is valid.

  ### 4. Use LightOp top-k for the DFLASH selector on HCU

  Commit:

  4407cb1fc1bd2fc45be1d8255109f3cf18d38bcb
  perf(hcu): use LightOp topk for DFLASH selector

  Changed file:

  python/sglang/srt/models/dflash.py

  When FlashInfer top-k is unavailable and the active platform is HCU, the DFLASH selector now calls:

  lightop.topk(scores, k, dim=-1)

  Dispatch behavior is:

   Platform/path                       Implementation
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━
   Supported FlashInfer environment    flashinfer.top_k
  ──────────────────────────────────  ──────────────────
   HCU                                 lightop.topk
  ──────────────────────────────────  ──────────────────
   Other fallback platforms            torch.topk

  This keeps the HIP compatibility fix while allowing HCU to use its optimized top-k implementation.

  ## Accuracy Tests


  ### Deterministic smoke tests

  Four arithmetic prompts were sent through the OpenAI-compatible API with thinking disabled:

   Expression    Expected    Actual
  ━━━━━━━━━━━━  ━━━━━━━━━━  ━━━━━━━━
   17 + 22             39        39
  ────────────  ──────────  ────────
   7 * 8               56        56
  ────────────  ──────────  ────────
   100 - 43            57        57
  ────────────  ──────────  ────────
   81 / 9               9         9

  All four responses were exact and reported zero reasoning tokens.

  A longer generation request also confirmed that the live decode path was using CUDA Graph:

  Decode batch ... cuda graph: True

  ### EvalScope full evaluation

  Command:

  bash evalscope_more_client.sh false humaneval,gsm8k

  Results:

   Model              Dataset      Metric      Subset              Samples    Score
  ━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━  ━━━━━━━━━  ━━━━━━━
   Qwen3.6-35B-A3B    HumanEval    Accuracy    openai_humaneval        164    95.7%
  ─────────────────  ───────────  ──────────  ──────────────────  ─────────  ───────
   Qwen3.6-35B-A3B    HumanEval    Pass@1      openai_humaneval        164    95.7%
  ─────────────────  ───────────  ──────────  ──────────────────  ─────────  ───────
   Qwen3.6-35B-A3B    GSM8K        Accuracy    main                   1319    96.7%

  Exact report values:

  HumanEval: 0.9573
  GSM8K:     0.9674

  Artifact validation:

  - HumanEval predictions: 164 records.
  - HumanEval reviews: 164 records.
  - GSM8K predictions: 1319 records.
  - GSM8K reviews: 1319 records.
  - Both report JSON files were parsed successfully.
  - The combined HTML report was generated.
  - EvalScope exited with status 0.
  - No traceback, worker crash, VM fault, GPU fault, HSA exception, or corrupted output was observed.

  ### Kernel-level correctness checks

  The Triton sliding-window GQA fallback was compared against a PyTorch reference:

  Maximum absolute difference: 0.0078125

  FP8 KV cache warmup, CUDA Graph capture, and Graph replay completed successfully.

  The AITER W16A16 MoE path was also tested using the actual TP-sharded model dimensions:

  Experts:                  256
  Hidden size:              2048
  Intermediate size/rank:   128
  Top-k:                    8

  Results:

  Input preserved:          true
  Output aliases input:     false
  Maximum absolute error:   0.00018310546875

  This verifies both the numerical output and the required non-inplace ownership behavior.

  ## Speed Tests and Profiling

  End-to-end statistics reported by EvalScope for the final configuration:

   Dataset      Avg latency     Avg TTFT    Avg TPOT    Avg output throughput    Avg input tokens    Avg output tokens
  ━━━━━━━━━━━  ━━━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━
   HumanEval       17.497 s    1262.5 ms     67.9 ms              14.85 tok/s                 180                  260
  ───────────  ─────────────  ───────────  ──────────  ───────────────────────  ──────────────────  ───────────────────
   GSM8K           15.869 s     305.5 ms     64.4 ms              15.32 tok/s                 689                  243

  The complete HumanEval and GSM8K evaluation took 14 minutes 48 seconds with an EvalScope client batch size of 32.

  During concurrent GSM8K evaluation, the server log reported aggregate decode throughput up to approximately 500 tokens/s. This
  value is included as runtime evidence rather than a controlled benchmark.

  No controlled A/B microbenchmark or profiler trace comparing LightOp top-k against torch.topk was collected in this PR. Therefore,
  the LightOp change should be treated as a platform-specific dispatch optimization whose correctness is covered by the full
  evaluation, while its precise speedup remains to be measured separately.

  A diagnostic baseline using Triton attention, BF16 KV cache, disabled CUDA Graph, and AITER MoE disabled produced:

   Dataset      Score
  ━━━━━━━━━━━  ━━━━━━━
   HumanEval    96.3%
  ───────────  ───────
   GSM8K        96.9%

  This baseline differs in multiple runtime settings and is included only as an accuracy sanity check. It is not a valid isolated
  performance comparison.

  ## Additional Validation

  The following checks were completed:

  - Both deployment scripts pass bash -n.
  - Modified Python files pass python3 -m py_compile in the target container.
  - git diff --check passes.
  - The final source worktree is clean.
  - All four commits are present on feat/Qwen3.6-35B-A3B-Dflash2.
  - Service /health returns HTTP 200.
  - /v1/models returns the expected Qwen3.6 model ID.
  - Target CUDA Graph capture completed for all 23 configured batch sizes.
  - Draft CUDA Graph capture completed for all 23 configured batch sizes.
  - The service remains healthy after the full 1483-sample evaluation.

  DFLASH currently supports only speculative_num_steps=1. If a larger value is supplied, SGLang explicitly normalizes it to 1 during
  argument processing.

  The startup-time multimem hipErrorInvalidValue messages are capability-probe failures followed by an explicit fallback to standard
  NCCL all-reduce. They do not affect model loading, Graph capture, generation, or accuracy evaluation.

  ## Checklist

  - [ ] Format your code according to the Format code with pre-commit.
  - [ ] Add unit tests according to the Run and add unit tests.
  - [x] Update documentation according to Write documentations.
  - [x] Provide accuracy benchmark results according to Test the accuracy.
  - [ ] Provide a controlled speed benchmark and profiler results according to Benchmark the speed.
  - [x] Follow the SGLang code style guidance.

  ## Review and Merge Process

  1. Ping Merge Oncalls to start the process. See the PR Merge Process.
  2. Get approvals from CODEOWNERS and other reviewers.
  3. Trigger CI tests with comments or contact authorized users to do so.
      - Common commands include /tag-and-rerun-ci, /tag-run-ci-label, /rerun-failed-ci.

  4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->