### PR TITLE
test(hcu): derive FP8 quant reference bounds from the output dtype

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -31,6 +31,7 @@ _is_hcu = is_hcu()
 _kv_layout_hcu_fa = _is_hcu and get_bool_env_var(
     "SGLANG_KV_LAYOUT_HCU_FA", default="true"
 )
+_hcu_fa_layout = "bhsd" if _is_hcu and not _kv_layout_hcu_fa else None
 
 if _is_hcu:
     from sglang.srt.layers.attention.triton_vllm_flash_attn import (
@@ -372,6 +373,9 @@ def flash_attn_varlen_func(
     layout=None,
 ):
     global _SERVER_ARGS, IS_SLIMQUANT_W4A8, IS_KVCACHE_FP8_E4M3
+    if layout is None:
+        layout = _hcu_fa_layout
+
     if IS_KVCACHE_FP8_E4M3 is None:
         from sglang.srt.server_args import get_global_server_args
 

--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -31,7 +31,6 @@ _is_hcu = is_hcu()
 _kv_layout_hcu_fa = _is_hcu and get_bool_env_var(
     "SGLANG_KV_LAYOUT_HCU_FA", default="true"
 )
-_hcu_fa_layout = "bhsd" if _is_hcu and not _kv_layout_hcu_fa else None
 
 if _is_hcu:
     from sglang.srt.layers.attention.triton_vllm_flash_attn import (
@@ -373,9 +372,6 @@ def flash_attn_varlen_func(
     layout=None,
 ):
     global _SERVER_ARGS, IS_SLIMQUANT_W4A8, IS_KVCACHE_FP8_E4M3
-    if layout is None:
-        layout = _hcu_fa_layout
-
     if IS_KVCACHE_FP8_E4M3 is None:
         from sglang.srt.server_args import get_global_server_args
 

--- a/test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py
+++ b/test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py
@@ -3,6 +3,7 @@
 
 """HCU FP8 per-token-group quantization numeric reference tests."""
 
+import math
 import unittest
 
 import torch
@@ -18,8 +19,6 @@ register_hcu_ci(
     nightly=True,
 )
 register_hcu_ci(est_time=60, suite="stage-b-test-1-hcu-small")
-
-HCU_FP8_QUANT_MAX = 224.0
 
 
 class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
@@ -47,14 +46,24 @@ class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
                     group_size=group_size,
                 )
 
+                # E4M3FN and E4M3FNUZ have different finite ranges. Derive the
+                # reference bound from the kernel's actual output dtype instead
+                # of hardcoding a platform-specific value.
+                quant_info = torch.finfo(quantized.dtype)
+                quant_max = quant_info.max
+                # Preserve a one-ULP rounding allowance at the largest exponent:
+                # 32 for E4M3FN, 16 for E4M3FNUZ.
+                max_quant_step = math.ldexp(
+                    quant_info.eps, math.frexp(quant_max)[1] - 1
+                )
+
                 grouped = source.float().reshape(tokens, -1, group_size)
                 reference_scales = (
-                    grouped.abs().amax(dim=-1).clamp_min(1e-10)
-                    / HCU_FP8_QUANT_MAX
+                    grouped.abs().amax(dim=-1).clamp_min(1e-10) / quant_max
                 )
                 reference_quantized = (
                     (grouped / reference_scales.unsqueeze(-1))
-                    .clamp(-HCU_FP8_QUANT_MAX, HCU_FP8_QUANT_MAX)
+                    .clamp(-quant_max, quant_max)
                     .to(quantized.dtype)
                     .reshape_as(quantized)
                 )
@@ -74,7 +83,7 @@ class TestBW1100FP8QuantReferenceHCU(unittest.TestCase):
                 )
                 self.assertLessEqual(
                     quant_diff.max().item(),
-                    16.0,
+                    max_quant_step,
                 )
 
 


### PR DESCRIPTION
## Motivation

The HCU FP8 per-token-group quantization reference test hardcoded
`HCU_FP8_QUANT_MAX = 224.0`, which corresponds to an E4M3FNUZ-style range.
The HCU kernel actually outputs `torch.float8_e4m3fn` (max = 448.0), so the
hardcoded bound caused `test_fp8_quant_reference_hcu.py` to fail on CI
(`AssertionError: Tensor-likes are not close`), even though the kernel
behavior is correct.

## Modifications

- `test/registered/hcu/kernels/test_fp8_quant_reference_hcu.py`
  - Remove the hardcoded `HCU_FP8_QUANT_MAX = 224.0`.
  - Derive `quant_max` from `torch.finfo(quantized.dtype)` so the test
    adapts to whatever FP8 dtype the kernel emits (E4M3FN on HCU, E4M3FNUZ
    on MI300-class platforms).
  - Derive a one-ULP rounding allowance `max_quant_step` at the largest
    exponent (`32` for E4M3FN, `16` for E4M3FNUZ) via
    `math.ldexp(quant_info.eps, math.frexp(quant_max)[1] - 1)` and use it
    as the max absolute tolerance for the quantized tensor comparison.
  - Scale reference and elementwise mismatch-ratio checks are unchanged.

No production kernel code is modified; this is a test-only fix.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->