### PR TITLE
perf(hcu): use AITER IPC collectives for DP TP-MoE

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1132,6 +1132,9 @@ class GroupCoordinator:
         # generic RCCL kernel for the small, latency-bound decode collective.
         # Gated by SGLANG_DP_USE_REDUCE_SCATTER. Falls back (returns False)
         # for HCU, non-ROCm, or unsupported shape/size/topology so the caller uses RCCL.
+        # HCU stays excluded here on purpose; the DP-attention MAX_LEN combine
+        # re-enables the aiter IPC kernel narrowly in dp_attention.py's
+        # `_aiter_reduce_scatter_tensor` so no other reduce_scatter caller is affected.
         if not (
             is_hip()
             and not _is_hcu
@@ -1258,9 +1261,8 @@ class GroupCoordinator:
         # Aiter's should_custom_ag still owns shape/layout validation:
         # 16B alignment, weak-contiguous, supported topology, and per-rank
         # size <= max_size/(world*2).
-        # On a hit, writes directly into the caller's pre-allocated `output` via
-        # all_gather_reg during CUDA-graph capture, and all_gather_unreg
-        # under torch_memory_saver and other paths.
+        # On a hit, writes directly into the caller's pre-allocated `output`.
+        # HCU and torch_memory_saver use the unregistered graph path.
         ca_comm = self.ca_comm
         if (
             is_hip()
@@ -1273,7 +1275,9 @@ class GroupCoordinator:
         ):
             if getattr(ca_comm, "_IS_CAPTURING", False):
                 if torch.cuda.is_current_stream_capturing():
-                    if envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get():
+                    # HCU's registered graph path corrupts replay output; see the
+                    # retirement gate in docs/internal/dcu-main-conflict-ledger.md.
+                    if _is_hcu or envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get():
                         ca_comm.all_gather_unreg(input, out=output, dim=0)
                     else:
                         ca_comm.all_gather_reg(input, out=output, dim=0)

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1275,8 +1275,6 @@ class GroupCoordinator:
         ):
             if getattr(ca_comm, "_IS_CAPTURING", False):
                 if torch.cuda.is_current_stream_capturing():
-                    # HCU's registered graph path corrupts replay output; see the
-                    # retirement gate in docs/internal/dcu-main-conflict-ledger.md.
                     if _is_hcu or envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get():
                         ca_comm.all_gather_unreg(input, out=output, dim=0)
                     else:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -792,6 +792,9 @@ class Envs:
     # symmetric-memory kernel), OFF elsewhere (would fall back to RCCL); override
     # explicitly to force on/off on any platform.
     SGLANG_DP_USE_REDUCE_SCATTER = EnvBool(_default_hip)
+    # Opt HCU CUDA graph DP padding into MAX_LEN, enabling all-gather and
+    # fused reduce-scatter for the pure TP-MoE DP-attention path.
+    SGLANG_DP_USE_MAX_LEN = EnvBool(False)
     # Quantize the variable-length DP-MoE gather payload (SGLANG_DP_USE_GATHERV
     # path, prefill/extend only) to fp8-e4m3 with per-token-group-128 scales:
     # halves the gathered hidden-state bytes over NCCL; the combine

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -93,6 +93,13 @@ _USE_ROCM700A_WA = _is_hip and get_bool_env_var("SGLANG_USE_ROCM700A")
 _is_cpu = is_cpu()
 
 
+@functools.lru_cache(maxsize=1)
+def _dp_use_max_len() -> bool:
+    from sglang.srt.environ import envs
+
+    return envs.SGLANG_DP_USE_MAX_LEN.get()
+
+
 class DpPaddingMode(IntEnum):
 
     # Padding tokens to max length and then gather tokens using `all_gather_into_tensor`
@@ -145,10 +152,13 @@ class DpPaddingMode(IntEnum):
     def get_default_mode_in_cuda_graph(cls) -> DpPaddingMode:
         # TODO(kkhuang-amd): noqa, temporary work-around for rocm 7.0.0 alpha
         # it can be safely removed later, once RCCL fixed
-        if _USE_ROCM700A_WA or _is_hcu:
+        if _USE_ROCM700A_WA:
             return cls.SUM_LEN
-        else:
-            return cls.MAX_LEN
+        # HCU keeps SUM_LEN until the aiter graph all-gather is validated; opt
+        # into MAX_LEN for all-gather plus fused reduce-scatter.
+        if _is_hcu and not _dp_use_max_len():
+            return cls.SUM_LEN
+        return cls.MAX_LEN
 
 
 class _DpGatheredBufferWrapper:
@@ -878,6 +888,46 @@ def dp_scatter(
         memcpy(local_tokens, global_tokens, 0, local_start_pos, local_num_tokens, True)
 
 
+def _aiter_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor) -> bool:
+    """HCU-only: run the DP-attention MAX_LEN combine over aiter's custom (IPC)
+    reduce_scatter. Returns True if it handled the op, False to let the caller
+    fall back to `get_tp_group().reduce_scatter_tensor` (RCCL on HCU).
+
+    `GroupCoordinator._maybe_aiter_reduce_scatter` deliberately excludes HCU
+    (`and not _is_hcu`) as a historical precision guard, so the generic path sends
+    HCU to RCCL and misses the aiter IPC kernel. This narrow wrapper re-enables the
+    aiter kernel ONLY for the HCU DP-attention combine under MAX_LEN, leaving every
+    other reduce_scatter_tensor caller on HCU untouched. Mirrors the upstream 0518
+    `_aiter_reduce_scatter_tensor`, plus our should_custom_ar / equal-chunk guards
+    (see dp-max-len-merge-notes.md §6.2).
+
+    Opt-in: needs SGLANG_DP_USE_MAX_LEN=1 (this wrapper) AND SGLANG_USE_AITER_AR=1
+    (so ca_comm is the aiter CustomAllreduce that actually has reduce_scatter).
+    registered=False is forced: HCU's registered graph-replay path corrupts output
+    (same root cause as all_gather_reg; see merge notes §7).
+    """
+    if not (_is_hcu and _dp_use_max_len()):
+        return False
+    # aiter custom comm is float-only.
+    if not input.dtype.is_floating_point:
+        return False
+    if not (input.is_contiguous() and output.is_contiguous()):
+        return False
+    ca = getattr(get_tp_group(), "ca_comm", None)
+    if ca is None or getattr(ca, "disabled", True):
+        return False
+    if not (hasattr(ca, "reduce_scatter") and hasattr(ca, "should_custom_ar")):
+        return False
+    # should_custom_ar bounds the pre-reduce buffer size and validates topology.
+    if not ca.should_custom_ar(input):
+        return False
+    # Equal-chunk only: the global buffer must split evenly into per-rank output.
+    if input.shape[0] != output.shape[0] * get_tensor_model_parallel_world_size():
+        return False
+    ca.reduce_scatter(input, output, registered=False)
+    return True
+
+
 def dp_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor):
     if is_dp_gatherv_active():
         # Variable-length combine matching all_gatherv dispatch: scatter the
@@ -888,6 +938,8 @@ def dp_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor):
             get_tp_group().reduce_scatterv(input, output=output, sizes=sizes)
             return
     if get_tensor_model_parallel_world_size() == get_attention_dp_size():
+        if _aiter_reduce_scatter_tensor(output, input):
+            return
         get_tp_group().reduce_scatter_tensor(output, input)
     else:
         scattered_local_tokens = input.tensor_split(

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -898,8 +898,7 @@ def _aiter_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor) -> b
     HCU to RCCL and misses the aiter IPC kernel. This narrow wrapper re-enables the
     aiter kernel ONLY for the HCU DP-attention combine under MAX_LEN, leaving every
     other reduce_scatter_tensor caller on HCU untouched. Mirrors the upstream 0518
-    `_aiter_reduce_scatter_tensor`, plus our should_custom_ar / equal-chunk guards
-    (see dp-max-len-merge-notes.md §6.2).
+    `_aiter_reduce_scatter_tensor`, plus our should_custom_ar / equal-chunk guards.
 
     Opt-in: needs SGLANG_DP_USE_MAX_LEN=1 (this wrapper) AND SGLANG_USE_AITER_AR=1
     (so ca_comm is the aiter CustomAllreduce that actually has reduce_scatter).
@@ -908,8 +907,10 @@ def _aiter_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor) -> b
     """
     if not (_is_hcu and _dp_use_max_len()):
         return False
-    # aiter custom comm is float-only.
-    if not input.dtype.is_floating_point:
+    # aiter custom comm only supports fp16/bf16/fp32.
+    if input.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+        return False
+    if output.dtype != input.dtype:
         return False
     if not (input.is_contiguous() and output.is_contiguous()):
         return False


### PR DESCRIPTION
Opt HCU CUDA graphs into the MAX_LEN DP layout so the pure TP-MoE
path uses all-gather instead of zero-buffer all-reduce and combines
TP partial outputs with one reduce-scatter.

Use AITER's unregistered IPC paths for HCU all-gather and
reduce-scatter to avoid registered CUDA graph replay corruption.
Keep existing eligibility checks and RCCL fallbacks for unsupported
shapes, dtypes, sizes, and topologies.

## Performance

The values below are calculated as `before / after`.

| Metric | Before / After | Improvement |
|---|---:|---:|
| TPOT | 1.026332122× | 2.57% lower |
| Output throughput | 0.973099337× | 2.76% higher |

- TPOT reduction: `1 - 1 / 1.026332122 = 2.57%`
- Output throughput increase: `1 / 0.973099337 - 1 = 2.76%`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->