### PR TITLE
[feat]Qwen3.6-35B-A3B 支持--speculative-algorithm DSPARK

### DIFF
--- a/python/sglang/srt/configs/dspark.py
+++ b/python/sglang/srt/configs/dspark.py
@@ -1,0 +1,34 @@
+"""Normalize compact DSPARK exports without changing their checkpoint files."""
+
+from copy import deepcopy
+
+
+def normalize_dspark_config(config: dict):
+    """Return a flat HF network config for a nested DSPARK export, else None."""
+    network = config.get("transformer_layer_config")
+    architectures = config.get("architectures") or []
+    is_dspark = config.get("speculators_model_type") == "dspark" or any(
+        name in ("DSparkDraftModel", "Qwen3DSparkModel") for name in architectures
+    )
+    if not is_dspark or network is None:
+        return None
+    if not isinstance(network, dict):
+        raise ValueError("DSPARK transformer_layer_config must be an object.")
+    model_type = network.get("model_type")
+    if not isinstance(model_type, str) or not model_type:
+        raise ValueError("DSPARK transformer_layer_config requires model_type.")
+    for key in ("hidden_size", "num_hidden_layers", "num_attention_heads", "vocab_size"):
+        value = network.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"DSPARK transformer_layer_config requires positive {key}.")
+    result = deepcopy(network)
+    for key, value in config.items():
+        if key in ("transformer_layer_config", "model_type"):
+            continue
+        if key in network and value is None:
+            continue
+        if key in network and value != network[key]:
+            raise ValueError(f"Conflicting DSPARK network config field: {key}.")
+        result[key] = deepcopy(value)
+    result["model_type"] = model_type
+    return result

--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -463,6 +463,58 @@ def vllm_flash_attn_varlen_func(
             out=out,
         )
 
+    # HCU paged MTP folds query tokens into heads and supports at most
+    # 64 query heads per KV head. Split uniform causal verification blocks
+    # without changing their bottom-right causal alignment or the KV cache.
+    if (
+        _is_hcu
+        and layout == "legacy_bhsd"
+        and k.shape[2] == 64
+        and q.shape[2] == v.shape[2]
+        and causal
+        and window_size == (-1, -1)
+        and 1 < max_seqlen_q <= 16
+        and q.shape[0] == (cu_seqlens_q.numel() - 1) * max_seqlen_q
+        and q.shape[1] * max_seqlen_q > k.shape[1] * 64
+        and q.shape[1] <= k.shape[1] * 64
+    ):
+        batch_size = cu_seqlens_q.numel() - 1
+        chunk_size = min(16, k.shape[1] * 64 // q.shape[1])
+        queries = q.reshape(batch_size, max_seqlen_q, *q.shape[1:])
+        chunks = []
+        for begin in range(0, max_seqlen_q, chunk_size):
+            end = min(begin + chunk_size, max_seqlen_q)
+            chunk_q = queries[:, begin:end].contiguous().flatten(0, 1)
+            chunk_cu = torch.arange(
+                batch_size + 1, device=cu_seqlens_q.device, dtype=cu_seqlens_q.dtype
+            ) * (end - begin)
+            chunk_lengths = (seqused_k - (max_seqlen_q - end)).clamp_min(0)
+            chunk_out = vllm_flash_attn_varlen_func_interface(
+                q=chunk_q,
+                k=k,
+                v=v,
+                cu_seqlens_q=chunk_cu,
+                max_seqlen_q=end - begin,
+                seqused_k=chunk_lengths,
+                max_seqlen_k=max_seqlen_k,
+                softmax_scale=softmax_scale,
+                causal=causal,
+                window_size=window_size,
+                block_table=block_table,
+                fa_version=fa_version,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+            )
+            chunks.append(
+                chunk_out.reshape(batch_size, end - begin, *chunk_out.shape[1:])
+            )
+        result = torch.cat(chunks, dim=1).flatten(0, 1)
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
     return vllm_flash_attn_varlen_func_interface(
         q=q,
         k=k,

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -88,6 +88,7 @@ class VanillaMarkov(nn.Module):
             raise ValueError(
                 f"VanillaMarkov requires markov_rank > 0, got {self.markov_rank}."
             )
+        self.register_buffer("draft_token_ids", None)
         self.markov_w1 = nn.Embedding(self.vocab_size, self.markov_rank)
         self.markov_w2 = nn.Linear(self.markov_rank, self.vocab_size, bias=False)
 
@@ -95,7 +96,13 @@ class VanillaMarkov(nn.Module):
         return self.markov_w1(token_ids.long())
 
     def project_bias(self, latent_states: torch.Tensor) -> torch.Tensor:
-        return self.markov_w2(latent_states)
+        bias = self.markov_w2(latent_states)
+        if self.draft_token_ids is None:
+            return bias
+        # Previous tokens and verification use target IDs. Expand only the
+        # output bias; the checkpoint's input embedding already spans that vocab.
+        full = bias.new_zeros((*bias.shape[:-1], self.vocab_size))
+        return full.index_copy_(-1, self.draft_token_ids, bias)
 
     def compute_step_bias(
         self,
@@ -388,10 +395,15 @@ class DSparkDraftMixin:
         self.markov_head = build_markov_head(config)
         self.confidence_head = build_confidence_head(config)
         self.lm_head: Optional[nn.Module] = None
+        self.draft_lm_head: Optional[nn.Module] = None
+        self.register_buffer("draft_token_ids", None)
 
     def attach_shared_modules(
         self, *, embed_tokens: nn.Module, lm_head: nn.Module
     ) -> None:
+        if self.draft_token_ids is not None:
+            if int(lm_head.org_vocab_size) != self.markov_head.vocab_size:
+                raise ValueError("DSpark reduced-vocab checkpoint does not match target vocabulary.")
         self.embed_tokens = embed_tokens
         self.lm_head = lm_head
 
@@ -418,18 +430,82 @@ class DSparkDraftMixin:
                 "DSpark dense draft requires the target lm_head "
                 "(call attach_shared_modules first)."
             )
+        if self.draft_lm_head is not None:
+            # d2t is an offset table: target_id = draft_id + d2t[draft_id].
+            # Keep the worker/sampler interface in target vocabulary space,
+            # including zero probability for tokens outside the draft shortlist.
+            logits = self.draft_lm_head(hidden.to(self.draft_lm_head.weight.dtype))
+            full = logits.new_full(
+                (*logits.shape[:-1], self.markov_head.vocab_size), float("-inf")
+            )
+            return full.index_copy_(-1, self.draft_token_ids, logits), None
         if self.logits_mup_width_multiplier:
             hidden = hidden / self.logits_mup_width_multiplier
         local_logits = project_through_lm_head(hidden, self.lm_head)
         base_logits = gather_and_crop_vocab(local_logits, self.lm_head)
         return base_logits, None
 
+    def _init_reduced_vocab(self, offsets, lm_weight, markov_weights) -> None:
+        if lm_weight is None:
+            raise ValueError("DSpark d2t requires checkpoint lm_head.weight.")
+        w1 = markov_weights.get("markov_head.markov_w1.weight")
+        w2 = markov_weights.get("markov_head.markov_w2.weight")
+        if w1 is None or w2 is None:
+            raise ValueError("DSpark d2t requires both Markov weight matrices.")
+        draft_vocab = int(offsets.numel())
+        rank = self.markov_head.markov_rank
+        if offsets.ndim != 1 or offsets.dtype not in (torch.int32, torch.int64):
+            raise ValueError("DSpark d2t must be a one-dimensional integer offset table.")
+        if w1.ndim != 2 or w1.shape[1] != rank:
+            raise ValueError("DSpark reduced-vocab Markov input shape is invalid.")
+        if tuple(w2.shape) != (draft_vocab, rank):
+            raise ValueError("DSpark reduced-vocab Markov output shape is invalid.")
+        if tuple(lm_weight.shape) != (draft_vocab, int(self.config.hidden_size)):
+            raise ValueError("DSpark reduced-vocab lm_head shape is invalid.")
+        if self.markov_head.markov_w2.out_features != draft_vocab:
+            raise ValueError("DSpark config vocabulary does not match d2t.")
+        target_vocab = int(w1.shape[0])
+        ids = offsets.to(dtype=torch.long) + torch.arange(
+            draft_vocab, device=offsets.device
+        )
+        if (
+            draft_vocab == 0
+            or bool((ids < 0).any())
+            or bool((ids >= target_vocab).any())
+            or ids.unique().numel() != draft_vocab
+        ):
+            raise ValueError("DSpark d2t contains duplicate or out-of-range target IDs.")
+        old = self.markov_head.markov_w1.weight
+        self.markov_head.markov_w1 = nn.Embedding(
+            target_vocab, rank, device=old.device, dtype=old.dtype
+        )
+        self.markov_head.vocab_size = target_vocab
+        self.draft_token_ids = ids.to(device=old.device)
+        self.markov_head.draft_token_ids = self.draft_token_ids
+        self.draft_lm_head = nn.Linear(
+            int(self.config.hidden_size), draft_vocab, bias=False,
+            device=old.device, dtype=old.dtype,
+        )
+        default_weight_loader(self.draft_lm_head.weight, lm_weight)
+        logger.info(
+            "DSpark reduced vocabulary: draft=%d target=%d; loaded d2t and draft lm_head.",
+            draft_vocab, target_vocab,
+        )
+
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        offsets = None
+        lm_weight = None
         markov_weights = []
         confidence_weights = []
         backbone_weights = []
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            if name == "d2t":
+                offsets = loaded_weight
+                continue
+            if name == "lm_head.weight":
+                lm_weight = loaded_weight
+                continue
             if any(name.startswith(p) for p in _DSPARK_SKIPPED_WEIGHT_PREFIXES):
                 continue
             if name.startswith("confidence_head."):
@@ -441,6 +517,9 @@ class DSparkDraftMixin:
             else:
                 backbone_weights.append((name, loaded_weight))
 
+        if offsets is not None:
+            self._init_reduced_vocab(offsets, lm_weight, dict(markov_weights))
+            params_dict = dict(self.named_parameters())
         super().load_weights(backbone_weights)
 
         for name, loaded_weight in markov_weights:

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -647,6 +647,15 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
         "target_layer_ids",
         _cfg_get(draft_hf_config, "target_layer_ids", None),
     )
+    # Compact DSPARK exports name the same ordered target-layer selection
+    # aux_hidden_state_layer_ids. Never replace it with evenly spaced layers.
+    aux_layer_ids = _cfg_get(draft_hf_config, "aux_hidden_state_layer_ids", None)
+    if aux_layer_ids is not None:
+        if layer_ids is not None and layer_ids != aux_layer_ids:
+            raise ValueError(
+                "Conflicting target_layer_ids and aux_hidden_state_layer_ids."
+            )
+        layer_ids = aux_layer_ids
     parsed_target_layer_ids: Optional[List[int]]
     if layer_ids is None:
         parsed_target_layer_ids = None

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -22,6 +22,7 @@ from typing import Optional
 from transformers import PretrainedConfig
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
+from sglang.srt.configs.dspark import normalize_dspark_config
 from sglang.srt.configs.model_config_parser_registry import (
     ModelConfigParserBase,
     get_model_config_parser,
@@ -99,6 +100,19 @@ def _try_load_longcat_config(model, revision: Optional[str], **kwargs):
     )
 
 
+def _try_load_dspark_config(model, revision: Optional[str], **kwargs):
+    raw_config, _ = PretrainedConfig.get_config_dict(
+        model, revision=revision, **kwargs
+    )
+    config_dict = normalize_dspark_config(raw_config)
+    if config_dict is None:
+        return None
+    model_type = config_dict.pop("model_type")
+    config = AutoConfig.for_model(model_type, **config_dict)
+    config._name_or_path = str(model)
+    return config
+
+
 @register_model_config_parser("hf")
 class HfModelConfigParser(ModelConfigParserBase):
     def parse(
@@ -108,7 +122,9 @@ class HfModelConfigParser(ModelConfigParserBase):
         revision: Optional[str] = None,
         **kwargs,
     ):
-        config = _try_load_longcat_config(model, revision, **kwargs)
+        config = _try_load_dspark_config(model, revision, **kwargs)
+        if config is None:
+            config = _try_load_longcat_config(model, revision, **kwargs)
         if config is None:
             config = AutoConfig.from_pretrained(
                 model,


### PR DESCRIPTION
## Motivation

本 MR 修复 `--speculative-algorithm DSPARK` 在 Qwen3.6-35B-A3B 上使用不同 draft checkpoint 时的兼容性问题，使以下两类权重能够在 HCU 环境下完成加载、推理和精度评测：

- `Qwen3.6-35B-A3B-speculator.dspark`[https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-speculator.dspark]：使用缩减词表、独立 draft LM head 和 `d2t` 映射。

修复依据 checkpoint 配置、权重形状和内核能力进行判断，不依赖模型目录名。部署保留主模型及 draft 的 `--attention-backend fa3`、`--kv-cache-dtype fp8_e5m2`、CUDA Graph，以及 `SGLANG_ROCM_USE_AITER_MOE=1`。

基线为 `upstream/release/20260825_v0.5.18`（`6d59319229`），工作分支为 `feat/Qwen3.6-35B-A3B-dpark-0.5.18`。本 MR 包含以下三个依次提交的源码修复，最终 HEAD 为 `48fcb0299b`。

## Modifications

### 1. `2c6b570779` — 修复 reduced-vocabulary draft 加载与 token 映射

Commit：`2c6b5707792d5d25bfde722af5297ef645c25ca5`

`fix(dspark): load reduced vocabulary heads and map target token logits`

**问题：** 旧 draft 的词表为 32000，目标模型词表为 248320。Checkpoint 的 Markov 输入权重为 `[248320,256]`，而原实现建立的参数为 `[32000,256]`，导致加载失败。此外，缩减词表的 token ID 不能直接作为目标模型 token ID，独立 draft LM head 也不能被共享的 target LM head 替代。

**修改：**

- 在 `python/sglang/srt/models/dspark.py` 中加载 `d2t` 和独立的 `lm_head.weight`。
- 按 checkpoint 的实际词表大小建立 Markov 输入 embedding，保留缩减词表的输出维度。
- 使用 `target_id = draft_id + d2t[draft_id]` 恢复目标 token ID。
- 将 draft logits 和 Markov bias 映射至目标词表；候选词表外的 base logits 设置为 `-inf`，保持零采样概率。
- 检查映射类型、重复或越界 ID、权重形状、缺失 head 和目标词表一致性。
- 无 `d2t` 的 full-vocabulary draft 保留原有 target-sharing 路径。

**结果：** 旧 draft 可以完成 TP4 启动和全量精度评测。适配阶段的 7 项回归测试通过，覆盖权重加载、数值计算、全词表路径、非法输入及 DCU Graph 捕获/回放。

### 2. `8bb8ae250c` — 兼容 compact draft 配置与辅助层字段

Commit：`8bb8ae250c504d7f0329200db98919de8aea1012`

`Support compact DSPARK draft configurations and auxiliary layer aliases`

**问题：** 新 draft 将网络参数放在 `transformer_layer_config` 中，顶层缺少普通 Hugging Face 配置所需的 `model_type` 等字段，直接加载会报 `Unrecognized model ... Should have a model_type key`。其辅助层选择字段为 `aux_hidden_state_layer_ids`，需要被正确识别并保留顺序。

**修改：**

- 新增 `python/sglang/srt/configs/dspark.py`，将 compact DSPARK 配置转换为可加载的平面 HF 网络配置。
- 在 `python/sglang/srt/utils/hf_transformers/config.py` 的统一加载入口应用转换；不改写 checkpoint 文件，旧平面配置保留原加载流程。
- 保留网络层类型、RoPE 参数和 draft 元数据；校验必要字段及内外层冲突，避免外层空值覆盖有效网络参数。
- 在 `python/sglang/srt/speculative/dflash_utils.py` 中兼容 `aux_hidden_state_layer_ids`，保留辅助层顺序；与 `target_layer_ids` 冲突时明确报错。

**结果：** 新旧配置等 9 项测试通过。新 draft 的 `fc.weight=[2048,16384]` 与 8 个辅助层一致；checkpoint 不含 `d2t`、embedding 和 LM head，符合其 target-sharing 导出方式。完整服务启动还需下一个提交解决 FA3 MTP 内核限制。

### 3. `48fcb0299b` — 修复 HCU FA3 MTP 头数限制

Commit：`48fcb0299bbeb744dd7e07e436aa7672878edd4d`

`Split HCU causal MTP queries exceeding paged attention head limits`

**问题：** 支持draft model 的 `block_size=15`，target verify 每请求处理 16 个 token。TP2 启动时权重与 FP8 KV Cache 已加载成功，但 CUDA Graph 捕获触发 HCU paged attention 的 `num_heads <= num_kv_heads * 64` 断言。该内核将 MTP 查询 token 折叠到头维度，限制实际涉及 `query_heads × query_length`。

**修改：**

- 在 `python/sglang/srt/layers/attention/flashattention_interface.py` 中，对超过限制的均匀因果查询按 token 分块调用同一 FA3 接口。
- 根据每块在原序列中的位置调整可见 KV 长度，保持右下对齐的因果语义，并拼接恢复原输出顺序。
- 分块大小由 Q/KV 头数和内核限制计算，不绑定具体 draft 权重。
- 保留 FP8 KV Cache 和 CUDA Graph，不通过缩短模型 block size 或关闭 graph 绕过问题。

新增路径限定于 HCU、legacy BHSD、page size 64、无滑窗、查询长度 2～16 的均匀因果 MTP，且满足相应 head dimension 与单 token 头数限制。其他形状沿用既有路径。

**结果：** 9、15、16 token 的 FP8 KV attention 对照 PyTorch 参考计算及 CUDA Graph 回放全部通过，最大绝对误差为 `0.00390625`。新 draft 的 TP2 服务成功启动，并完成单请求、流式、32 并发和全量精度评测。

## Accuracy Tests

### 公共测试配置

- 主模型与 draft 均使用 FA3、FP8 E5M2 KV Cache；`SGLANG_ROCM_USE_AITER_MOE=1`。
- CUDA Graph 开启，target/draft verify 捕获成功。
- HumanEval：164 条，指标为 Pass@1；GSM8K：1319 条，指标为 Accuracy。
- `enable_thinking=false`、`temperature=0`、`top_p=1`、`seed=42`、`max_tokens=13312`。
- Eval batch size：32；流式 OpenAI-compatible API；HumanEval `review_timeout=30`。

### draft：Qwen3.6-35B-A3B-speculator.dspark

配置：TP4，DCU 4/5/6/7，block size 8，target verify 9 token；验证代码对应 `2c6b570779`。

- **HumanEval Pass@1：95.12%（156/164）**；8 题未通过，执行错误 0。
- **GSM8K Accuracy：96.89%（1278/1319）**；41 题未通过，执行错误 0。

## Speed Tests and Profiling

本次完成了服务运行与 CUDA Graph 验证，**尚未完成相同 TP、相同输入下的无投机性能基线对比，也未采集 profiler trace，因此不声明加速收益**。

已验证：

- draft model 在 TP4下成功捕获 target verify 和 draft verify CUDA Graph。
- 实际解码日志确认 CUDA Graph 正常使用。
- FA3 分块修复继续调用原 FA3 内核，但额外分块、复制和拼接的性能开销尚未独立量化。


待补充的性能验证：固定 TP、输入/输出长度和并发，比较无投机基线与 DSPARK 的吞吐、TTFT、TPOT、接受长度，并量化 FA3 分块路径的开销。

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

当前状态说明：

- 已执行 `git diff --check` 和配套 shell 脚本语法检查，未执行完整 pre-commit 检查。
- 已运行上述回归、数值与 API 检查。
- 全量精度结果已提供；独立速度 benchmark 和 profiling 尚未完成，因此合并项保持未勾选。
- 尚未完成依据贡献指南的完整代码风格核验，Checklist 不标记为已完成。

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

以上为后续审阅流程；本说明不代表已取得审批、通过 CI 或完成合并。

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->