### PR TITLE
ci(hcu): use v0.5.18 image and restore eval dependencies

### DIFF
--- a/.github/workflows/nightly-test-hcu.yml
+++ b/.github/workflows/nightly-test-hcu.yml
@@ -76,7 +76,8 @@ jobs:
           INPUT_REF: ${{ inputs.ref || '' }}
           INPUT_JOB_FILTER: ${{ inputs.job_filter || 'all' }}
           VAR_RUNNER_LABEL: ${{ vars.HCU_CI_RUNNER_LABEL || '' }}
-          VAR_IMAGE: ${{ vars.HCU_CI_IMAGE || '' }}
+          VAR_IMAGE: ${{ vars.HCU_CI_IMAGE_0518 || '' }}
+          DEFAULT_IMAGE: 10.16.1.152:5000/jenkins/model_test_env/sglang:0.5.18-latest
           CONTINUE_ON_ERROR: ${{ inputs.continue_on_error || '' }}
           GITHUB_SHA_VALUE: ${{ github.sha }}
         run: |
@@ -86,7 +87,7 @@ jobs:
             echo "Routing validation runner label hcu-ci-pr to hcu-ci-pr-2 for nmz4 test runner."
             runner_label="hcu-ci-pr-2"
           fi
-          image="${INPUT_IMAGE:-${VAR_IMAGE}}"
+          image="${INPUT_IMAGE:-${VAR_IMAGE:-${DEFAULT_IMAGE}}}"
           target_ref="${INPUT_REF:-${GITHUB_SHA_VALUE}}"
           continue_on_error="${CONTINUE_ON_ERROR:-true}"
           job_filter="${INPUT_JOB_FILTER:-all}"
@@ -109,7 +110,7 @@ jobs:
           fi
 
           if [[ -z "${image}" ]]; then
-            echo "::error::HCU CI image is required. Set vars.HCU_CI_IMAGE or workflow input image."
+            echo "::error::HCU CI image is required. Set vars.HCU_CI_IMAGE_0518 or workflow input image."
             exit 1
           fi
 

--- a/.github/workflows/pr-test-hcu.yml
+++ b/.github/workflows/pr-test-hcu.yml
@@ -391,11 +391,12 @@ jobs:
           INPUT_RUNNER_LABEL: ${{ inputs.runner_label || '' }}
           INPUT_IMAGE: ${{ inputs.image || '' }}
           VAR_RUNNER_LABEL: ${{ vars.HCU_CI_RUNNER_LABEL || '' }}
-          VAR_IMAGE: ${{ vars.HCU_CI_IMAGE || '' }}
+          VAR_IMAGE: ${{ vars.HCU_CI_IMAGE_0518 || '' }}
+          DEFAULT_IMAGE: 10.16.1.152:5000/jenkins/model_test_env/sglang:0.5.18-latest
           CONTINUE_ON_ERROR: ${{ inputs.continue_on_error || false }}
         run: |
           runner_label="${INPUT_RUNNER_LABEL:-${VAR_RUNNER_LABEL}}"
-          image="${INPUT_IMAGE:-${VAR_IMAGE}}"
+          image="${INPUT_IMAGE:-${VAR_IMAGE:-${DEFAULT_IMAGE}}}"
 
           if [[ -z "${runner_label}" ]]; then
             echo "::error::HCU runner label is required. Set vars.HCU_CI_RUNNER_LABEL or workflow input runner_label."
@@ -403,7 +404,7 @@ jobs:
           fi
 
           if [[ -z "${image}" ]]; then
-            echo "::error::HCU CI image is required. Set vars.HCU_CI_IMAGE or workflow input image."
+            echo "::error::HCU CI image is required. Set vars.HCU_CI_IMAGE_0518 or workflow input image."
             exit 1
           fi
 

--- a/.github/workflows/pr-test-hcu.yml
+++ b/.github/workflows/pr-test-hcu.yml
@@ -615,7 +615,7 @@ jobs:
       HCU_CI_INSTALL_WHEEL_URLS: ${{ needs.wait-hcu-wheels.outputs.wheel_urls || '' }}
       HCU_WHEEL_STAGING_ROOT: /ci_public/sglang-das/hcu-wheel-staging
       HCU_WHEEL_STAGING_CONTAINER_ROOT: /hcu-wheel-staging
-      HCU_CI_USE_INSTALLED_WHEELS: ${{ needs.check-changes.outputs.wheel_required == 'true' && '1' || '' }}
+      HCU_CI_USE_INSTALLED_WHEELS: "1"
     steps:
       - name: Checkout code
         env:
@@ -716,7 +716,7 @@ jobs:
       HCU_CI_INSTALL_WHEEL_URLS: ${{ needs.wait-hcu-wheels.outputs.wheel_urls || '' }}
       HCU_WHEEL_STAGING_ROOT: /ci_public/sglang-das/hcu-wheel-staging
       HCU_WHEEL_STAGING_CONTAINER_ROOT: /hcu-wheel-staging
-      HCU_CI_USE_INSTALLED_WHEELS: ${{ needs.check-changes.outputs.wheel_required == 'true' && '1' || '' }}
+      HCU_CI_USE_INSTALLED_WHEELS: "1"
       SGLANG_HCU_RERANKER_MODEL: /public/opendas/DL_DATA/llm-models/qwen3/Qwen3-Reranker-0.6B
     steps:
       - name: Checkout code

--- a/scripts/ci/hcu/hcu_ci_install_reasoning_code_deps.sh
+++ b/scripts/ci/hcu/hcu_ci_install_reasoning_code_deps.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 CONTAINER="${HCU_CI_CONTAINER:-${HCU_CI_CONTAINER_NAME:-ci_sglang}}"
-HOST_WHEEL_DIR="${HCU_REASONING_CODE_WHEEL_HOST_DIR:-/home/github/sgl_whl_temp/hcu_eval_wheels}"
+HOST_WHEEL_DIR="${HCU_REASONING_CODE_WHEEL_HOST_DIR:-${HCU_WHEEL_STAGING_ROOT:-/home/github/sgl_whl_temp}/hcu_eval_wheels}"
 CONTAINER_WHEEL_DIR="${HCU_REASONING_CODE_WHEEL_CONTAINER_DIR:-/hcu-wheel-staging/hcu_eval_wheels}"
 MATH_VERIFY_HOST_WHEEL="${HOST_WHEEL_DIR}/math_verify-0.8.0-py3-none-any.whl"
 LATEX2SYMPY_HOST_WHEEL="${HOST_WHEEL_DIR}/latex2sympy2_extended-1.10.2-py3-none-any.whl"

--- a/scripts/ci/utils/sgl_eval_ref.sh
+++ b/scripts/ci/utils/sgl_eval_ref.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Hygon Information Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck disable=SC2034
+
+# Single source of truth for the sgl-eval commit every CI variant installs.
+# Meant to be sourced, not executed -- each variant then installs
+# "$SGL_EVAL_SPEC" with its own pip invocation, since those differ (uv pip on
+# CUDA/CPU, `docker exec ... pip` on AMD, `python3 -m pip` on NPU).
+#
+# sgl-eval is git-only and cannot be declared in python/pyproject.toml (see the
+# note there). Every eval that shells out to the `sgl-eval` CLI fails without
+# it, and a bump moves scoring for all of them at once -- so re-baseline
+# MODEL_SCORE_THRESHOLDS in
+# test/registered/eval/test_text_models_gsm8k_eval.py, and the mmlu thresholds
+# of run_eval's other callers, before changing this.
+SGL_EVAL_REF="a231b7a439b235090ff7baa30778fa2b514309ae"
+SGL_EVAL_SPEC="sgl-eval@git+https://github.com/sgl-project/sgl-eval.git@${SGL_EVAL_REF}"


### PR DESCRIPTION
Uses HCU_CI_IMAGE_0518 with the requested 0.5.18-latest fallback, restores the fixed sgl-eval ref removed by the latest sync, and reads reasoning/code offline wheels from shared staging. YAML, Bash, sgl-eval CLI, offline evaluator smoke, and diff checks passed. No product or test code changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->