### PR TITLE
ci(hcu): ensure constrained decoding dependency

### DIFF
--- a/.github/workflows/pr-test-hcu.yml
+++ b/.github/workflows/pr-test-hcu.yml
@@ -612,7 +612,7 @@ jobs:
       HCU_CI_INSTALL_WHEEL_URLS: ${{ needs.wait-hcu-wheels.outputs.wheel_urls || '' }}
       HCU_WHEEL_STAGING_ROOT: /ci_public/sglang-das/hcu-wheel-staging
       HCU_WHEEL_STAGING_CONTAINER_ROOT: /hcu-wheel-staging
-      HCU_CI_USE_INSTALLED_WHEELS: ${{ needs.check-changes.outputs.wheel_required == 'true' && '1' || '' }}
+      HCU_CI_USE_INSTALLED_WHEELS: "1"
     steps:
       - name: Checkout code
         env:
@@ -708,7 +708,7 @@ jobs:
       HCU_CI_INSTALL_WHEEL_URLS: ${{ needs.wait-hcu-wheels.outputs.wheel_urls || '' }}
       HCU_WHEEL_STAGING_ROOT: /ci_public/sglang-das/hcu-wheel-staging
       HCU_WHEEL_STAGING_CONTAINER_ROOT: /hcu-wheel-staging
-      HCU_CI_USE_INSTALLED_WHEELS: ${{ needs.check-changes.outputs.wheel_required == 'true' && '1' || '' }}
+      HCU_CI_USE_INSTALLED_WHEELS: "1"
       SGLANG_HCU_RERANKER_MODEL: /public/opendas/DL_DATA/llm-models/qwen3/Qwen3-Reranker-0.6B
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-test-hcu.yml
+++ b/.github/workflows/pr-test-hcu.yml
@@ -389,10 +389,12 @@ jobs:
           INPUT_IMAGE: ${{ inputs.image || '' }}
           VAR_RUNNER_LABEL: ${{ vars.HCU_CI_RUNNER_LABEL || '' }}
           VAR_IMAGE: ${{ vars.HCU_CI_IMAGE || '' }}
+          DEFAULT_RUNNER_LABEL: bw1100
+          DEFAULT_IMAGE: 10.16.1.152:5000/jenkins/model_test_env/sglang:latest
           CONTINUE_ON_ERROR: ${{ inputs.continue_on_error || false }}
         run: |
-          runner_label="${INPUT_RUNNER_LABEL:-${VAR_RUNNER_LABEL}}"
-          image="${INPUT_IMAGE:-${VAR_IMAGE}}"
+          runner_label="${INPUT_RUNNER_LABEL:-${VAR_RUNNER_LABEL:-${DEFAULT_RUNNER_LABEL}}}"
+          image="${INPUT_IMAGE:-${VAR_IMAGE:-${DEFAULT_IMAGE}}}"
 
           if [[ -z "${runner_label}" ]]; then
             echo "::error::HCU runner label is required. Set vars.HCU_CI_RUNNER_LABEL or workflow input runner_label."
@@ -420,7 +422,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         run: |
           cd "${HCU_CI_CHECKOUT_DIR}"
-          python3.9 scripts/ci/hcu/verify_hcu_registration.py
+          python3 scripts/ci/hcu/verify_hcu_registration.py
 
       - name: Setup HCU validation container
         if: github.event_name == 'workflow_dispatch'
@@ -603,9 +605,9 @@ jobs:
       HCU_CI_IMAGE: ${{ needs.validate-config.outputs.image }}
       HCU_CI_CONTAINER_NAME: ci_sglang_hcu_${{ github.run_id }}_stage_a
       HCU_CI_SKIP_PULL: ${{ vars.HCU_CI_SKIP_PULL || '' }}
-      HCU_CI_SKIP_DEPENDENCY_INSTALL: ${{ vars.HCU_CI_SKIP_DEPENDENCY_INSTALL || '' }}
-      HCU_CI_SKIP_REQUIREMENTS_INSTALL: ${{ vars.HCU_CI_SKIP_REQUIREMENTS_INSTALL || '' }}
-      HCU_CI_SKIP_SGLANG_BUILD: ${{ vars.HCU_CI_SKIP_SGLANG_BUILD || '' }}
+      HCU_CI_SKIP_DEPENDENCY_INSTALL: ${{ vars.HCU_CI_SKIP_DEPENDENCY_INSTALL || '1' }}
+      HCU_CI_SKIP_REQUIREMENTS_INSTALL: ${{ vars.HCU_CI_SKIP_REQUIREMENTS_INSTALL || '1' }}
+      HCU_CI_SKIP_SGLANG_BUILD: ${{ vars.HCU_CI_SKIP_SGLANG_BUILD || '1' }}
       HCU_CI_VISIBLE_DEVICES: ${{ vars.HCU_CI_VISIBLE_DEVICES || '' }}
       HCU_CI_INSTALL_WHEEL_URLS: ${{ needs.wait-hcu-wheels.outputs.wheel_urls || '' }}
       HCU_WHEEL_STAGING_ROOT: /ci_public/sglang-das/hcu-wheel-staging
@@ -699,9 +701,9 @@ jobs:
       HCU_CI_IMAGE: ${{ needs.validate-config.outputs.image }}
       HCU_CI_CONTAINER_NAME: ci_sglang_hcu_${{ github.run_id }}_stage_b_${{ matrix.part }}
       HCU_CI_SKIP_PULL: ${{ vars.HCU_CI_SKIP_PULL || '' }}
-      HCU_CI_SKIP_DEPENDENCY_INSTALL: ${{ vars.HCU_CI_SKIP_DEPENDENCY_INSTALL || '' }}
-      HCU_CI_SKIP_REQUIREMENTS_INSTALL: ${{ vars.HCU_CI_SKIP_REQUIREMENTS_INSTALL || '' }}
-      HCU_CI_SKIP_SGLANG_BUILD: ${{ vars.HCU_CI_SKIP_SGLANG_BUILD || '' }}
+      HCU_CI_SKIP_DEPENDENCY_INSTALL: ${{ vars.HCU_CI_SKIP_DEPENDENCY_INSTALL || '1' }}
+      HCU_CI_SKIP_REQUIREMENTS_INSTALL: ${{ vars.HCU_CI_SKIP_REQUIREMENTS_INSTALL || '1' }}
+      HCU_CI_SKIP_SGLANG_BUILD: ${{ vars.HCU_CI_SKIP_SGLANG_BUILD || '1' }}
       HCU_CI_VISIBLE_DEVICES: ${{ vars.HCU_CI_VISIBLE_DEVICES || '' }}
       HCU_CI_INSTALL_WHEEL_URLS: ${{ needs.wait-hcu-wheels.outputs.wheel_urls || '' }}
       HCU_WHEEL_STAGING_ROOT: /ci_public/sglang-das/hcu-wheel-staging

--- a/scripts/ci/hcu/hcu_ci_install_dependency.sh
+++ b/scripts/ci/hcu/hcu_ci_install_dependency.sh
@@ -44,7 +44,7 @@ import importlib
 import sys
 
 print(f"python {sys.version.split()[0]}")
-for name in ["sglang", "torch", "pytest", "tabulate", "sgl_kernel", "kernels", "tvm_ffi"]:
+for name in ["sglang", "torch", "pytest", "tabulate", "llguidance", "sgl_kernel", "kernels", "tvm_ffi"]:
     try:
         module = importlib.import_module(name)
         version = getattr(module, "__version__", "unknown")
@@ -71,6 +71,16 @@ install_with_retry() {
   done
 }
 
+install_required_test_dependencies() {
+  # Wheel mode deliberately skips project dependencies. Keep the constrained
+  # decoding dependency aligned with this release branch's pyproject range.
+  echo "[hcu-ci] Ensuring a branch-compatible llguidance is available"
+  install_with_retry docker exec "${CONTAINER}" \
+    python3 -m pip install --cache-dir=/sgl-data/pip-cache --no-deps "llguidance>=0.7.11,<0.8.0"
+  docker exec "${CONTAINER}" python3 -c \
+    'import importlib.metadata; from packaging.version import Version; version = Version(importlib.metadata.version("llguidance")); assert Version("0.7.11") <= version < Version("0.8.0")'
+}
+
 if [[ "${SKIP_COMPAT_INSTALL}" == "1" || "${SKIP_COMPAT_INSTALL}" == "true" ]]; then
   echo "[hcu-ci] HCU_CI_SKIP_COMPAT_INSTALL=${SKIP_COMPAT_INSTALL}; skipping HCU compatibility pins"
 else
@@ -92,6 +102,7 @@ fi
 
 if [[ "${SKIP_DEPENDENCY_INSTALL}" == "1" || "${SKIP_DEPENDENCY_INSTALL}" == "true" ]]; then
   echo "[hcu-ci] HCU_CI_SKIP_DEPENDENCY_INSTALL=${SKIP_DEPENDENCY_INSTALL}; skipping regular dependency installation"
+  install_required_test_dependencies
   print_python_status
   exit 0
 fi
@@ -133,4 +144,5 @@ fi
 
 echo "[hcu-ci] Installed sglang version:"
 run_in_container "python -c 'import sglang, sys; print(sglang.__version__); sys.exit(0)' || true"
+install_required_test_dependencies
 print_python_status


### PR DESCRIPTION
Ensures the v0.5.12-compatible llguidance range is present even when HCU wheel mode skips regular dependencies. Fork PR fallbacks now match repository CI defaults: bw1100, the existing sglang:latest image, and skip dependency/requirements/source build flags set to 1; registration uses the available python3 command. This prevents fork jobs from accidentally compiling Rust edition 2024 code with Cargo 1.75. Bash, YAML, container dependency, and diff checks passed. No model path, product code, or test code changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->