### PR TITLE
[bugfix] Isolate the use of --speculative-algorithm DSPARK for the Qwen3.6-35B-A3B model family via the SGLANG_USE_QWEN_DSPARK environment variable.

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -488,6 +488,8 @@ class Envs:
     # ===================================================================
     # DSpark speculative decoding
     # ===================================================================
+    # Opt in to Qwen DSPARK checkpoint and HCU MTP compatibility fixes.
+    SGLANG_USE_QWEN_DSPARK = EnvBool(False)
     SGLANG_DSPARK_DEBUG_CONFIDENCE_PREFIX_SCHEDULER = EnvBool(False)
     SGLANG_DSPARK_DEBUG_CONFIDENCE_METRICS = EnvBool(False)
     SGLANG_DSPARK_DEBUG_DUMP = EnvTuple(tuple())

--- a/python/sglang/srt/layers/attention/flashattention_interface.py
+++ b/python/sglang/srt/layers/attention/flashattention_interface.py
@@ -23,6 +23,8 @@ from flash_attn import (
     vllm_flash_attn_with_kvcache as vllm_flash_attn_with_kvcache_interface,
 )
 
+from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_spec
 from sglang.srt.utils import is_hcu
 from sglang.srt.utils.common import get_bool_env_var
 
@@ -468,6 +470,8 @@ def vllm_flash_attn_varlen_func(
     # without changing their bottom-right causal alignment or the KV cache.
     if (
         _is_hcu
+        and envs.SGLANG_USE_QWEN_DSPARK.get()
+        and get_spec().speculative_algorithm == "DSPARK"
         and layout == "legacy_bhsd"
         and k.shape[2] == 64
         and q.shape[2] == v.shape[2]

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from copy import copy
 from typing import Callable, Iterable, Optional, Tuple
 
 import torch
@@ -382,6 +383,14 @@ _DSPARK_SKIPPED_WEIGHT_PREFIXES = (
 class DSparkDraftMixin:
 
     def __init__(self, config, quant_config=None, prefix: str = "") -> None:
+        if envs.SGLANG_USE_QWEN_DSPARK.get() and getattr(
+            config, "aux_hidden_state_layer_ids", None
+        ) is not None:
+            # Pass canonical fields to the shared DFlash backbone without
+            # changing DFlash's own configuration semantics or the caller's config.
+            draft_config = parse_dspark_draft_config(draft_hf_config=config)
+            config = copy(config)
+            config.target_layer_ids = draft_config.target_layer_ids
         super().__init__(config=config, quant_config=quant_config, prefix=prefix)
         self._fused_kv_write_cache = None
         self.logits_mup_width_multiplier = None
@@ -493,6 +502,7 @@ class DSparkDraftMixin:
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        use_qwen_dspark = envs.SGLANG_USE_QWEN_DSPARK.get()
         offsets = None
         lm_weight = None
         markov_weights = []
@@ -500,10 +510,10 @@ class DSparkDraftMixin:
         backbone_weights = []
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
-            if name == "d2t":
+            if use_qwen_dspark and name == "d2t":
                 offsets = loaded_weight
                 continue
-            if name == "lm_head.weight":
+            if use_qwen_dspark and name == "lm_head.weight":
                 lm_weight = loaded_weight
                 continue
             if any(name.startswith(p) for p in _DSPARK_SKIPPED_WEIGHT_PREFIXES):

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -574,7 +574,9 @@ class DFlashDraftConfig:
         return resolved
 
 
-def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
+def parse_dflash_draft_config(
+    *, draft_hf_config: Any, use_qwen_dspark_config: bool = False
+) -> DFlashDraftConfig:
     """Parse and validate DFLASH draft config fields from HF config/dict."""
     dflash_cfg = _get_dflash_config(draft_hf_config)
     draft_text_config = _get_text_config(draft_hf_config)
@@ -650,7 +652,7 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
     # Compact DSPARK exports name the same ordered target-layer selection
     # aux_hidden_state_layer_ids. Never replace it with evenly spaced layers.
     aux_layer_ids = _cfg_get(draft_hf_config, "aux_hidden_state_layer_ids", None)
-    if aux_layer_ids is not None:
+    if use_qwen_dspark_config and aux_layer_ids is not None:
         if layer_ids is not None and layer_ids != aux_layer_ids:
             raise ValueError(
                 "Conflicting target_layer_ids and aux_hidden_state_layer_ids."

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 import msgspec
 
+from sglang.srt.environ import envs
+
 from sglang.srt.runtime_context import (
     get_model,
     get_spec,
@@ -237,7 +239,10 @@ def _get_dspark_config(config: Any) -> dict:
 
 
 def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
-    base = parse_dflash_draft_config(draft_hf_config=draft_hf_config)
+    base = parse_dflash_draft_config(
+        draft_hf_config=draft_hf_config,
+        use_qwen_dspark_config=envs.SGLANG_USE_QWEN_DSPARK.get(),
+    )
 
     dspark_cfg = _get_dspark_config(draft_hf_config)
     text_config = _get_text_config(draft_hf_config)

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -29,6 +29,7 @@ from sglang.srt.configs.model_config_parser_registry import (
     register_model_config_parser,
 )
 from sglang.srt.connector import create_remote_connector
+from sglang.srt.environ import envs
 from sglang.srt.utils import is_remote_url, lru_cache_frozenset
 
 from ..hf_transformers_patches import _ensure_gguf_version
@@ -101,6 +102,8 @@ def _try_load_longcat_config(model, revision: Optional[str], **kwargs):
 
 
 def _try_load_dspark_config(model, revision: Optional[str], **kwargs):
+    if not envs.SGLANG_USE_QWEN_DSPARK.get():
+        return None
     raw_config, _ = PretrainedConfig.get_config_dict(
         model, revision=revision, **kwargs
     )


### PR DESCRIPTION
## Motivation

将 Qwen3.6-35B-A3B 的 DSPARK 兼容性适配改为显式启用，避免模型专用适配默认作用于其他模型或投机算法的共享路径。

此前 PR #341（`4603df038b`）增加了 reduced-vocabulary draft 权重加载、compact DSPARK 配置及辅助层别名解析、HCU FA3 MTP 查询分块。部分改动位于共享配置解析和 attention 接口，缺少明确的启用边界。

本 MP 新增默认关闭的 `SGLANG_USE_QWEN_DSPARK` 环境变量。只有需要这些 Qwen DSPARK 适配的服务才显式设置为 `1`；未设置或设置为 `0` 时，相关入口保留适配前的行为，同时继续支持原有 DSPARK 功能。


## Modifications

### 1. 增加默认关闭的环境开关

在 `python/sglang/srt/environ.py` 注册：

```python
SGLANG_USE_QWEN_DSPARK = EnvBool(False)
```

该变量是进程启动配置，需要在启动服务前设置，并传递到实际运行 SGLang 的容器和各 worker 所在进程环境中。修改后应重启服务；它不是请求级参数。

### 2. 隔离 compact DSPARK 配置加载

在 `python/sglang/srt/utils/hf_transformers/config.py` 中，关闭开关时跳过新增的 compact DSPARK 配置探测，避免增加额外的 checkpoint 配置读取。

开启时保留嵌套 `transformer_layer_config` 的转换能力及字段校验，继续支持 compact draft 导出格式。

### 3. 隔离辅助层别名并保持 backbone 输入一致

- `python/sglang/srt/speculative/dflash_utils.py`：为共享解析函数增加显式选择参数，默认不应用 `aux_hidden_state_layer_ids` 别名。
- `python/sglang/srt/speculative/dspark_components/dspark_config.py`：仅 DSPARK 入口根据环境开关启用该别名。
- `python/sglang/srt/models/dspark.py`：开启时将解析后的辅助层写入配置副本的 `target_layer_ids`，再传给共享 DFlash backbone，确保辅助层选择与 `fc` 输入维度一致，不修改调用方配置对象。

普通 DFlash 调用即使处于设置了该环境变量的进程中，也不自动启用 DSPARK 的辅助层别名。

### 4. 隔离 reduced-vocabulary 权重加载

在 `python/sglang/srt/models/dspark.py` 中，仅在开关开启时拦截 `d2t` 和独立 `lm_head.weight`，启用原有的 reduced-vocabulary 加载及目标 token 映射逻辑。

关闭时，权重路由与适配前保持一致。开启时继续保留映射类型、形状、重复及越界 token ID 等校验，不绑定具体 draft 目录名称。

### 5. 限制 HCU FA3 MTP 分块入口

在 `python/sglang/srt/layers/attention/flashattention_interface.py` 中，新增分块路径同时要求：

- `SGLANG_USE_QWEN_DSPARK=1`；
- 当前投机算法为 `DSPARK`；
- 满足原有 HCU、legacy BHSD、page size 64、因果查询、无滑窗及头数限制等条件。

普通推理、EAGLE 和 DFLASH 不进入该新增分块路径。开启适配后仍保留 FA3、FP8 E5M2 KV Cache 和 CUDA Graph。

### 环境变量使用方式

**Qwen3.6-35B-A3B + DSPARK：--speculative-algorithm DSPARK 和export SGLANG_USE_QWEN_DSPARK=1 。

该开关不是根据模型名称自动识别的白名单；应只在需要这些适配的 Qwen DSPARK 服务中设置为 `1`。依赖 compact config 或 reduced-vocabulary 支持的 Qwen draft，关闭后可能无法加载，这是显式启用机制的预期行为。

### 提交与基线

- 提交分支：`feat/deepseek-DSPARK-BUGFIX`。
- 基线：`upstream/release/20260825_v0.5.18`，本轮 fetch 确认的 HEAD 为 `77ba00139ac13b8a6bdb9ee15554cd9c18537fbc`。
- 修复提交：`a28509449846221843ccb572ca3b5ae6c1c38787`，`fix(dspark): gate Qwen adaptations behind explicit opt-in`。
- 该提交通过 `cherry-pick -x` 移植自 Qwen BUGFIX 分支的 `ab5cd9c17801f30ae16f1dc106b34481e09c186a`，两者隔离补丁相同，无需重复合入。
- 共修改 6 个源文件，新增 31 行、删除 5 行。基线已有的 PR #345 不属于本 MP 新增修改。

## Accuracy Tests

### 全量评测配置

- 目标模型：Qwen3.6-35B-A3B；
- 评测源码：`a28509449846221843ccb572ca3b5ae6c1c38787` 的独立快照。
- TP2，DCU 4、5；`SGLANG_USE_QWEN_DSPARK=1`、`SGLANG_ROCM_USE_AITER_MOE=1`。
- Target 和 draft 均使用 FA3、FP8 E5M2 KV Cache；target/draft verify CUDA Graph 捕获成功。
- HumanEval 164 条，Pass@1；GSM8K 1319 条，Accuracy。
- Eval batch size 32；`enable_thinking=false`、`temperature=0`、`top_p=1`、`seed=42`、`max_tokens=13312`；HumanEval `review_timeout=30`。
- 使用流式 OpenAI-compatible API；不设置 `EVAL_LIMIT`，不复用历史评测结果缓存。

### Draft 1：Qwen3.6-35B-A3B-speculator.dspark（from redhatai）

Reduced vocabulary draft，block size 8，target verify 9 token。本轮全量结果已从逐条评分核对：

- **HumanEval Pass@1：96.34%（158/164）**。
- **GSM8K Accuracy：96.59%（1274/1319）**。
- 两项执行错误均为 **0**，样本无缺失、无重复，`incomplete=false`。
- EvalScope 驱动退出码为 **0**。


### 隔离与兼容性回归

- 10 项隔离测试通过，覆盖默认关闭、配置额外 I/O、compact/旧平面配置、普通 DFlash 别名隔离、backbone 辅助层传递、reduced-vocabulary 数值及关闭时权重路由、FA3 调用边界。
- 开关开启的 DSPARK 路径完成 9/15/16 token 的 HCU FP8 KV attention 对照和 CUDA Graph 回放检查，最大绝对误差为 `0.00390625`。
- 可用 DeepSeek V4 `-v2` 配置在适配前后解析一致；6 组配置比较及五个共享定义的 AST 对照通过。该配置是否与现场 `/nvme` 权重完全一致尚待确认。

## Speed Tests and Profiling

本次验证了两类 draft 的服务启动及 CUDA Graph 捕获，未进行相同输入和并发条件下的无投机速度基线对比，也未采集完整 profiler trace，因此不声明吞吐或延迟改善。

开关关闭时跳过新增 compact 配置读取及相关适配入口；这不构成已量化的性能收益。开启后仍使用既有 FA3 分块逻辑，其性能开销本 MP 未单独测量。

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

当前验证状态：`git diff --check`、配套 shell 语法检查及上述隔离测试通过；未执行完整 pre-commit。测试脚本和运行产物保存在任务目录，未纳入该源代码提交；本 README 是 MP 说明，未修改仓库正式文档。Ocyx 全量结果、独立速度基线及完整 CI 尚待补齐，故不将相关 Checklist 标为完成。

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so. Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

以上为后续审阅流程，本说明不代表已经取得审批或通过 CI。

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->